### PR TITLE
Add spec-template system (fresh install)

### DIFF
--- a/.claude/commands/lib/intake.md
+++ b/.claude/commands/lib/intake.md
@@ -19,7 +19,7 @@ Not sure where your idea belongs? Drop it here and let the LLMs file it in the r
 
 When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
 
-Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
+Use your best judgment to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
 
 When you have emptied the submissions section below, leave behind a single bullet:
 

--- a/.claude/commands/lib/intake.md
+++ b/.claude/commands/lib/intake.md
@@ -1,0 +1,199 @@
+# Intake
+
+Process ideas from `specs/INTAKE.md` — and from open GitHub Issues — and file them into the appropriate TODO spec files.
+
+## Step 1 — Ensure INTAKE.md exists
+
+Check whether `specs/INTAKE.md` exists.
+
+If it **does not exist**:
+1. Create the `specs/` directory if needed.
+2. Create `specs/INTAKE.md` with this exact content:
+
+```markdown
+# Ideas intake
+
+Not sure where your idea belongs? Drop it here and let the LLMs file it in the right place later!
+
+## AGENTS Instructions
+
+When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
+
+Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
+
+When you have emptied the submissions section below, leave behind a single bullet:
+
+- *Add your ideas here*.
+
+Items waiting for more information stay in this file with a date annotation: `*(waiting for response, asked YYYY-MM-DD)*`. Re-surface stale items after **7 days** with no reply — change this number to adjust the threshold. If the user asks to defer an item, annotate it as `*(snoozed until YYYY-MM-DD)*` and skip it until that date.
+
+## Submissions
+
+- *Add your ideas here*.
+```
+
+Then tell the user the file has been created and stop — there is nothing to process yet.
+
+## Step 2 — Check waiting and snoozed items
+
+Read `specs/INTAKE.md` and scan for items with date annotations before doing anything else.
+
+**For each item annotated `*(waiting for response, asked YYYY-MM-DD)*`:**
+1. If the item has a `[#N](url)` prefix, run `gh issue view N --json comments` and check whether any comments were posted after the asked date.
+2. New comments found → strip the annotation and re-add the item to the processing queue for this run.
+3. No new comments and older than **7 days** (default; see AGENTS Instructions to adjust) → add to the stale list. Surface in the Step 8 report: "Still waiting on #N (asked YYYY-MM-DD)."
+4. No new comments and within 7 days → skip silently.
+
+**For each item annotated `*(snoozed until YYYY-MM-DD)*`:**
+- Snooze date is in the future → skip entirely.
+- Snooze date has passed → strip the annotation and re-add to the processing queue.
+
+**During the run**, if the user says to defer a stale item ("we'll get to it in May", "ignore this for now"):
+- Update its annotation to `*(snoozed until YYYY-MM-DD)*` based on what they said.
+- Move on without posting to GH.
+
+## Step 3 — Pull from GitHub Issues
+
+**Config:** Read `specs/.meta.json` if it exists and check `auto_create_issues`:
+- `true` → enable issue auto-creation for this run.
+- `false` → disable; skip silently.
+- Key absent (or `.meta.json` missing entirely) → ask the user: *"Should I create a GitHub issue for each manual submission that has no issue link? (Set `auto_create_issues` in `specs/.meta.json` to avoid this prompt.)"*
+  - User confirms → treat as `true` for this run.
+  - User declines → treat as `false` for this run.
+  - No user present (headless) → treat as `false`; note in the Step 8 report that `auto_create_issues` was unset and no issues were created.
+
+1. Run `gh auth status` using the Bash tool.
+   - If `gh` is not installed or the user is not authenticated: skip the rest of this step, make a note for the report, and continue to Step 4.
+2. Run: `gh issue list --state open --json number,title,url,labels --limit 100`
+3. Filter out any issues that already carry one of these labels: `intake:filed`, `intake:rejected`, `intake:ignore`.
+4. For each remaining issue, append a bullet to the `## Submissions` section of `specs/INTAKE.md`:
+   ```
+   - [#N](url) Issue title
+   ```
+5. If no unprocessed issues are found, note it and continue.
+
+## Step 4 — Read the Submissions
+
+Read `specs/INTAKE.md`. Extract every bullet under `## Submissions` that is not:
+- The placeholder `*Add your ideas here*`
+- A `*(waiting for response...)*` or `*(snoozed until...)*` item that was not re-queued in Step 2
+
+If nothing remains to process, tell the user and stop (include the Step 8 report if there were stale items to surface).
+
+## Step 5 — Survey existing TODO spec files
+
+Use Grep to find all `*.todo.md` files under `specs/`. Read their headings so you understand what components/areas each file covers. Do not read every line — just enough to map file → component/area.
+
+## Step 6 — Process each item
+
+For each item, determine which of three paths applies:
+
+---
+
+### Path 1 — Routed (clear intent, known target)
+
+You can confidently identify the target `.todo.md` and the item is not a duplicate.
+
+1. **Determine the target.** Match the item to the most relevant `.todo.md`. For work that needs to happen in a dependency, file it in `specs/deps/{repo}.todo.md` (create it if needed). If the item spans multiple components, split it into one entry per relevant file.
+
+2. **Format the entry.** Write it as a plain `- ` bullet. For GH-sourced items, preserve the issue link as a prefix:
+   ```
+   - [#42](url) Description of what needs to happen
+   ```
+   For manual items, write a concise, actionable description. If the submission has sub-bullets, preserve them as indented sub-bullets.
+
+3. **Auto-create a GH issue** if the item has no `[#N](url)` prefix, `auto_create_issues` is `true` for this run, **and** Step 3 confirmed that the GitHub CLI is installed and authenticated:
+   - If Step 3 reported that `gh` is missing or unauthenticated, **do not** attempt `gh issue create`; treat auto-creation as disabled for this run and record it in the Step 8 report.
+   - Otherwise, run: `gh issue create --title "<concise title>" --body "<item description>"`
+   - Extract the issue number from the returned URL and update the entry to prepend `[#N](url)`.
+   - If creation still fails for any other reason (e.g. permission or network error), continue without a link and note the failure in the Step 8 report.
+
+4. **Create the spec file if missing.** Use this minimal template:
+   ```markdown
+   # <Component/Area/Dep Name> — TODOs
+
+   - <first item>
+   ```
+   For dep TODOs, see `specs/deps/README.md` for the recommended template.
+
+5. **Apply a GitHub label** if the item has a `[#N](url)` prefix:
+   - **Filed:** `gh issue edit N --add-label "intake:filed"`
+   - **User rejects the idea:** `gh issue edit N --add-label "intake:rejected"` — skip filing
+   - **User says leave it alone:** `gh issue edit N --add-label "intake:ignore"` — skip filing
+
+6. **Clear from INTAKE.md** (handled in Step 7).
+
+---
+
+### Path 2 — Duplicate+boost (near-identical item already exists)
+
+You find an existing TODO item that covers the same ground.
+
+1. **Find the existing item.** Grep the relevant spec file for similar wording. Show the user what you found: "This item already exists in `<file>`: `<existing text>`."
+
+2. **Boost the existing item:**
+   - Append any new details from the duplicate as a sub-bullet on the existing item.
+   - If the duplicate has a GH issue, link it as an additional sub-bullet: `  - Also requested: [#N](url)`
+   - If this item has now been duplicated multiple times, ask the user whether it should be promoted to a higher section (e.g. Backlog → Later → Sooner). Move it only with user approval.
+
+3. **Apply `intake:filed`** to the duplicate GH issue (if applicable).
+
+4. **Clear from INTAKE.md** (handled in Step 7).
+
+---
+
+### Path 3 — Needs more info (ambiguous routing, missing requirements, low confidence)
+
+You cannot confidently route the item without additional context.
+
+1. **Do not apply any GH label yet.**
+
+2. **Post a comment on the GH issue**, clearly marked as from Claude — not the user:
+   ```
+   🤖 Claude: automated message from /intake — not from the developer.
+
+   To route this issue I need a bit more information:
+   [1–3 specific questions]
+
+   My best routing guess: [target file or component] (confidence: low/medium — reason)
+
+   Reply here to proceed.
+   ```
+   If a human was present in the chat during this run and discussion happened: summarize that conversation in the comment before the questions, then post. This keeps GH as the canonical record even for supervised runs.
+
+   For items with no GH issue (manual submissions): ask the user directly in chat instead.
+
+3. **Annotate the item** in INTAKE.md by appending `*(waiting for response, asked YYYY-MM-DD)*` (use today's date).
+
+4. **Leave it in INTAKE.md** — do not clear it in Step 7.
+
+---
+
+## Step 7 — Selective clearing of INTAKE.md
+
+After all items are processed, update `specs/INTAKE.md`:
+- **Remove** items that were routed (Path 1) or duplicate+boosted (Path 2).
+- **Leave** items annotated `*(waiting for response...)*` or `*(snoozed until...)*` exactly as they are.
+- Ensure the Submissions section always ends with the placeholder bullet if it would otherwise be empty:
+  ```markdown
+  - *Add your ideas here*.
+  ```
+
+## Step 8 — Report
+
+Give the user a brief summary:
+- Which items were filed and where.
+- Any items split across multiple spec files.
+- Any duplicates found and how they were boosted.
+- Any spec files newly created.
+- **Waiting:** any items newly marked as waiting for more info (with the GH link).
+- **Stale:** any items that have been waiting longer than 7 days with no reply.
+- **GitHub:** which issues were labeled and how; any issues auto-created for manual submissions (when `auto_create_issues` is enabled). If `gh` was unavailable, note it here.
+
+## Preferred tools
+
+- **Read** — read INTAKE.md and existing spec files
+- **Grep** — find existing TODO spec files and check for duplicate entries
+- **Edit** — update spec files and INTAKE.md annotations
+- **Write** — create new spec files or INTAKE.md if missing
+- **Bash** — `gh` CLI calls only (auth check, issue list, issue view, issue edit, issue comment); use the file tools above for all file operations

--- a/.claude/commands/lib/knock-out-todos.md
+++ b/.claude/commands/lib/knock-out-todos.md
@@ -1,0 +1,93 @@
+# Knock Out TODOs
+
+Identify and implement the easiest open TODO items in this repository. The user may specify how many to tackle — default is 5 if not stated.
+
+Number to tackle: $ARGUMENTS (default 5 if blank)
+
+## How to find TODOs
+
+Use the Grep tool to search for `^- ` across all `specs/**/*.todo.md` files. Read the results and assess relative difficulty. Skip items that are TBD placeholders or that clearly require decisions from the user (e.g. "open questions", "TBD", or items requiring new full components with no spec yet).
+
+## How to choose which items to tackle
+
+Prefer items that:
+- Have clear, self-contained requirements
+- Affect existing code (modifications or additions to existing modules)
+- Can be done with file edits alone — focused, localized changes
+- Are independent and do not require user input or clarification to proceed
+
+Avoid items that:
+- Say "TBD" or leave requirements unresolved
+- Require building entirely new modules or major architectural changes
+- Require external dependencies or third-party integrations not yet in place
+- Would require asking the user a question before starting
+
+## Workflow
+
+1. Read all open TODO items using Grep. Scan quickly — you do not need to read every spec file in full.
+
+2. For each chosen item, check its context before doing anything else:
+
+   **If the item is in `specs/deps/`** — "implementing" this item means opening a downstream GitHub issue, not writing product code. Follow the [Dep TODO flow](#dep-todo-flow) below instead of the standard steps.
+
+   **If the item has dep sub-bullets** (indented lines in the form `  - [{repo}#{N}](url)`):
+   - Check the status of each: `gh issue view N --repo {owner}/{repo} --json state,title`
+   - Any sub-bullet issue still open → item is blocked. Note it and skip — report the blocker to the user.
+   - All sub-bullet issues closed → item is unblocked. Proceed with implementation or validation.
+
+   **If the item has a `[#N](url)` GitHub issue prefix** — fetch details:
+   - Run `gh issue view N --json title,body,comments` using the Bash tool.
+   - Read the body and any comments for additional context, acceptance criteria, or unresolved questions.
+   - Meaningful detail or discussion → incorporate it into the implementation plan.
+   - Sparse body with no comments → check with the user before proceeding.
+
+3. Read the relevant source files for the items you've chosen using the Read tool.
+4. Implement the changes using the Edit and Write tools.
+5. For each completed item: (a) remove it from its `.todo.md` file using the Edit tool; (b) add its description to the appropriate section of `spec.md` to reflect current state. Drop any dep sub-bullets when promoting — they are implementation history, not current state. If the item has a `[#N](url)` GitHub issue prefix, note the issue number — collect all of them for the wrap-up step.
+6. Update `CHANGELOG.md` under `## WIP` with a concise summary of what was done (max ~5 bullets, brief). If any completed items were GH-linked, output a ready-to-paste block at the end of your summary:
+
+   ```
+   To close linked issues on merge, add to your PR description:
+   closes #42
+   closes #17
+   ```
+
+7. Run the appropriate build or validation command for the project to confirm changes compile and pass checks.
+
+---
+
+## Dep TODO flow
+
+When a chosen item lives in `specs/deps/{repo}.todo.md`, follow this flow instead of the standard implementation steps:
+
+1. Draft a GitHub issue from the TODO description. Write the title and body so the target repo has enough context to act on it independently — don't assume they know this repo's internals.
+2. Open the issue: `gh issue create --repo {owner}/{repo} --title "..." --body "..."`
+3. Add a sub-bullet to the local TODO item:
+   ```
+   - [#local](url) Description
+     - [{repo}#{N}]({url}) Downstream issue opened
+   ```
+4. Cross-link both issues with comments for traceability:
+   - On the local issue: `gh issue comment {local-N} --body "🤖 Claude: Downstream issue opened in {repo}: [{repo}#{N}]({url})"`
+   - On the downstream issue: `gh issue comment {dep-N} --repo {owner}/{repo} --body "🤖 Claude: Opened on behalf of [{this-repo}#{local-N}]({url})"`
+5. Leave the TODO item in place — it stays open until the downstream issue is closed. Sub-bullet reconciliation (step 2 above) will unblock it on the next run.
+
+## Preferred tools and actions
+
+- **Grep** — find TODO items and search source files for relevant code
+- **Read** — read source files for the items you've chosen before implementing
+- **Edit** and **Write** — make all code changes, mark TODOs as complete, move items to main spec, and update the CHANGELOG
+- **Bash** — `gh` calls only (`gh issue view` to read context and check dep status, `gh issue create` to open downstream dep issues, `gh issue comment` to cross-link); use the file tools above for all file operations
+
+## Style rules
+
+- Follow existing code conventions and patterns already established in the codebase
+- Avoid adding new dependencies unless explicitly required by the spec
+- Keep changes minimal and focused — do not refactor surrounding code that was not part of the TODO
+
+## Reminders
+
+* `spec.md` = current state | `spec.todo.md` = future plans | INTAKE = entry point
+* Completed work belongs in `spec.md` — remove items from todo files when done, never leave completed items behind
+* Items flow: INTAKE → `spec.todo.md` → `{feature}.todo.md` (if big) → `spec.md` (when done)
+* GH-linked items (`[#N]`): include `closes #N` in your PR description — GitHub closes the issue on merge

--- a/.claude/commands/lib/refine.md
+++ b/.claude/commands/lib/refine.md
@@ -1,0 +1,182 @@
+# Refine
+
+Add technical detail, effort estimates, and priority adjustments to the highest-priority open TODO items — the middle step between `/intake` and `/knock-out-todos`.
+
+The user may specify how many items to refine — default is **3** if not stated.
+
+---
+
+## Step 1 — Find and prioritize TODO items
+
+Use Grep to search for `^- ` across all `specs/**/*.todo.md` files.
+
+**Skip items that are:**
+- Already refined: have a `*(effort: ...)` annotation **and** at least one indented technical sub-bullet
+- Snoozed: annotated `*(snoozed until YYYY-MM-DD)*` where the date is still in the future
+- Reminders or section headings (lines not starting with `- `)
+
+**Re-check waiting items first.** For each item annotated `*(waiting for response, asked YYYY-MM-DD)*`:
+1. If the item has a `[#N](url)` prefix, run `gh issue view N --json comments` and check for comments posted after the asked date.
+2. New comments found → strip the annotation and add the item to the candidate pool (treat as high priority — the user has responded).
+3. No new comments and older than **7 days** → add to the stale list for Step 6.
+4. No new comments and within 7 days → skip silently.
+
+**Prioritize candidates:**
+1. Items in "Sooner" sections before "Later" before "Backlog" within each file
+2. Higher position in the file (earlier = higher priority)
+3. Items with a `[#N](url)` GH issue prefix (proxy for stakeholder interest)
+
+Select the top N items (default 3; user-specified number overrides).
+
+---
+
+## Step 2 — Load context for each item
+
+For each selected item:
+
+1. **GH issue details:** If the item has a `[#N](url)` prefix, run `gh issue view N --json title,body,comments`. Read the body and all comments — these may contain requirements, constraints, or previous discussion.
+2. **Spec file context:** Read the containing `.todo.md` file to understand the area and neighboring items.
+3. **Current state:** Read the relevant component spec (`specs/spec.md`, `specs/scaffold.md`, `specs/worker.md`, etc.) to understand what already exists.
+4. **Source scan:** If relevant source files exist and are small, do a light scan to understand the implementation surface.
+
+---
+
+## Step 3 — Assess and refine each item
+
+For each item, work through these questions:
+
+**Clarity check:**
+- Is the **what** (deliverable, behavior, interface) clear enough to implement without guessing?
+- Is the **why** (purpose, user value, problem being solved) clear?
+- Are there **implementation decisions** that need to be made before work can start?
+- Are there known **dependencies** or **risks**?
+
+**Estimate effort** using these labels — based on complexity and scope, not time:
+- **XS** — trivial; self-contained, no risk of side effects
+- **S** — small and well-understood; clear scope, minimal coordination needed
+- **M** — moderate; spans a few files or touches non-trivial logic
+- **L** — substantial; crosses components or requires careful coordination
+- **XL** — large and complex; must be broken down before implementation. If it keeps growing during refinement, consider splitting into a new `.todo.md` file or chunking into smaller sequential items.
+- **Unknown** — not enough context to assess complexity yet
+
+Append 0–3 `?` marks to indicate confidence in the estimate: `*(effort: XL)*` = high confidence; `*(effort: M?)*` = probably Medium; `*(effort: S???)*` = rough guess. Use more `?`s when estimating from limited context.
+
+---
+
+### If supervised (user present in chat)
+
+- Ask questions directly in chat. Work iteratively — do not write anything to files until key ambiguities are resolved.
+- Confirm the effort estimate with the user.
+- If the user adjusts scope, priority, or approach during discussion, note it before writing.
+- Get explicit sign-off from the user before proceeding to Step 4.
+
+---
+
+### If headless (no user in chat)
+
+- Make a best-effort assessment using available context (GH issue body/comments, spec files, source).
+- For questions about **product decisions or intent** (the "why" or "what") that cannot be answered from context, post a clarifying comment on the GH issue:
+
+  ```
+  🤖 Spec Agent, reporting for refinement duty! 🫡
+
+  I'm preparing this item for implementation and have some questions:
+  [1–3 specific, answerable questions]
+
+  My current understanding: [brief summary of what will be built and how]
+  Estimated effort: [XS/S/M/L/XL — one-line reasoning focused on complexity and scope]
+
+  Once you clarify things for me, I'll get these todos refined and ready! 💎 🫡
+  ```
+
+- Annotate the item as `*(waiting for response, asked YYYY-MM-DD)*` if key product decisions remain unanswered.
+- Still add an effort estimate and whatever technical detail can be inferred from context — do not leave the item completely unrefined just because some questions remain. Make your best guess and use more `?` marks where confidence is low. If context is sparse, `???` signals to reviewers that clarification is needed.
+- Where clarity is low, append up to 3 `?` marks to individual technical sub-bullet sentences to flag guesses and prompt reviewers to clarify further.
+
+---
+
+## Step 4 — Write updates to spec and TODO files
+
+**In the `.todo.md` file:**
+
+Add an inline effort estimate and technical sub-bullets to each refined item:
+
+```
+- [#N](url) Description of the item *(effort: M)*
+  - Implementation: [brief technical approach — how it will be built]
+  - Depends on: [prerequisites or blockers, if any]
+```
+
+If no GH issue prefix exists:
+```
+- Description of the item *(effort: S)*
+  - Implementation: [brief technical approach]
+```
+
+Append `?` marks to the effort label to reflect confidence: `*(effort: M?)*` = probably Medium; `*(effort: S???)*` = rough guess. Append `?` marks to the end of individual sub-bullet sentences where you're guessing — to flag areas that need reviewer clarification.
+
+Additional rules:
+- If priority was adjusted during Step 3, move the item to the appropriate section (Sooner / Later / Backlog).
+- If a GH comment was posted in headless mode, append `*(waiting for response, asked YYYY-MM-DD)*` to the item.
+- Do not add speculative or unconfirmed details — only what was agreed or clearly inferable.
+
+**In related spec files** (only when the purpose or approach genuinely improved):
+- Add or update the feature description in `spec.md` or the relevant component spec.
+- Do not add unconfirmed design decisions.
+
+---
+
+## Step 5 — Commit and open a PR
+
+### Supervised
+
+After the user gives sign-off in Step 3:
+1. Commit all changes.
+2. Push the branch.
+3. Ask the user: *"Ready to open a PR with these changes?"*
+4. On confirmation, run:
+   ```
+   gh pr create --title "refine: ..." --body "..."
+   ```
+   PR body should include:
+   - List of items refined with their effort estimates
+   - Any outstanding questions (items still waiting for GH replies)
+   - `closes #N` for any GH issues that are now fully defined
+
+### Headless
+
+1. Commit all changes.
+2. Push the branch.
+3. Run `gh pr create` automatically. Preface the PR body with one of:
+
+   If refinement went smoothly:
+   > 🤖 Spec Agent, reporting in from refinement! 🫡 I've refined your todo items and want to make sure I've got the details right. Comment on this PR and/or comment on the GH issues to steer me in the right direction.
+
+   If many items have high uncertainty (`???`):
+   > 🤖 Spec Agent, reporting in from refinement! 🫡 I did my best, boss, but I've got a lot of questions. Please review my updates and comment to clarify things for me, especially in areas where I've got a ton of `??`s 😅
+
+   Then include:
+   - List of items refined with effort estimates and brief implementation summary
+   - Outstanding questions: items where GH comments were posted (with issue links)
+   - `closes #N` lines for any GH issues that are fully defined and no longer need questions answered
+
+**PR title format:** `refine: add detail and estimates for [item names or area]`
+
+---
+
+## Step 6 — Report
+
+Give the user (or include in the PR description) a brief summary:
+- **Refined:** each item, its new effort estimate, and the key technical decision or clarification added
+- **Waiting:** items where a GH comment was posted asking for more info (with issue link)
+- **Stale:** items that have been waiting longer than 7 days with no reply
+- **PR:** link to the opened PR
+
+---
+
+## Preferred tools
+
+- **Grep** — find TODO items across spec files
+- **Read** — read spec files, GH issue details, source files for context
+- **Edit** — update TODO items and spec files
+- **Bash** — `gh` CLI calls only (issue view, issue comment, pr create); use the file tools above for all file operations

--- a/.claude/commands/lib/respec.md
+++ b/.claude/commands/lib/respec.md
@@ -1,0 +1,127 @@
+# /respec
+
+Apply or refresh the [spec-template](https://github.com/NoahWright87/spec-template) system in this repository.
+
+This command handles three situations:
+1) A fresh repo with no specs yet
+2) An existing `specs/` folder that predates this template
+3) A repo already running this template that needs updating.
+
+It detects which case applies and walks you through each step.
+
+**Non-Claude users:** This file is plain markdown. Read it and apply it in your tool of choice — the instructions are the same regardless of IDE.
+
+For the reasoning behind how this command is written, see [PHILOSOPHY.md](https://github.com/NoahWright87/spec-template/blob/main/PHILOSOPHY.md).
+
+---
+
+## Step 1 — Assess the repo
+
+Use Glob to check for `specs/` and Read to check for `specs/.meta.json`.
+
+| What exists | Path to take |
+|-------------|--------------|
+| No `specs/` directory | [Fresh install](#fresh-install) |
+| `specs/` exists, no `.meta.json` | [Adaptation](#adaptation) |
+| `specs/` exists with `.meta.json` | [Update](#update) |
+
+---
+
+## Fresh install
+
+### What to copy
+
+Fetch the latest versions of the managed files (listed in [Managed files](#managed-files)) from the source repo and write them into this repo at the same relative paths.
+
+The source repo URL is whatever URL you fetched this command from. It will be recorded in `specs/.meta.json`.
+
+### What to ask the user first
+
+Before writing the optional files below, describe what each one would add and ask the user whether to include it:
+
+- **Root `AGENTS.md`** — offers agent instructions for the whole repo, with a section on using specs. If one already exists, offer to append a spec section to it rather than replacing it.
+- **`CHANGELOG.md`** — a blank changelog template. If one already exists, leave it in place and skip this offer.
+
+Write only what the user approves.
+
+### After writing files
+
+Write `specs/.meta.json` with the source repo URL, the current commit hash (fetch it from the source repo), and today's date:
+
+```json
+{
+  "source": "https://github.com/YOUR_USERNAME/spec-template",
+  "commit": "COMMIT_HASH",
+  "date": "YYYY-MM-DD"
+}
+```
+
+Users may add optional config keys to this file at any time (e.g. `"auto_create_issues": true`). Never remove or overwrite keys not listed above.
+
+Then give the user a brief summary: which files were written, which optional files were included, and what to do next (run `/intake` or add specs).
+
+---
+
+## Adaptation
+
+The repo already has a `specs/` folder, but it was not set up with this template. The goal is to meld the template's structure with what's already there — adding what's missing and proposing merges where files overlap. The user approves each change before anything is written.
+
+### What to do
+
+1. Read all existing files under `specs/` using Glob and Read.
+2. For each managed file (see [Managed files](#managed-files)):
+   - **Absent:** Show the user what the template version looks like and ask whether to add it.
+   - **Present, compatible:** Show the user both versions side by side and propose a merge. The user decides what to keep.
+   - **Present, serving the same purpose:** Propose replacing the existing file with the template version, showing both so the user can compare.
+3. Write only what the user approves, one file at a time.
+4. Once the user is satisfied, write `specs/.meta.json` (same format as above).
+5. Report a summary: what changed, what was left in place, and any notes on differences found.
+
+---
+
+## Update
+
+The repo is already running this template. Fetch upstream changes and apply them to the managed files.
+
+### What to do
+
+1. Read `specs/.meta.json` for the source URL and last-known commit.
+2. Fetch the current versions of all managed files from the source URL.
+3. For each managed file, compare the fetched version to the local copy:
+   - **Unchanged:** Skip silently.
+   - **Changed:** Show the user a summary of what changed and ask whether to apply it.
+4. Apply approved updates. Leave everything else in place.
+5. **Check TODO format migration.** Compare the fetched `specs/spec.todo.md` template against all local `*.todo.md` files. If the template uses a different bullet format than what the repo's TODO files currently use (e.g. the template now uses plain `- ` bullets but local files still use `- [ ]` checkboxes), tell the user what changed and offer to migrate. If the user approves, update the local TODO files to the current format, preserving all content. Apply only what the user approves.
+6. Update `specs/.meta.json` with the new commit hash and today's date. Preserve all other keys exactly — do not remove or modify user-set fields such as `auto_create_issues`.
+7. Report what was updated, what was skipped, and whether a TODO format migration was applied.
+
+---
+
+## Managed files
+
+These are the files this command installs and keeps current. Everything else in the repo stays untouched.
+
+| File | Purpose |
+|------|---------|
+| `specs/README.md` | Explains the spec system to humans |
+| `specs/AGENTS.md` | Explains the spec system to agents |
+| `specs/spec.md` | Template for writing a new spec |
+| `specs/spec.todo.md` | Template for writing a new TODO spec |
+| `specs/INTAKE.md` | Intake bucket for ideas and requests |
+| `.claude/commands/what-now.md` | `/what-now` command (main entry point) |
+| `.claude/commands/lib/intake.md` | `/intake` logic (invoked via `/what-now`) |
+| `.claude/commands/lib/knock-out-todos.md` | `/knock-out-todos` logic (invoked via `/what-now`) |
+| `.claude/commands/lib/spec-backfill.md` | `/spec-backfill` logic (invoked via `/what-now`) |
+| `.claude/commands/lib/respec.md` | This command (invoked via `/what-now`) |
+| `.claude/commands/lib/refine.md` | `/refine` logic (invoked via `/what-now`) |
+| `.github/workflows/spec-check.yml` | PR check: warns when source changes lack spec updates |
+| `specs/deps/README.md` | Explains the deps/ pattern; templates for dep specs and dep TODOs |
+
+---
+
+## Preferred tools
+
+- **Glob** — discover what exists under `specs/` and `.claude/commands/`
+- **Read** — examine existing files before proposing changes
+- **WebFetch** — fetch managed files from the source repo using raw GitHub URLs
+- **Write** and **Edit** — apply changes after the user confirms

--- a/.claude/commands/lib/spec-backfill.md
+++ b/.claude/commands/lib/spec-backfill.md
@@ -1,0 +1,147 @@
+# /spec-backfill
+
+Bootstrap or improve specs that mirror the codebase. Works for greenfield repos with no specs, brownfield repos with partial coverage, and already-spec'd repos that need a completeness check.
+
+**`$ARGUMENTS`** — optional plain-language scope or depth hint. Examples:
+- *(no arguments)* — scan for gaps and incomplete specs, report, ask what to do next
+- `go deep in the auth module` — read source + tests for that area and fill specs
+- `just map the top level` — create top-level placeholders only, skip submodules
+- `check completeness` — report placeholder counts without creating anything
+
+Re-running this command at any time is the completeness check. It is idempotent.
+
+For the reasoning behind this command's design, see [PHILOSOPHY.md](https://github.com/NoahWright87/spec-template/blob/main/PHILOSOPHY.md).
+
+---
+
+## Phase 1 — Assess the repo
+
+Use Glob to discover:
+
+**Source roots** — look for: `src/`, `app/`, `lib/`, `packages/*/src/`, `services/*/src/`. Note all that exist.
+
+**Test roots** — look for: `test/`, `tests/`, `__tests__/`, `spec/` (non-spec-template), `cypress/`, `playwright/`, `e2e/`, `integration/`. Note all that exist.
+
+**Existing specs coverage** — map what already exists under `specs/`. For each existing spec file, count occurrences of `> **TODO:**` to measure incompleteness.
+
+If `$ARGUMENTS` names a specific module or area, note it — that area gets priority in all later phases.
+
+---
+
+## Phase 2 — STOP POINT: report and confirm
+
+Present a concise summary before writing anything:
+
+1. **Gaps** — source modules with no corresponding spec file. List: source path → proposed spec path.
+2. **Incomplete specs** — existing spec files that still contain `> **TODO:**` placeholders. List: file path → placeholder count.
+3. **Proposed mapping** — how `src/**` would mirror into `specs/**`.
+
+Then ask the user:
+
+- "Should I create placeholder specs for the [N] unmapped modules?"
+- "Should I also read test files to fill in the Acceptance sections?" *(ask only if test roots were found)*
+- If `$ARGUMENTS` requested a deep read: "I'll read source + tests for [area] — confirm?"
+
+Write nothing until the user approves. If the user says "just show me the report," stop here.
+
+---
+
+## Phase 3 — Create placeholder specs
+
+For each unmapped source module the user approved, create a spec file using the existing `spec.md` template. Fill any section that can be reasonably inferred from the module's name, directory, or obvious purpose. Mark every section that cannot be determined with `> **TODO:**`.
+
+**File placement:**
+- Small or simple module (few files, single clear purpose) → `specs/{module}.spec.md`
+- Larger or multi-concern module → `specs/{module}/spec.md`, with optional `specs/{module}/{submodule}.spec.md` for distinct sub-concerns
+
+**Placeholder template** (used for every created spec):
+
+```markdown
+# {Module Name} Spec
+
+## Purpose
+> **TODO:** Why does this exist? Who or what depends on it?
+
+## Related
+> **TODO:** Link to related specs once they exist.
+
+## Contract
+
+### Inputs
+> **TODO:** What does this accept? (requests, parameters, events, config, user actions)
+
+### Outputs
+> **TODO:** What does this produce or affect? (responses, UI, side effects, persisted data)
+
+### Guarantees / Constraints
+> **TODO:** Invariants, ordering, auth expectations, performance expectations.
+
+## Behavior
+> **TODO:** Describe the happy path, alternate paths, error states, and notable edge cases.
+
+## User Experience (UX)
+> **TODO:** How do consumers (users or developers) interact with this?
+
+## Acceptance
+> **TODO:** Fill from tests. What behaviors are asserted and where?
+```
+
+Fill the Purpose section with whatever the module name and location suggest, even if brief. A partial answer is better than a placeholder that will sit forever.
+
+---
+
+## Phase 4 — Fill Acceptance from tests (if approved)
+
+For each spec with a `> **TODO:**` Acceptance section:
+
+1. Find relevant test files by path similarity (`src/foo/**` ↔ tests mentioning `foo`), import references, and naming conventions (`foo.test.ts`, `FooService.spec.ts`, etc.).
+2. Prioritize test types: e2e / integration / contract first; unit tests sparingly — skip assertions about internal implementation details.
+3. Translate `describe` / `it` blocks into behavioral AC bullets in the Acceptance section. Focus on observable outcomes.
+4. After the ACs, note the source test file paths so the link is traceable.
+5. Where tests are too thin or unclear to produce honest ACs: leave the `> **TODO:**` in place and add a note: `> **TODO:** Test coverage is sparse here — add integration tests before relying on this section.`
+
+---
+
+## Phase 5 — Fill from source (deep mode)
+
+For the area named in `$ARGUMENTS`:
+
+1. Read source files in that area. Understand what the module accepts, produces, and guarantees.
+2. Fill the Contract (Inputs, Outputs, Guarantees) and Behavior sections with what the code reveals.
+3. Where the code's behavior is clear but the *intent* is unclear, note it: `> **TODO:** Behavior observed, but intent unclear — verify with module owner.`
+4. Deep mode is scoped to the named area only. A full-repo deep read is too slow and token-heavy to be useful.
+
+---
+
+## Phase 6 — Report
+
+After each run, give the user:
+
+- Files created (paths)
+- Files updated (paths + what changed)
+- Total `> **TODO:**` placeholders remaining across all specs in `specs/`
+- Suggested next steps:
+  - Re-run `/spec-backfill` at any time to check remaining gaps
+  - Run `/spec-backfill go deep in [area]` to fill a specific module
+  - Run `/intake` to file any new ideas that surfaced during this review
+
+---
+
+## Placeholder convention
+
+Unfilled spec sections use `> **TODO:** description`. This format:
+- Renders visibly in GitHub (blockquote, bold label)
+- Is greppable: `> \*\*TODO\*\*`
+- Signals clearly that a section needs attention
+
+Filling a placeholder means replacing the `> **TODO:**` line with real content. Partial fills are fine — leave `> **TODO:**` for the parts that remain unknown.
+
+---
+
+## Preferred tools
+
+- **Glob** — discover source roots, test roots, and existing spec coverage
+- **Read** — read source files, test files, and existing specs before proposing changes
+- **Grep** — find `> **TODO:**` placeholders across existing specs; find test files by path/name pattern
+- **Write** — create new spec files after the user approves
+- **Edit** — update existing spec files (fill placeholders, add new sections)

--- a/.claude/commands/what-now.md
+++ b/.claude/commands/what-now.md
@@ -1,0 +1,27 @@
+# What Now?
+
+Not sure which command to run? Use this as your starting point.
+
+Use the AskUserQuestion tool to present the options below. Once the user selects one, read the corresponding command file and follow it as your next set of instructions. Do not load any command files until the user has made their choice — only read the one they pick.
+
+## Options
+
+| Choice | What it does |
+|--------|-------------|
+| **File ideas and GitHub Issues** | Sort new ideas, feature requests, and open GH Issues into the right TODO spec files |
+| **Add detail to TODO items** | Clarify vague TODOs, add effort estimates (XS–XL), and open a PR with proposed spec updates |
+| **Implement TODO items** | Pick the easiest open TODO items and implement them |
+| **Backfill specs from existing code** | Generate spec files from an existing codebase; mark gaps with `> **TODO:**` for later |
+| **Install or update the spec system** | Set up this template in a new repo or pull in upstream updates |
+
+## After the user picks
+
+| Choice | File to read and follow |
+|--------|------------------------|
+| File ideas and GitHub Issues | `.claude/commands/lib/intake.md` |
+| Add detail to TODO items | `.claude/commands/lib/refine.md` |
+| Implement TODO items | `.claude/commands/lib/knock-out-todos.md` |
+| Backfill specs from existing code | `.claude/commands/lib/spec-backfill.md` |
+| Install or update the spec system | `.claude/commands/lib/respec.md` |
+
+Read the file. Follow it exactly. Do not summarize or paraphrase — the command file is the instruction set.

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,0 +1,183 @@
+name: Spec Coverage Check
+
+# Warns (without blocking) when source files change in a PR without a
+# corresponding update somewhere in specs/. The warning comment is
+# formatted for an LLM to read and act on (e.g. run /spec-backfill).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Edit SOURCE_ROOTS to match your repo's layout.
+# Space-separated list of source root directories to check against specs/.
+env:
+  SOURCE_ROOTS: "src app lib"
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  spec-coverage:
+    name: Check spec coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for git diff against base branch
+
+      - name: Detect uncovered source changes
+        id: check
+        run: |
+          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+
+          spec_changes=()
+          src_changes=()
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if [[ "$file" == specs/* ]]; then
+              spec_changes+=("$file")
+            else
+              for root in $SOURCE_ROOTS; do
+                if [[ "$file" == "$root/"* ]]; then
+                  src_changes+=("$file")
+                  break
+                fi
+              done
+            fi
+          done <<< "$changed"
+
+          # No source changes in this PR — nothing to check
+          if [[ ${#src_changes[@]} -eq 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # For each changed source file, look for a spec file that shares
+          # a path prefix. Matching is intentionally loose: specs/auth/ covers
+          # src/auth/login.js, src/auth/register.js, etc.
+          uncovered=()
+          for src_file in "${src_changes[@]}"; do
+            # Strip source root to get relative path
+            # e.g. src/auth/login.js -> auth/login.js
+            relative=""
+            for root in $SOURCE_ROOTS; do
+              if [[ "$src_file" == "$root/"* ]]; then
+                relative="${src_file#"$root/"}"
+                break
+              fi
+            done
+
+            dir=$(dirname "$relative")  # auth for auth/login.js, . for login.js
+            covered=false
+
+            if [[ "$dir" == "." ]]; then
+              # Root-level source file: any spec change is considered coverage
+              [[ ${#spec_changes[@]} -gt 0 ]] && covered=true
+            else
+              # Walk up the ancestor chain looking for a matching spec change
+              # e.g. auth/services -> auth -> (root)
+              check_dir="$dir"
+              while [[ -n "$check_dir" && "$check_dir" != "." ]]; do
+                for spec_file in "${spec_changes[@]}"; do
+                  spec_rel="${spec_file#specs/}"
+                  # Match if the spec file lives under this directory component
+                  if [[ "$spec_rel" == "$check_dir/"* || "$spec_rel" == "$check_dir."* ]]; then
+                    covered=true
+                    break
+                  fi
+                done
+                [[ "$covered" == "true" ]] && break
+                parent=$(dirname "$check_dir")
+                [[ "$parent" == "$check_dir" ]] && break
+                check_dir="$parent"
+              done
+            fi
+
+            [[ "$covered" == "false" ]] && uncovered+=("$src_file")
+          done
+
+          echo "has_uncovered=$([ ${#uncovered[@]} -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+          # Write uncovered list (newline-delimited heredoc — safe for any path)
+          {
+            echo "uncovered_list<<UNCOVERED_EOF"
+            printf '%s\n' "${uncovered[@]}"
+            echo "UNCOVERED_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          HAS_UNCOVERED: ${{ steps.check.outputs.has_uncovered }}
+          UNCOVERED_LIST: ${{ steps.check.outputs.uncovered_list }}
+        with:
+          script: |
+            const marker = '<!-- spec-coverage-check -->';
+            const hasUncovered = process.env.HAS_UNCOVERED === 'true';
+            const raw = process.env.UNCOVERED_LIST || '';
+            const uncovered = raw.trim() ? raw.trim().split('\n') : [];
+            // P avoids a bare '|' at the start of a YAML line, which trips GitHub's parser
+            const P = '|';
+
+            let body;
+            if (!hasUncovered) {
+              body = `${marker}\n✅ All changed source files have corresponding spec updates in this PR.`;
+            } else {
+              const rows = uncovered.map(f => {
+                // Build suggested spec paths from most-specific to least-specific
+                // e.g. src/auth/services/login.js -> specs/auth/services/, specs/auth/
+                const parts = f.replace(/^[^/]+\//, '').split('/');
+                parts.pop(); // remove filename
+                const suggestions = [];
+                let path = '';
+                for (const part of parts) {
+                  path = path ? `${path}/${part}` : part;
+                  suggestions.unshift(`\`specs/${path}/\``);
+                }
+                return `${P} \`${f}\` ${P} ${suggestions.join(', ') || '`specs/`'} ${P}`;
+              }).join('\n');
+
+              body = `${marker}
+## ⚠️ Spec coverage warning
+
+These source files changed in this PR without a corresponding update in \`specs/\`:
+
+${P} Source file ${P} Suggested spec locations ${P}
+${P}-------------|--------------------------|
+${rows}
+
+**To fix:** update the relevant specs and push, or run \`/spec-backfill\` to generate them.
+
+*This warning is informational — it does not block merging.*`;
+            }
+
+            // Find the existing bot comment (if any) and update or create
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (hasUncovered) {
+              // Only create a new comment when there are warnings;
+              // don't clutter PRs that never had uncovered files
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+Keep this repo aligned with spec-driven development. Specs are the source of truth; code implements them.
+
+## Structure
+
+- Specs live in `specs/` and mirror the source tree.
+- Every directory in `specs/` includes `spec.md` (current behavior) and `spec.todo.md` (future work).
+- Additional focused specs are named `{feature}.spec.md` and follow the same structure as `spec.md`.
+- Every spec includes a **Related** section with links to other spec files (not TODOs).
+
+## Workflow
+
+1. Start new work in `spec.todo.md`.
+2. Once a TODO item is implemented, promote its description into `spec.md`.
+3. Keep specs and code in sync — when behavior changes, update the spec alongside the code.
+
+## Split rule
+
+Applies to both spec files and TODO spec files.
+
+- Split a spec when it grows past **300 lines**.
+- A spec at **500 lines** must be split before further work continues.
+- A single large or complex idea in `spec.todo.md` warrants its own `{feature}.todo.md` — the same size thresholds apply, but also use judgment: if an idea has enough sub-concerns to benefit from its own space, extract it.
+- A refined `{feature}.todo.md` functions as a PRD or HLD, all in-repo. When fully implemented, it graduates to `{feature}.spec.md`.
+
+## Evolving conventions
+
+The spec system should grow to capture the team's real conventions, not just the template defaults.
+
+While writing or reviewing specs, notice repeated corrections from the user. When the same pattern is corrected twice or more, suggest adding it as a new bullet in the Writing specs section of `specs/AGENTS.md`. The goal is to capture team habits where agents will actually read them.
+
+## Language
+
+Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y." See [PHILOSOPHY.md](PHILOSOPHY.md) for rationale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,4 @@ While writing or reviewing specs, notice repeated corrections from the user. Whe
 
 ## Language
 
-Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y." See [PHILOSOPHY.md](PHILOSOPHY.md) for rationale.
+Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,92 +1,11 @@
 # Change Log
 
-This file lists the current and previous versions, along with the features that changed in each.
+This file tracks changes to this repository by version.
 
 # Versions
 
+## WIP
+
 ## 0.1.0
 
-- Add `/what-now` meta command: thin interactive entrypoint that presents a menu (via AskUserQuestion) and delegates to the chosen command by reading that file on demand — only the selected command enters context; add Commands + Headless mode sections to `scaffold/specs/AGENTS.md` so autonomous agents have the same routing map with a global rule that "ask the user" means posting to GH issues or PRs
-- Add `/refine` command: middle step between `/intake` and `/knock-out-todos`; prioritizes highest-priority TODO items, adds technical detail and effort estimates (XS/S/M/L/XL/Unknown) as inline annotations, asks clarifying questions interactively in supervised mode or via GH issue comments in headless mode, and commits + opens a PR with proposed updates
-- Add opt-in auto-create GH issues to `/intake`: when `"auto_create_issues": true` is set in `specs/.meta.json`, `/intake` creates a GH issue for each manual submission lacking a `[#N](url)` link, then labels it `intake:filed` as usual; off by default
-- Fix step ordering in `/intake`: rename "Step 0" to Step 2 and renumber all subsequent steps (2–7 → 3–8) so the file reads top-to-bottom without a confusing out-of-order heading; update all internal step references
-- Add `scripts/install-scaffold.sh` — deterministic shell script that copies `dist/` scaffold files into a target repo without overwriting existing files; reduces Claude token usage during onboarding
-- Add `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups items by area with links to spec files; suitable for GH Pages publishing
-- Add `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GH Pages on push to main; auto-regenerates roadmap before upload
-- Add pre-flight phase to worker `entrypoint.sh`: queries unprocessed GH issues, open TODO count, and INTAKE waiting items before invoking Claude; exits early (zero tokens) on no-op runs; passes stats as context to reduce in-session queries
-- Support two worker auth modes: Claude Code subscription (mount `~/.claude` from host) or Anthropic API key (`ANTHROPIC_API_KEY`); `ANTHROPIC_API_KEY` is no longer required
-- Add `specs/scaffold.md` and `specs/worker.md` — feature-level current-state specs (split from monolithic `specs/spec.md`)
-- Switch `## Reminders` bullets in `knock-out-todos.md` to `*` so grep for `^- ` skips them naturally
-- Restructure `README.md`: move Quick Start (onboarding command) to top before pitch text; add `## What is this?` wrapper for background sections; document human-vs-AI docs separation in `spec.md`
-
-## v0.7.0
-
-- Add `worker/` — autonomous containerized runner (Dockerfile, entrypoint.sh, worker-instructions.md, README.md); cron job model with Docker volume state persistence, GHCR publishing
-- Add scaffold detection + install mode + operate mode to worker: checks for `specs/AGENTS.md`; missing → copies `dist/` payload, opens bootstrap PR; present → runs intake + knock-out-todos via Claude CLI
-- Add `scaffold/specs/` — template source files for the installable scaffold payload
-- Add `scripts/generate-dist.sh` — generates `dist/` from scaffold sources + command files with auto-generated do-not-edit headers; commit dist/ for downstream consumption
-- Add `dist/` — generated installable scaffold payload committed to repo for direct consumption
-- Add `.github/workflows/build-worker.yml` — builds and publishes worker image to GHCR on pushes to `worker/` or `scripts/` on main
-- Add `CONTRIBUTING.md` — scaffold source structure, dist/ regeneration workflow, manual installation without /respec
-- Update `README.md` — add "Running on autopilot" section linking to worker runtime
-- Fill in `specs/spec.md` with current two-layer system state
-- Switch TODO item format from `- [ ]` checkboxes to plain `- ` bullets; update `/knock-out-todos` accordingly (remove Step 0 orphan scan, new grep pattern, remove → promote flow instead of check-then-move)
-- Add `PHILOSOPHY.md` proximity section — explains how format affords behavior and the checkbox incident as a concrete example
-- Add `/respec` Update step 5 — detects TODO format changes and offers to migrate existing TODO files; applies only with user approval
-- Fix bootstrap PR deduplication: use deterministic branch name `scaffold/bootstrap`; check for open PR before creating a new one
-- Fix install mode file copy: use `rsync --ignore-existing` so existing repo files are never overwritten
-- Fix `/intake` Path 1 entry format: plain `- ` bullets instead of `- [ ]` checkboxes
-- Fix dep TODO template: plain bullets in `scaffold/specs/deps/README.md`
-- Pin `@anthropic-ai/claude-code` to `2.1.71` in Dockerfile to reduce supply chain risk; add `rsync` to system deps
-- Remove undocumented/unimplemented `EXECUTION_MODE` param from Dockerfile and spec
-
-## v0.6.2
-
-- Rewrite `README.md` — human-friendly pitch, SpecKit comparison, commands overview, updated "What gets installed" table (adds `spec-backfill.md` and `spec-check.yml`)
-
-## v0.6.1
-
-- Add `.claude/commands/README.md` — human-friendly guide to the commands with Mermaid flow diagrams; not installed into target repos
-
-## v0.6
-
-- Add `specs/deps/` directory — dep specs (outsider knowledge) + outbound TODO files for cross-repo work
-- Add 3-way intake routing to `/intake`: Routed / Duplicate+boost / Needs more info
-- Add Step 0 to `/intake`: check waiting items (date-annotated), re-process on new comments, re-surface stale items after 7 days (configurable), support snooze annotations
-- Add comment-as-question escape hatch: `/intake` posts to GH issues when it can't route, clearly marked as from Claude
-- Update `/knock-out-todos` with dep TODO flow: opening downstream GH issues + cross-linking
-- Update `/knock-out-todos` with dep sub-bullet reconciliation: checks downstream issue status before implementing
-- Add `specs/deps/README.md` to managed files in `/respec`
-- Issue #1 labeled `intake:filed`
-
-## v0.5
-
-- Add `.github/workflows/spec-check.yml` — PR check that warns when source files change without a corresponding spec update; informational only, never blocks merging
-- Add `spec-check.yml` to managed files in `/respec`
-
-## v0.4
-
-- Add `/spec-backfill` command — bootstrap or improve specs mirroring the codebase; idempotent re-runs act as a completeness check
-- Add `> **TODO:**` placeholder convention — greppable, renders visibly in GitHub, tracked by `/spec-backfill`
-- Document placeholder convention in `specs/AGENTS.md`
-- Add `/spec-backfill` to managed files in `/respec`
-
-## v0.3
-
-- Add GitHub Issues integration to `/intake` — pulls open issues, applies `intake:filed/rejected/ignore` labels
-- Add `/knock-out-todos` GH integration — reads issue details/comments before implementing, closes issues on completion
-- Add `PHILOSOPHY.md` repetition principle — important rules stated in multiple files; `## Reminders` sections throughout
-- Add `{feature}.todo.md` file type — elaborated plans / PRDs that live in-repo; split rules apply to TODO specs too
-- Add evolving conventions pattern — repeated user corrections become new bullets in `specs/AGENTS.md`
-
-## v0.2
-
-- Add `/respec` command — one command that handles fresh install, adaptation, and update
-- Add `PHILOSOPHY.md` — principles doc covering affirmative language, minimalism, and specs as source of truth
-- Add `specs/AGENTS.md` — spec-scoped agent instructions, installed into target repos by `/respec`
-- Update `README.md` — lead with quick start, copy/paste install prompt, opt-out instructions
-- Reformat `AGENTS.md` — same content, clearer structure, affirmative language throughout
-
-## v0.1
-
-- Initial version.
+- Install spec-template scaffold via `/respec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Change Log
+
+This file lists the current and previous versions, along with the features that changed in each.
+
+# Versions
+
+## 0.1.0
+
+- Add `/what-now` meta command: thin interactive entrypoint that presents a menu (via AskUserQuestion) and delegates to the chosen command by reading that file on demand — only the selected command enters context; add Commands + Headless mode sections to `scaffold/specs/AGENTS.md` so autonomous agents have the same routing map with a global rule that "ask the user" means posting to GH issues or PRs
+- Add `/refine` command: middle step between `/intake` and `/knock-out-todos`; prioritizes highest-priority TODO items, adds technical detail and effort estimates (XS/S/M/L/XL/Unknown) as inline annotations, asks clarifying questions interactively in supervised mode or via GH issue comments in headless mode, and commits + opens a PR with proposed updates
+- Add opt-in auto-create GH issues to `/intake`: when `"auto_create_issues": true` is set in `specs/.meta.json`, `/intake` creates a GH issue for each manual submission lacking a `[#N](url)` link, then labels it `intake:filed` as usual; off by default
+- Fix step ordering in `/intake`: rename "Step 0" to Step 2 and renumber all subsequent steps (2–7 → 3–8) so the file reads top-to-bottom without a confusing out-of-order heading; update all internal step references
+- Add `scripts/install-scaffold.sh` — deterministic shell script that copies `dist/` scaffold files into a target repo without overwriting existing files; reduces Claude token usage during onboarding
+- Add `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups items by area with links to spec files; suitable for GH Pages publishing
+- Add `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GH Pages on push to main; auto-regenerates roadmap before upload
+- Add pre-flight phase to worker `entrypoint.sh`: queries unprocessed GH issues, open TODO count, and INTAKE waiting items before invoking Claude; exits early (zero tokens) on no-op runs; passes stats as context to reduce in-session queries
+- Support two worker auth modes: Claude Code subscription (mount `~/.claude` from host) or Anthropic API key (`ANTHROPIC_API_KEY`); `ANTHROPIC_API_KEY` is no longer required
+- Add `specs/scaffold.md` and `specs/worker.md` — feature-level current-state specs (split from monolithic `specs/spec.md`)
+- Switch `## Reminders` bullets in `knock-out-todos.md` to `*` so grep for `^- ` skips them naturally
+- Restructure `README.md`: move Quick Start (onboarding command) to top before pitch text; add `## What is this?` wrapper for background sections; document human-vs-AI docs separation in `spec.md`
+
+## v0.7.0
+
+- Add `worker/` — autonomous containerized runner (Dockerfile, entrypoint.sh, worker-instructions.md, README.md); cron job model with Docker volume state persistence, GHCR publishing
+- Add scaffold detection + install mode + operate mode to worker: checks for `specs/AGENTS.md`; missing → copies `dist/` payload, opens bootstrap PR; present → runs intake + knock-out-todos via Claude CLI
+- Add `scaffold/specs/` — template source files for the installable scaffold payload
+- Add `scripts/generate-dist.sh` — generates `dist/` from scaffold sources + command files with auto-generated do-not-edit headers; commit dist/ for downstream consumption
+- Add `dist/` — generated installable scaffold payload committed to repo for direct consumption
+- Add `.github/workflows/build-worker.yml` — builds and publishes worker image to GHCR on pushes to `worker/` or `scripts/` on main
+- Add `CONTRIBUTING.md` — scaffold source structure, dist/ regeneration workflow, manual installation without /respec
+- Update `README.md` — add "Running on autopilot" section linking to worker runtime
+- Fill in `specs/spec.md` with current two-layer system state
+- Switch TODO item format from `- [ ]` checkboxes to plain `- ` bullets; update `/knock-out-todos` accordingly (remove Step 0 orphan scan, new grep pattern, remove → promote flow instead of check-then-move)
+- Add `PHILOSOPHY.md` proximity section — explains how format affords behavior and the checkbox incident as a concrete example
+- Add `/respec` Update step 5 — detects TODO format changes and offers to migrate existing TODO files; applies only with user approval
+- Fix bootstrap PR deduplication: use deterministic branch name `scaffold/bootstrap`; check for open PR before creating a new one
+- Fix install mode file copy: use `rsync --ignore-existing` so existing repo files are never overwritten
+- Fix `/intake` Path 1 entry format: plain `- ` bullets instead of `- [ ]` checkboxes
+- Fix dep TODO template: plain bullets in `scaffold/specs/deps/README.md`
+- Pin `@anthropic-ai/claude-code` to `2.1.71` in Dockerfile to reduce supply chain risk; add `rsync` to system deps
+- Remove undocumented/unimplemented `EXECUTION_MODE` param from Dockerfile and spec
+
+## v0.6.2
+
+- Rewrite `README.md` — human-friendly pitch, SpecKit comparison, commands overview, updated "What gets installed" table (adds `spec-backfill.md` and `spec-check.yml`)
+
+## v0.6.1
+
+- Add `.claude/commands/README.md` — human-friendly guide to the commands with Mermaid flow diagrams; not installed into target repos
+
+## v0.6
+
+- Add `specs/deps/` directory — dep specs (outsider knowledge) + outbound TODO files for cross-repo work
+- Add 3-way intake routing to `/intake`: Routed / Duplicate+boost / Needs more info
+- Add Step 0 to `/intake`: check waiting items (date-annotated), re-process on new comments, re-surface stale items after 7 days (configurable), support snooze annotations
+- Add comment-as-question escape hatch: `/intake` posts to GH issues when it can't route, clearly marked as from Claude
+- Update `/knock-out-todos` with dep TODO flow: opening downstream GH issues + cross-linking
+- Update `/knock-out-todos` with dep sub-bullet reconciliation: checks downstream issue status before implementing
+- Add `specs/deps/README.md` to managed files in `/respec`
+- Issue #1 labeled `intake:filed`
+
+## v0.5
+
+- Add `.github/workflows/spec-check.yml` — PR check that warns when source files change without a corresponding spec update; informational only, never blocks merging
+- Add `spec-check.yml` to managed files in `/respec`
+
+## v0.4
+
+- Add `/spec-backfill` command — bootstrap or improve specs mirroring the codebase; idempotent re-runs act as a completeness check
+- Add `> **TODO:**` placeholder convention — greppable, renders visibly in GitHub, tracked by `/spec-backfill`
+- Document placeholder convention in `specs/AGENTS.md`
+- Add `/spec-backfill` to managed files in `/respec`
+
+## v0.3
+
+- Add GitHub Issues integration to `/intake` — pulls open issues, applies `intake:filed/rejected/ignore` labels
+- Add `/knock-out-todos` GH integration — reads issue details/comments before implementing, closes issues on completion
+- Add `PHILOSOPHY.md` repetition principle — important rules stated in multiple files; `## Reminders` sections throughout
+- Add `{feature}.todo.md` file type — elaborated plans / PRDs that live in-repo; split rules apply to TODO specs too
+- Add evolving conventions pattern — repeated user corrections become new bullets in `specs/AGENTS.md`
+
+## v0.2
+
+- Add `/respec` command — one command that handles fresh install, adaptation, and update
+- Add `PHILOSOPHY.md` — principles doc covering affirmative language, minimalism, and specs as source of truth
+- Add `specs/AGENTS.md` — spec-scoped agent instructions, installed into target repos by `/respec`
+- Update `README.md` — lead with quick start, copy/paste install prompt, opt-out instructions
+- Reformat `AGENTS.md` — same content, clearer structure, affirmative language throughout
+
+## v0.1
+
+- Initial version.

--- a/specs/.meta.json
+++ b/specs/.meta.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/NoahWright87/spec-template",
+  "commit": "c548ad1efba144b7cb30ebb0eefe01fc025f45de",
+  "date": "2026-03-13"
+}

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -72,7 +72,7 @@ Code already says what it does. A comment that merely restates the code adds noi
 
 ## Language
 
-Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y." See [PHILOSOPHY.md](../PHILOSOPHY.md) for rationale.
+Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y."
 
 ## Reminders
 

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -1,0 +1,86 @@
+# Specs — Agent Instructions
+
+This directory uses **spec-driven development**. Specs are the source of truth; code implements them.
+
+## Structure
+
+- Specs live in `specs/` and mirror the source tree.
+- Every directory in `specs/` includes:
+  - `spec.md` — current, shippable behavior
+  - `spec.todo.md` — future work and roadmap
+- Additional focused specs are named `{feature}.spec.md` and follow the same structure as `spec.md`.
+- Every spec includes a **Related** section linking to other spec files (not TODOs).
+
+## Workflow
+
+1. Start new work in `spec.todo.md`.
+2. Once a TODO item is implemented, promote its description into `spec.md`.
+3. Keep specs and code in sync — when behavior changes, update the spec alongside the code.
+
+## Writing specs
+
+- Describe behavior, not implementation
+- Be explicit where ambiguity could cause bugs
+- Keep specs short, readable, and skimmable
+- Future or uncommitted behavior belongs in `spec.todo.md`, not `spec.md`
+
+## Split rule
+
+Applies to both spec files and TODO spec files.
+
+- Split a spec when it grows past **300 lines**.
+- A spec at **500 lines** must be split before further work continues.
+- A single large or complex idea in `spec.todo.md` warrants its own `{feature}.todo.md` — use size thresholds as a guide, but also use judgment: if an idea has enough sub-concerns to benefit from its own space, extract it.
+- A refined `{feature}.todo.md` functions as a PRD or HLD, all in-repo. When implemented, it graduates to `{feature}.spec.md`.
+
+## Evolving conventions
+
+The spec system grows to capture the team's actual conventions — not just the template defaults.
+
+While writing or reviewing specs, notice repeated corrections from the user. When the same pattern is corrected twice or more, suggest adding it as a new bullet in the Writing specs section of this file (`specs/AGENTS.md`). Capture team habits where agents will actually read them.
+
+## Incomplete specs
+
+When a spec section cannot be determined from available context, mark it with a `> **TODO:**` placeholder:
+
+```markdown
+> **TODO:** Why does this module exist? Who depends on it?
+```
+
+This format renders visibly in GitHub, is greppable (`> \*\*TODO\*\*`), and signals clearly that the section needs attention. Fill a placeholder whenever context allows — even a partial answer is better than leaving it blank. Run `/spec-backfill` at any time to scan for remaining placeholders and check overall spec completeness.
+
+## Dependency specs
+
+The `specs/deps/` directory holds specs and outbound TODO files for repositories this project depends on.
+
+- `specs/deps/{name}.spec.md` — outsider knowledge: what the dep does from our perspective, why we use it, how we interface with it, owner, known quirks. Written for routing, not integration docs.
+- `specs/deps/{name}.todo.md` — outbound work items; "implementing" one means opening a GitHub issue in that repo. `/knock-out-todos` opens the downstream issue and records it as a sub-bullet on the TODO item.
+- Sub-bullet format for cross-repo issues: `  - [{repo}#{N}](url)` — added by `/knock-out-todos` after opening the downstream issue.
+- When all sub-bullet issues are closed, the main item is unblocked. Once validated, move it to `spec.md` and drop the sub-bullets — they are implementation history, not current state.
+
+See [`deps/README.md`](deps/README.md) for templates.
+
+## Comments explain why, not what
+
+This applies to code comments, spec annotations, and inline notes throughout the codebase.
+
+Code already says what it does. A comment that merely restates the code adds noise. A comment that explains *why* — the constraint, the history, the non-obvious reason — adds signal.
+
+- Write `# WHY: ltrimstr removes only one char; test() handles multi-space/newline prefixes` rather than `# fix whitespace`
+- Write `# WHY: credential helper is scoped to github.com to avoid leaking the token to other hosts` rather than `# scope credential helper`
+- When code is self-explanatory, omit the comment — the best comment is often none at all
+
+## Language
+
+Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y." See [PHILOSOPHY.md](../PHILOSOPHY.md) for rationale.
+
+## Reminders
+
+- `spec.md` = current state — `spec.todo.md` = future plans — `{feature}.todo.md` = elaborated plans / PRDs
+- Completed items flow from todo → `spec.md` when implemented
+- Large ideas flow from `spec.todo.md` → their own `{feature}.todo.md` when they need room to grow
+- Write in the affirmative; pair every constraint with its positive form
+
+---
+
+*Installed by [spec-template](https://github.com/NoahWright87/spec-template).*

--- a/specs/INTAKE.md
+++ b/specs/INTAKE.md
@@ -6,7 +6,7 @@ Not sure where your idea belongs? Drop it here and let the LLMs file it in the r
 
 When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
 
-Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
+Use your best judgment to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
 
 When you have emptied the submissions section below, leave behind a single bullet:
 

--- a/specs/INTAKE.md
+++ b/specs/INTAKE.md
@@ -1,0 +1,21 @@
+# Ideas intake
+
+Not sure where your idea belongs? Drop it here and let the LLMs file it in the right place later!
+
+## AGENTS Instructions
+
+When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
+
+Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
+
+When you have emptied the submissions section below, leave behind a single bullet:
+
+```
+- *Add your ideas here*.
+```
+
+Items waiting for more information stay in this file with a date annotation: `*(waiting for response, asked YYYY-MM-DD)*`. Re-surface stale items after **7 days** with no reply — change this number to adjust the threshold. If the user asks to defer an item, annotate it as `*(snoozed until YYYY-MM-DD)*` and skip it until that date.
+
+## Submissions
+
+- *Add your ideas here*.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,46 @@
+# Specs
+
+This directory contains **spec-driven source-of-truth documents** for this repository.
+Specs mirror the source tree and describe *what the system is and how it behaves*, not how it is implemented.
+
+## Core rules
+- `spec.md` is the **root spec** for each directory.
+- Every `spec.md` must have a neighboring `spec.todo.md`.
+- Additional specs are named `{feature}.spec.md` and use the same template.
+- Specs must include a **Related** section that links only to other specs (not TODOs).
+
+## File types
+
+### `spec.md`
+Primary specification for a page, feature, system, or module.
+Describes the **current, shippable contract**.
+
+### `{feature}.spec.md`
+Focused spec for a sub-feature or component.
+Same structure as `spec.md`, just smaller in scope.
+
+### `spec.todo.md`
+Roadmap for future work related to its neighboring spec.
+Prioritized from top to bottom.
+
+### `{feature}.todo.md`
+Elaborated plan for a specific feature or idea — extracted from `spec.todo.md` when an item grows large or complex enough to warrant its own space. Functions as a PRD or HLD, all in-repo. When implemented, it graduates to `{feature}.spec.md`.
+
+INTAKE can seed a `{feature}.todo.md` directly when a submitted idea is substantial enough to open a refinement conversation rather than file as a simple bullet.
+
+### `deps/`
+Specs and outbound TODO files for repositories this project depends on. Each dep gets a `{name}.spec.md` (outsider knowledge — what it does from our perspective, why we use it) and optionally a `{name}.todo.md` (work items that need to happen in that repo). See [`deps/README.md`](deps/README.md) for templates and the full pattern.
+
+## Split rule
+
+Applies to both spec files and TODO spec files.
+
+- Split when a file grows past **300 lines**.
+- A file at **500 lines** must be split before further work continues.
+- Use judgment for TODO files too: if a single idea has enough sub-concerns to benefit from its own space, extract it into `{feature}.todo.md` before hitting the line limits.
+
+## Writing guidelines
+- Prefer **behavior over implementation**
+- Be explicit where ambiguity could cause bugs
+- Keep specs short, readable, and skimmable
+- If it's not current behavior, it belongs in `spec.todo.md`

--- a/specs/deps/README.md
+++ b/specs/deps/README.md
@@ -1,0 +1,46 @@
+# Dependency Specs
+
+The `deps/` directory holds specs and outbound TODO files for repositories this project depends on.
+
+## Files
+
+- **`{name}.spec.md`** — outsider knowledge about the dep: what it does from our perspective, why we use it, how we interface with it, who owns it, known quirks. Written for routing — enough context for an agent or new teammate to understand the dep without digging into its codebase.
+- **`{name}.todo.md`** — work items that need to happen *in that repo*. "Implementing" one of these means opening a GitHub issue there. `/knock-out-todos` handles that step and records the downstream issue as a sub-bullet on the TODO item.
+
+## Dep spec template
+
+```markdown
+# {Dep Name}
+
+**What it does:** What this dep is for, from our perspective — the problem it solves for us.
+**Why we use it:** Why it was chosen; what gap it fills; any history worth knowing.
+**Interface:** How we call it (REST API, npm package, event bus, shared DB, etc.)
+**Owner:** Team or person responsible for the dep.
+**GitHub:** [link](url)
+**Notes:** Quirks, gotchas, or limitations we've discovered through use.
+```
+
+## Dep TODO format
+
+```markdown
+# {Dep Name} — Outbound TODOs
+
+Work that needs to happen in [{dep name}]({github url}).
+"Implementing" a TODO here means opening a GitHub issue in that repo.
+
+- [ ] [#local-issue](url) Description of what needs to happen in {dep name}
+  - [{dep-name}#{N}]({url}) ← downstream issue, added by /knock-out-todos once opened
+```
+
+When `/knock-out-todos` picks up a dep TODO, it:
+1. Opens a GitHub issue in the target repo
+2. Adds a sub-bullet with the downstream issue link
+3. Cross-links both issues with comments for traceability
+
+When all sub-bullet dep issues are closed, the main item is unblocked. Once validated/implemented, it moves to `spec.md` — without the sub-bullets, which are implementation history, not current state.
+
+## Reminders
+
+- Dep specs describe *our relationship* to the dep, not the dep's internal design
+- Keep dep specs short — just enough to route work confidently
+- Outbound TODOs go in `{name}.todo.md`; changes to *our* codebase go in the regular `spec.todo.md`

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,0 +1,52 @@
+# Spec Template — Current State
+
+## Purpose
+
+A two-product system for spec-driven development: an installable scaffold that gives AI a persistent memory in any repo, and an optional autonomous worker container that runs the intake/TODO workflow on a schedule.
+
+## Related
+
+- [`scaffold.md`](scaffold.md) — Layer 1 current state (scaffold files, dist/ generation)
+- [`worker.md`](worker.md) — Layer 2 current state (worker container, modes, CI/CD)
+- [`scaffold.todo.md`](scaffold.todo.md) — future scaffold and dist/ work
+- [`worker.todo.md`](worker.todo.md) — future worker runtime work
+- [`spec.todo.md`](spec.todo.md) — meta-tooling improvements (commands, UX)
+
+## System Overview
+
+The system has two independent layers. A repo can use Layer 1 without ever running Layer 2.
+
+**Layer 1 — Installable scaffold:** a small set of files (spec templates, AI slash commands, a PR check workflow) that downstream repos copy in via `/respec` or from `dist/`. Gives AI a persistent spec memory in the target repo. See [`scaffold.md`](scaffold.md).
+
+**Layer 2 — Autonomous worker:** a Docker container that clones a target repo, detects whether the scaffold is installed, and either bootstraps it (install mode) or runs the intake/TODO workflow (operate mode) on a cron schedule. See [`worker.md`](worker.md).
+
+## Commands
+
+- `/what-now`: Thin interactive entrypoint — presents a menu via AskUserQuestion and delegates to the chosen command by reading and following that command file. Lazy-loads only the selected command; no other files enter context. Intended for supervised use; the worker and autonomous agents use `specs/AGENTS.md` directly.
+  - `intake` (Steps 1–8): Ensure INTAKE.md exists → check waiting/snoozed items → pull from GitHub Issues → read `auto_create_issues` config from `specs/.meta.json` (controls whether manual submissions later get auto-filed as GH issues; absent = asks user) → read Submissions → survey TODO spec files → process each item (route/boost/ask) → selectively clear INTAKE.md → report
+    - **Auto-create GH issues:** opt-in via `"auto_create_issues": true` in `specs/.meta.json`; if the key is absent, asks the user. When enabled and `gh` is authenticated, creates a GH issue for each unlinked manual submission and labels it `intake:filed`. Off by default.
+  - `refine` (Steps 1–6): Find highest-priority TODO items → re-check waiting items for new GH responses → load GH issue + spec context → assess clarity and estimate effort → write technical detail and estimates → commit and open PR
+    - **Effort estimates:** XS / S / M / L / XL / Unknown (with optional `?` uncertainty markers) — added inline as `*(effort: M?)*` on the TODO item
+    - **Supervised mode:** iterates with user in chat until sign-off, then commits and opens PR
+    - **Headless mode:** posts clarifying questions to GH issues for unresolved product decisions, adds best-effort technical detail, commits and opens PR automatically; picks up GH replies on the next run
+  - `knock-out-todos`: Implement the easiest open TODO items — picks well-understood, low-risk work and executes it
+  - `spec-backfill`: Generate spec files from an existing codebase
+  - `respec`: Install or update the spec system in a target repo
+
+## Scripts
+
+- `scripts/generate-dist.sh` — regenerates `dist/` from scaffold source files; run after modifying any scaffold source
+- `scripts/install-scaffold.sh <target>` — copies `dist/` scaffold files into a target repo without overwriting existing files; faster/cheaper alternative to running `/respec` with Claude for the deterministic file-copy step
+- `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups open items by area with links back to individual spec files; suitable for GH Pages publishing
+- `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GitHub Pages on push to main; regenerates roadmap before upload
+
+## Human-Facing Docs
+
+- `README.md` is the human entrypoint; Quick Start (onboarding command) appears first before any background explanation
+- AI-facing instructions live in `.claude/commands/` and `specs/AGENTS.md` — not in the README
+
+## Guarantees / Constraints
+
+- Scaffold files in `dist/` are auto-generated from source — edit sources, run `scripts/generate-dist.sh`, commit result
+- Worker supports two auth modes: Claude Code subscription (mount `~/.claude`) or Anthropic API key (`ANTHROPIC_API_KEY`); never bake credentials into the image
+- Worker state volume is a supporting cache; GitHub and the target repo are the primary system of record

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,52 +1,17 @@
-# Spec Template — Current State
+# Toybox — Current State
 
 ## Purpose
 
-A two-product system for spec-driven development: an installable scaffold that gives AI a persistent memory in any repo, and an optional autonomous worker container that runs the intake/TODO workflow on a schedule.
+A place for fun little side projects.
 
 ## Related
 
-- [`scaffold.md`](scaffold.md) — Layer 1 current state (scaffold files, dist/ generation)
-- [`worker.md`](worker.md) — Layer 2 current state (worker container, modes, CI/CD)
-- [`scaffold.todo.md`](scaffold.todo.md) — future scaffold and dist/ work
-- [`worker.todo.md`](worker.todo.md) — future worker runtime work
-- [`spec.todo.md`](spec.todo.md) — meta-tooling improvements (commands, UX)
+> **TODO:** Add links to feature specs as they are created.
 
-## System Overview
+## Structure
 
-The system has two independent layers. A repo can use Layer 1 without ever running Layer 2.
-
-**Layer 1 — Installable scaffold:** a small set of files (spec templates, AI slash commands, a PR check workflow) that downstream repos copy in via `/respec` or from `dist/`. Gives AI a persistent spec memory in the target repo. See [`scaffold.md`](scaffold.md).
-
-**Layer 2 — Autonomous worker:** a Docker container that clones a target repo, detects whether the scaffold is installed, and either bootstraps it (install mode) or runs the intake/TODO workflow (operate mode) on a cron schedule. See [`worker.md`](worker.md).
-
-## Commands
-
-- `/what-now`: Thin interactive entrypoint — presents a menu via AskUserQuestion and delegates to the chosen command by reading and following that command file. Lazy-loads only the selected command; no other files enter context. Intended for supervised use; the worker and autonomous agents use `specs/AGENTS.md` directly.
-  - `intake` (Steps 1–8): Ensure INTAKE.md exists → check waiting/snoozed items → pull from GitHub Issues → read `auto_create_issues` config from `specs/.meta.json` (controls whether manual submissions later get auto-filed as GH issues; absent = asks user) → read Submissions → survey TODO spec files → process each item (route/boost/ask) → selectively clear INTAKE.md → report
-    - **Auto-create GH issues:** opt-in via `"auto_create_issues": true` in `specs/.meta.json`; if the key is absent, asks the user. When enabled and `gh` is authenticated, creates a GH issue for each unlinked manual submission and labels it `intake:filed`. Off by default.
-  - `refine` (Steps 1–6): Find highest-priority TODO items → re-check waiting items for new GH responses → load GH issue + spec context → assess clarity and estimate effort → write technical detail and estimates → commit and open PR
-    - **Effort estimates:** XS / S / M / L / XL / Unknown (with optional `?` uncertainty markers) — added inline as `*(effort: M?)*` on the TODO item
-    - **Supervised mode:** iterates with user in chat until sign-off, then commits and opens PR
-    - **Headless mode:** posts clarifying questions to GH issues for unresolved product decisions, adds best-effort technical detail, commits and opens PR automatically; picks up GH replies on the next run
-  - `knock-out-todos`: Implement the easiest open TODO items — picks well-understood, low-risk work and executes it
-  - `spec-backfill`: Generate spec files from an existing codebase
-  - `respec`: Install or update the spec system in a target repo
-
-## Scripts
-
-- `scripts/generate-dist.sh` — regenerates `dist/` from scaffold source files; run after modifying any scaffold source
-- `scripts/install-scaffold.sh <target>` — copies `dist/` scaffold files into a target repo without overwriting existing files; faster/cheaper alternative to running `/respec` with Claude for the deterministic file-copy step
-- `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups open items by area with links back to individual spec files; suitable for GH Pages publishing
-- `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GitHub Pages on push to main; regenerates roadmap before upload
-
-## Human-Facing Docs
-
-- `README.md` is the human entrypoint; Quick Start (onboarding command) appears first before any background explanation
-- AI-facing instructions live in `.claude/commands/` and `specs/AGENTS.md` — not in the README
+> **TODO:** Describe the source tree layout once projects are added.
 
 ## Guarantees / Constraints
 
-- Scaffold files in `dist/` are auto-generated from source — edit sources, run `scripts/generate-dist.sh`, commit result
-- Worker supports two auth modes: Claude Code subscription (mount `~/.claude`) or Anthropic API key (`ANTHROPIC_API_KEY`); never bake credentials into the image
-- Worker state volume is a supporting cache; GitHub and the target repo are the primary system of record
+> **TODO:** Document any constraints or invariants once projects are added.

--- a/specs/spec.todo.md
+++ b/specs/spec.todo.md
@@ -1,0 +1,23 @@
+# Spec Template — Roadmap
+
+## Summary
+This repo provides two products: (1) an installable spec / intake / TODO scaffold for other repos, and (2) a reusable autonomous worker runtime that runs Claude CLI in a container. See `scaffold.todo.md` and `worker.todo.md` for the large feature work. This file tracks improvements to the template system itself (commands, UX, meta-tooling).
+
+## Sooner
+
+## Later
+
+## Backlog
+
+- Sync general-purpose improvements from work fork *(blocked: waiting for work-specific code to be stripped before sharing)*
+
+## Ideas (Uncommitted)
+
+- When `/respec` runs in Update mode, compare the `dist/specs/spec.todo.md` template against the local TODO files. If the format differs (e.g. checkboxes vs plain bullets), offer to migrate existing TODO items to the current format. Apply only with user approval.
+
+## Reminders
+
+- Move completed items to `spec.md` — this file is for future plans, not current state
+- Large or complex ideas belong in their own `{feature}.todo.md`, not buried here
+- Items flow: INTAKE → `spec.todo.md` → `{feature}.todo.md` (if big) → `spec.md` (when done)
+- If a TODO item links to a GH issue (`[#N](...)`), include `closes #N` in your PR description — GitHub closes the issue on merge

--- a/specs/spec.todo.md
+++ b/specs/spec.todo.md
@@ -1,7 +1,8 @@
-# Spec Template — Roadmap
+# Toybox — Roadmap
 
 ## Summary
-This repo provides two products: (1) an installable spec / intake / TODO scaffold for other repos, and (2) a reusable autonomous worker runtime that runs Claude CLI in a container. See `scaffold.todo.md` and `worker.todo.md` for the large feature work. This file tracks improvements to the template system itself (commands, UX, meta-tooling).
+
+Future work for this repo. Add projects and features here as they are planned.
 
 ## Sooner
 
@@ -9,11 +10,7 @@ This repo provides two products: (1) an installable spec / intake / TODO scaffol
 
 ## Backlog
 
-- Sync general-purpose improvements from work fork *(blocked: waiting for work-specific code to be stripped before sharing)*
-
 ## Ideas (Uncommitted)
-
-- When `/respec` runs in Update mode, compare the `dist/specs/spec.todo.md` template against the local TODO files. If the format differs (e.g. checkboxes vs plain bullets), offer to migrate existing TODO items to the current format. Apply only with user approval.
 
 ## Reminders
 


### PR DESCRIPTION
## Summary

- Installs the [spec-template](https://github.com/NoahWright87/spec-template) scaffold via `/respec` (fresh install, commit `c548ad1`)
- Adds `specs/` with README, AGENTS, spec/todo templates, INTAKE bucket, and `deps/` pattern
- Adds `.claude/commands/` with `/what-now`, `/intake`, `/knock-out-todos`, `/refine`, `/spec-backfill`, and `/respec`
- Adds `.github/workflows/spec-check.yml` to warn on PRs that change source without updating specs
- Adds root `AGENTS.md` and `CHANGELOG.md`

## Test plan

- [ ] Open `/what-now` in Claude Code and confirm the menu appears
- [ ] Drop an idea into `specs/INTAKE.md` and run `/intake` to verify routing works
- [ ] Confirm `spec-check.yml` workflow runs on a test PR that touches source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)