### PR TITLE
refine: add estimates and detail for homepage + experiences TODOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file tracks changes to this repository by version.
 
 # Versions
 
+## WIP
+
+- Promote Toy Box MVP to `spec.md`; remove completed `[#2]` item from `spec.todo.md`
+- Refine homepage TODOs: add effort estimates and implementation detail to BTS / director's cut (`?bts=1` + design dep) and category filtering (hold until more toys exist)
+- Refine experiences TODOs: add implementation detail and effort estimates for Fireworks (M), Bouncing Shapes (S), Typing Racer (M), and Number Muncher (M?)
+- Add `specs/deps/design.todo.md` to track upstream design system work needed for BTS overlay support
+
 ## v0.2.0
 
 - Add Toy Box MVP: homepage with design system card grid, Starfield screensaver experience, React Router navigation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ This file tracks changes to this repository by version.
 
 # Versions
 
-## WIP
-
-- Promote Toy Box MVP to `spec.md`; remove completed `[#2]` item from `spec.todo.md`
-- Refine homepage TODOs: add effort estimates and implementation detail to BTS / director's cut (`?bts=1` + design dep) and category filtering (hold until more toys exist)
-- Refine experiences TODOs: add implementation detail and effort estimates for Fireworks (M), Bouncing Shapes (S), Typing Racer (M), and Number Muncher (M?)
-- Add `specs/deps/design.todo.md` to track upstream design system work needed for BTS overlay support
-
 ## v0.2.0
 
 - Add Toy Box MVP: homepage with design system card grid, Starfield screensaver experience, React Router navigation

--- a/specs/deps/design.todo.md
+++ b/specs/deps/design.todo.md
@@ -1,0 +1,19 @@
+# @noahwright/design — Downstream TODOs
+
+Tracked items that require changes in the `@noahwright/design` package before they can be completed here.
+
+## Sooner
+
+## Later
+
+- BTS overlay / panel support — add a composable overlay or panel component that experience pages can use for "behind-the-scenes" / director's cut mode *(effort: M??)*
+  - Needed by: `homepage.todo.md` BTS item
+  - The overlay should be renderable inside an experience page without disrupting the experience layout
+  - Likely a semi-transparent panel or drawer; exact design TBD when BTS content is first authored?
+
+## Backlog
+
+## Reminders
+
+- Items here represent work needed upstream in `@noahwright/design` before dependent TODOs in this repo can be implemented
+- When a downstream issue is opened, add a sub-bullet with the issue link per the dep TODO flow

--- a/specs/deps/design.todo.md
+++ b/specs/deps/design.todo.md
@@ -10,6 +10,7 @@ Tracked items that require changes in the `@noahwright/design` package before th
   - Needed by: `homepage.todo.md` BTS item
   - The overlay should be renderable inside an experience page without disrupting the experience layout
   - Likely a semi-transparent panel or drawer; exact design TBD when BTS content is first authored?
+  - [design#3](https://github.com/NoahWright87/design/issues/3) Downstream issue opened
 
 ## Backlog
 

--- a/specs/experiences.todo.md
+++ b/specs/experiences.todo.md
@@ -9,9 +9,15 @@
 - Spelling practice game
 - Custom word-list spelling toy
 - Sight word game
-- Typing racer
-- Number Muncher clone (if not chosen for MVP)
-- Prime Suspects (if not chosen for MVP)
+- Typing racer *(effort: M)*
+  - Display a phrase; player types it as fast as possible; show live WPM + accuracy on completion; category: `"educational"`
+  - Word/phrase list baked in as a static array; no backend needed
+  - Highlight current target character, color correct/incorrect keystrokes in real time
+- Number Muncher clone *(effort: M?)*
+  - Grid of numbers; player navigates with arrow keys and "eats" numbers matching the current rule (e.g. multiples of 3, primes); category: `"educational"`
+  - Stealth learning: math fluency through grid navigation speed, not drill formatting
+  - Rules cycle through a predefined set (multiples, factors, primes); difficulty increases over time?
+- Prime Suspects
 - Factor / multiple / prime math games
 - Spell Squares
 - Perimeter Wizard
@@ -19,10 +25,18 @@
 
 ### Screensavers / visual toys
 
-- Fireworks toy
+- Fireworks toy *(effort: M)*
+  - Click/tap anywhere → firework burst at cursor position; category: `"toy"`
+  - Canvas + `requestAnimationFrame` loop; same file/folder architecture as Starfield
+  - Particles radiate outward from click point at random angles and speeds; gravity pulls down each frame; opacity fades over ~60–80 frames
+  - Support multiple simultaneous bursts (array of active bursts; remove when all particles dead)
+  - Color: randomize per burst (classic multicolor) or per particle — pick whichever looks better
+- Bouncing shapes / retro screensaver toys *(effort: S)*
+  - Canvas; shapes (circles, squares, triangles) bounce around the viewport with velocity + wall collision; category: `"screensaver"`
+  - Classic DVD-logo vibe; optional delight: track/announce corner hits
+  - Configurable shape count, speed, and size via constants (no UI needed)
 - Maze maker / maze walker
 - Fish tank screensaver
-- Bouncing shapes / retro screensaver toys
 - Sarcastic/inspirational quote screensaver
 
 ### Sound / music

--- a/specs/homepage.todo.md
+++ b/specs/homepage.todo.md
@@ -4,10 +4,16 @@
 
 ## Later
 
-- Preserve room for "behind-the-scenes" / "director's cut" mode on individual experiences
+- Preserve room for "behind-the-scenes" / "director's cut" mode on individual experiences *(effort: XS)*
   - No need to implement now, but avoid structural choices that make this awkward
   - Future: overlay with implementation commentary, dev notes, or debug/explanation views
-- Category/tag filtering on the card grid (games, screensavers, sound toys, etc.)
+  - Implementation: `?bts=1` query param toggles BTS mode; each experience page reads the param and conditionally renders an overlay
+  - `Experience` data model gets an optional `btsNotes?: string` (or `btsComponent?: React.FC`) field when BTS content is first authored
+  - Depends on: design system changes to provide an overlay/panel component — see `specs/deps/design.todo.md`
+- Category/tag filtering on the card grid (games, screensavers, sound toys, etc.) *(effort: S)*
+  - `Experience` data model already has `category` field; `Pill` already renders it per card — data layer is ready
+  - Implementation: filter toggle buttons above `CardGrid`; `useState` for active category; filter `experiences` array on render
+  - Hold until there are enough experiences across multiple categories for filtering to feel useful (target: 2–3+ per category)
 
 ## Backlog
 

--- a/specs/spec.todo.md
+++ b/specs/spec.todo.md
@@ -6,8 +6,6 @@ Future work for this repo. Add projects and features here as they are planned.
 
 ## Sooner
 
-- [#2](https://github.com/NoahWright87/toybox/issues/2) Toy Box MVP — see `homepage.todo.md` and `experiences.todo.md` for full breakdown
-
 ## Later
 
 ## Backlog


### PR DESCRIPTION
## Summary

- **Promoted** completed Toy Box MVP (`[#2]`) out of `spec.todo.md` — it's shipped, already reflected in `spec.md`
- **Refined** `homepage.todo.md` — 2 items:
  - BTS / director's cut: `?bts=1` query param pattern, design dep noted, *(effort: XS)*
  - Category filtering: data layer already ready, guard note added (hold until 2–3+ experiences per category), *(effort: S)*
- **Created** `specs/deps/design.todo.md` — new file for tracking upstream `@noahwright/design` work; first item is BTS overlay/panel support
- **Refined** `experiences.todo.md` — 4 items with implementation detail + estimates:
  - Fireworks toy *(effort: M)* — canvas particles, gravity + fade, multi-burst support
  - Bouncing Shapes *(effort: S)* — DVD-logo vibe, wall collision, corner hit detection
  - Typing Racer *(effort: M)* — live WPM/accuracy, real-time keystroke coloring
  - Number Muncher clone *(effort: M?)* — arrow-key grid, rule-matching, stealth learning

## Outstanding questions / waiting

None — all items have enough detail to implement.

closes #2