### PR TITLE
Add Fireworks, Bouncing Shapes, Typing Racer, Number Muncher + category filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file tracks changes to this repository by version.
 
 # Versions
 
+## WIP
+
+- Add Fireworks experience (`/fireworks`) — canvas particle toy, click/tap to burst
+- Add Bouncing Shapes experience (`/bouncing-shapes`) — retro canvas screensaver with corner hit counter
+- Add Typing Racer experience (`/typing-racer`) — phrase typing game with live WPM and accuracy
+- Add Number Muncher experience (`/number-muncher`) — grid math game, arrow keys + eat matching numbers
+- Add category filter bar to homepage — toggle buttons filter card grid by experience category
+
 ## v0.2.0
 
 - Add Toy Box MVP: homepage with design system card grid, Starfield screensaver experience, React Router navigation

--- a/specs/bouncing-shapes.md
+++ b/specs/bouncing-shapes.md
@@ -1,0 +1,24 @@
+# Bouncing Shapes — Current State
+
+## Purpose
+
+A retro screensaver: colorful shapes (circles, squares, triangles) bounce around the viewport with classic wall-collision physics. Tracks corner hits.
+
+## Location
+
+- Route: `/bouncing-shapes`
+- Source: `src/experiences/BouncingShapes/BouncingShapes.tsx`
+- Page wrapper: `src/pages/BouncingShapesPage.tsx`
+
+## Behavior
+
+- Renders 15 shapes on a full-screen `<canvas>` using a `requestAnimationFrame` loop.
+- Each shape has a random kind (circle / square / equilateral triangle), size (30–70px), color (7-color palette), and velocity.
+- Shapes bounce off all four walls with simple reflection (`vx` or `vy` sign flip).
+- **Corner hit** — detected when a shape bounces off both a horizontal and vertical wall in the same frame. A running counter is displayed in the bottom-left.
+- Background is `#111`; no trail effect (hard clear each frame).
+
+## Related
+
+- [`spec.md`](spec.md)
+- [`experiences.todo.md`](experiences.todo.md)

--- a/specs/experiences.todo.md
+++ b/specs/experiences.todo.md
@@ -9,14 +9,6 @@
 - Spelling practice game
 - Custom word-list spelling toy
 - Sight word game
-- Typing racer *(effort: M)*
-  - Display a phrase; player types it as fast as possible; show live WPM + accuracy on completion; category: `"educational"`
-  - Word/phrase list baked in as a static array; no backend needed
-  - Highlight current target character, color correct/incorrect keystrokes in real time
-- Number Muncher clone *(effort: M?)*
-  - Grid of numbers; player navigates with arrow keys and "eats" numbers matching the current rule (e.g. multiples of 3, primes); category: `"educational"`
-  - Stealth learning: math fluency through grid navigation speed, not drill formatting
-  - Rules cycle through a predefined set (multiples, factors, primes); difficulty increases over time?
 - Prime Suspects
 - Factor / multiple / prime math games
 - Spell Squares
@@ -25,16 +17,6 @@
 
 ### Screensavers / visual toys
 
-- Fireworks toy *(effort: M)*
-  - Click/tap anywhere → firework burst at cursor position; category: `"toy"`
-  - Canvas + `requestAnimationFrame` loop; same file/folder architecture as Starfield
-  - Particles radiate outward from click point at random angles and speeds; gravity pulls down each frame; opacity fades over ~60–80 frames
-  - Support multiple simultaneous bursts (array of active bursts; remove when all particles dead)
-  - Color: randomize per burst (classic multicolor) or per particle — pick whichever looks better
-- Bouncing shapes / retro screensaver toys *(effort: S)*
-  - Canvas; shapes (circles, squares, triangles) bounce around the viewport with velocity + wall collision; category: `"screensaver"`
-  - Classic DVD-logo vibe; optional delight: track/announce corner hits
-  - Configurable shape count, speed, and size via constants (no UI needed)
 - Maze maker / maze walker
 - Fish tank screensaver
 - Sarcastic/inspirational quote screensaver

--- a/specs/fireworks.md
+++ b/specs/fireworks.md
@@ -1,0 +1,26 @@
+# Fireworks — Current State
+
+## Purpose
+
+A click-driven fireworks toy. Click anywhere to launch a burst of colorful particles.
+
+## Location
+
+- Route: `/fireworks`
+- Source: `src/experiences/Fireworks/Fireworks.tsx`
+- Page wrapper: `src/pages/FireworksPage.tsx`
+
+## Behavior
+
+- Renders a full-screen `<canvas>` with a black background.
+- **Click / tap** — spawns a firework burst at the cursor position.
+- Each burst fires 60 particles outward at random angles and speeds.
+- Particles have gravity (`vy += 0.08` per frame), air friction (`vx/vy *= 0.99`), and fade out as `life` decreases toward 0.
+- Multiple simultaneous bursts are supported; dead particles are filtered out each frame.
+- Color is randomized per burst (HSL with random hue ± 20°).
+- Trail effect from `rgba(0,0,0,0.15)` fill each frame.
+
+## Related
+
+- [`spec.md`](spec.md)
+- [`experiences.todo.md`](experiences.todo.md)

--- a/specs/homepage.todo.md
+++ b/specs/homepage.todo.md
@@ -10,11 +10,6 @@
   - Implementation: `?bts=1` query param toggles BTS mode; each experience page reads the param and conditionally renders an overlay
   - `Experience` data model gets an optional `btsNotes?: string` (or `btsComponent?: React.FC`) field when BTS content is first authored
   - Depends on: design system changes to provide an overlay/panel component — see `specs/deps/design.todo.md`
-- Category/tag filtering on the card grid (games, screensavers, sound toys, etc.) *(effort: S)*
-  - `Experience` data model already has `category` field; `Pill` already renders it per card — data layer is ready
-  - Implementation: filter toggle buttons above `CardGrid`; `useState` for active category; filter `experiences` array on render
-  - Hold until there are enough experiences across multiple categories for filtering to feel useful (target: 2–3+ per category)
-
 ## Backlog
 
 ## Reminders

--- a/specs/number-muncher.md
+++ b/specs/number-muncher.md
@@ -1,0 +1,28 @@
+# Number Muncher — Current State
+
+## Purpose
+
+A stealth-learning math game. Navigate a grid of numbers with arrow keys and eat those matching the current rule. Math fluency through speed and repetition, not drilling.
+
+## Location
+
+- Route: `/number-muncher`
+- Source: `src/experiences/NumberMuncher/NumberMuncher.tsx` + `NumberMuncher.css`
+- Page wrapper: `src/pages/NumberMuncherPage.tsx`
+
+## Behavior
+
+- 7×5 grid of random numbers (1–99). The current rule is shown in the HUD (e.g. "Eat: multiples of 3").
+- **Arrow keys** — move the blue player cursor around the grid.
+- **Space / Enter** — eat the number under the cursor.
+  - Correct eat: +10 score, cell disappears, brief green flash.
+  - Wrong eat: lose a life, brief red flash. 3 lives total; game over at 0.
+- **Level advance** — when all matching numbers in the grid are eaten, the rule advances to the next in the cycle and a fresh grid is generated (600ms delay).
+- **Rules cycle**: multiples of 3 → even numbers → prime numbers → multiples of 5 → multiples of 4 → odd numbers → repeat.
+- Grid guarantees at least 4 matching numbers per level.
+- Game over screen shows final score with a "Play Again" button.
+
+## Related
+
+- [`spec.md`](spec.md)
+- [`experiences.todo.md`](experiences.todo.md)

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -7,6 +7,10 @@ A place for fun little side projects.
 ## Related
 
 - [`starfield.md`](starfield.md)
+- [`fireworks.md`](fireworks.md)
+- [`bouncing-shapes.md`](bouncing-shapes.md)
+- [`typing-racer.md`](typing-racer.md)
+- [`number-muncher.md`](number-muncher.md)
 
 ## Stack
 
@@ -24,11 +28,23 @@ src/
   data/
     experiences.ts                # static registry of available experiences
   pages/
-    HomePage.tsx / .css           # hub — card grid launcher
+    HomePage.tsx / .css           # hub — card grid launcher with category filter
     StarfieldPage.tsx / .css      # full-viewport wrapper for Starfield
+    FireworksPage.tsx / .css      # full-viewport wrapper for Fireworks
+    BouncingShapesPage.tsx / .css # full-viewport wrapper for BouncingShapes
+    TypingRacerPage.tsx / .css    # full-viewport wrapper for TypingRacer
+    NumberMuncherPage.tsx / .css  # full-viewport wrapper for NumberMuncher
   experiences/
     Starfield/
       Starfield.tsx               # canvas screensaver component
+    Fireworks/
+      Fireworks.tsx               # canvas particle toy
+    BouncingShapes/
+      BouncingShapes.tsx          # canvas screensaver component
+    TypingRacer/
+      TypingRacer.tsx / .css      # typing speed game
+    NumberMuncher/
+      NumberMuncher.tsx / .css    # grid-based math game
 ```
 
 ## Homepage
@@ -36,9 +52,14 @@ src/
 - Renders a `Layout` (Header + Footer from `@noahwright/design`) wrapping a `CardGrid` of experience `Card`s.
 - Card data is driven by `src/data/experiences.ts` — add a new entry to add a new toy to the grid.
 - Cards are interactive and navigate to the experience route on click.
+- Category filter bar above the grid: pill-style toggle buttons (`All` + one per category); filters the card grid by `experience.category`. Categories are derived dynamically from the registry.
 
 ## Experiences
 
 Each experience lives in `src/experiences/{Name}/` and is routed at `/{name}` in `App.tsx`. Currently shipped:
 
 - **Starfield** (`/starfield`) — see [`starfield.md`](starfield.md)
+- **Fireworks** (`/fireworks`) — see [`fireworks.md`](fireworks.md)
+- **Bouncing Shapes** (`/bouncing-shapes`) — see [`bouncing-shapes.md`](bouncing-shapes.md)
+- **Typing Racer** (`/typing-racer`) — see [`typing-racer.md`](typing-racer.md)
+- **Number Muncher** (`/number-muncher`) — see [`number-muncher.md`](number-muncher.md)

--- a/specs/typing-racer.md
+++ b/specs/typing-racer.md
@@ -1,0 +1,25 @@
+# Typing Racer — Current State
+
+## Purpose
+
+A typing speed game. Type a displayed phrase as fast and accurately as possible; see your WPM and accuracy on completion.
+
+## Location
+
+- Route: `/typing-racer`
+- Source: `src/experiences/TypingRacer/TypingRacer.tsx` + `TypingRacer.css`
+- Page wrapper: `src/pages/TypingRacerPage.tsx`
+
+## Behavior
+
+- Displays a random phrase from a built-in list of 12 pangrams / short sentences (no backend).
+- Timer starts on the first keystroke; stops when the full phrase is typed correctly.
+- **Character highlighting** — correct chars turn green, incorrect chars turn red. The current target character has a white underline cursor.
+- **Live stats** — WPM and accuracy update continuously while typing. A faint elapsed timer is shown.
+- **Completion screen** — shows final WPM, accuracy, and time with a "Try again" button that loads a new phrase.
+- Input has `spellCheck`, `autoComplete`, and `autoCapitalize` disabled; caret is hidden (visual cursor is drawn via CSS on the phrase).
+
+## Related
+
+- [`spec.md`](spec.md)
+- [`experiences.todo.md`](experiences.todo.md)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,10 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
 import StarfieldPage from "./pages/StarfieldPage";
+import FireworksPage from "./pages/FireworksPage";
+import BouncingShapesPage from "./pages/BouncingShapesPage";
+import TypingRacerPage from "./pages/TypingRacerPage";
+import NumberMuncherPage from "./pages/NumberMuncherPage";
 
 export default function App() {
   return (
@@ -8,6 +12,10 @@ export default function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/starfield" element={<StarfieldPage />} />
+        <Route path="/fireworks" element={<FireworksPage />} />
+        <Route path="/bouncing-shapes" element={<BouncingShapesPage />} />
+        <Route path="/typing-racer" element={<TypingRacerPage />} />
+        <Route path="/number-muncher" element={<NumberMuncherPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -14,4 +14,32 @@ export const experiences: Experience[] = [
     category: "screensaver",
     path: "/starfield",
   },
+  {
+    id: "fireworks",
+    title: "Fireworks",
+    description: "Click anywhere to launch a firework. Click a lot.",
+    category: "toy",
+    path: "/fireworks",
+  },
+  {
+    id: "bouncing-shapes",
+    title: "Bouncing Shapes",
+    description: "Colorful shapes bounce around. How many corner hits can you get?",
+    category: "screensaver",
+    path: "/bouncing-shapes",
+  },
+  {
+    id: "typing-racer",
+    title: "Typing Racer",
+    description: "Type the phrase as fast as you can. WPM and accuracy tracked.",
+    category: "educational",
+    path: "/typing-racer",
+  },
+  {
+    id: "number-muncher",
+    title: "Number Muncher",
+    description: "Navigate the grid and eat numbers that match the rule.",
+    category: "educational",
+    path: "/number-muncher",
+  },
 ];

--- a/src/experiences/BouncingShapes/BouncingShapes.tsx
+++ b/src/experiences/BouncingShapes/BouncingShapes.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from "react";
+
+const SHAPE_COUNT = 15;
+const MIN_SIZE = 30;
+const MAX_SIZE = 70;
+const BASE_SPEED = 3;
+const COLORS = ["#ff4466", "#ff8844", "#ffdd22", "#44ff88", "#22ddff", "#aa44ff", "#ff44cc"];
+
+type ShapeKind = "circle" | "square" | "triangle";
+
+interface Shape {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  color: string;
+  kind: ShapeKind;
+}
+
+function randomShape(w: number, h: number): Shape {
+  const kinds: ShapeKind[] = ["circle", "square", "triangle"];
+  const size = MIN_SIZE + Math.random() * (MAX_SIZE - MIN_SIZE);
+  const speed = BASE_SPEED * (0.5 + Math.random());
+  const angle = Math.random() * Math.PI * 2;
+  return {
+    x: size + Math.random() * (w - size * 2),
+    y: size + Math.random() * (h - size * 2),
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed,
+    size,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    kind: kinds[Math.floor(Math.random() * kinds.length)],
+  };
+}
+
+function drawShape(ctx: CanvasRenderingContext2D, s: Shape) {
+  ctx.fillStyle = s.color;
+  ctx.beginPath();
+  if (s.kind === "circle") {
+    ctx.arc(s.x, s.y, s.size / 2, 0, Math.PI * 2);
+  } else if (s.kind === "square") {
+    ctx.rect(s.x - s.size / 2, s.y - s.size / 2, s.size, s.size);
+  } else {
+    // equilateral triangle centered at (x, y)
+    const r = s.size / 2;
+    ctx.moveTo(s.x, s.y - r);
+    ctx.lineTo(s.x + r * Math.cos(Math.PI / 6), s.y + r * Math.sin(Math.PI / 6));
+    ctx.lineTo(s.x - r * Math.cos(Math.PI / 6), s.y + r * Math.sin(Math.PI / 6));
+    ctx.closePath();
+  }
+  ctx.fill();
+}
+
+export default function BouncingShapes() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d")!;
+    let W = 0, H = 0;
+    let shapes: Shape[] = [];
+    let rafId = 0;
+    let cornerHits = 0;
+
+    function resize() {
+      W = canvas.width = window.innerWidth;
+      H = canvas.height = window.innerHeight;
+      shapes = Array.from({ length: SHAPE_COUNT }, () => randomShape(W, H));
+    }
+
+    function frame() {
+      ctx.fillStyle = "#111";
+      ctx.fillRect(0, 0, W, H);
+
+      for (const s of shapes) {
+        s.x += s.vx;
+        s.y += s.vy;
+
+        const r = s.size / 2;
+        let xHit = false, yHit = false;
+
+        if (s.x - r < 0) { s.x = r; s.vx = Math.abs(s.vx); xHit = true; }
+        if (s.x + r > W) { s.x = W - r; s.vx = -Math.abs(s.vx); xHit = true; }
+        if (s.y - r < 0) { s.y = r; s.vy = Math.abs(s.vy); yHit = true; }
+        if (s.y + r > H) { s.y = H - r; s.vy = -Math.abs(s.vy); yHit = true; }
+
+        if (xHit && yHit) cornerHits++;
+
+        drawShape(ctx, s);
+      }
+
+      ctx.fillStyle = "rgba(255,255,255,0.35)";
+      ctx.font = "13px monospace";
+      ctx.fillText(`corner hits: ${cornerHits}`, 16, H - 16);
+
+      rafId = requestAnimationFrame(frame);
+    }
+
+    resize();
+    rafId = requestAnimationFrame(frame);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ display: "block", width: "100%", height: "100%" }}
+    />
+  );
+}

--- a/src/experiences/Fireworks/Fireworks.tsx
+++ b/src/experiences/Fireworks/Fireworks.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from "react";
+
+const PARTICLES_PER_BURST = 60;
+const GRAVITY = 0.08;
+const FRICTION = 0.99;
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  decay: number;
+  hue: number;
+  lightness: number;
+  size: number;
+}
+
+function createBurst(cx: number, cy: number): Particle[] {
+  const hue = Math.floor(Math.random() * 360);
+  return Array.from({ length: PARTICLES_PER_BURST }, () => {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 2 + Math.random() * 6;
+    return {
+      x: cx,
+      y: cy,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      life: 0.7 + Math.random() * 0.3,
+      decay: 0.012 + Math.random() * 0.008,
+      hue: hue + Math.random() * 40 - 20,
+      lightness: 55 + Math.random() * 20,
+      size: 2 + Math.random() * 3,
+    };
+  });
+}
+
+export default function Fireworks() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d")!;
+    let W = 0, H = 0;
+    let particles: Particle[] = [];
+    let rafId = 0;
+
+    function resize() {
+      W = canvas.width = window.innerWidth;
+      H = canvas.height = window.innerHeight;
+    }
+
+    function frame() {
+      ctx.fillStyle = "rgba(0,0,0,0.15)";
+      ctx.fillRect(0, 0, W, H);
+
+      const alive: Particle[] = [];
+      for (const p of particles) {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += GRAVITY;
+        p.vx *= FRICTION;
+        p.vy *= FRICTION;
+        p.life -= p.decay;
+
+        if (p.life > 0) {
+          ctx.globalAlpha = p.life;
+          ctx.fillStyle = `hsl(${p.hue},100%,${p.lightness}%)`;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+          ctx.fill();
+          alive.push(p);
+        }
+      }
+      ctx.globalAlpha = 1;
+      particles = alive;
+
+      rafId = requestAnimationFrame(frame);
+    }
+
+    function spawnBurst(x: number, y: number) {
+      particles.push(...createBurst(x, y));
+    }
+
+    function onClick(e: MouseEvent) {
+      spawnBurst(e.clientX, e.clientY);
+    }
+
+    function onTouch(e: TouchEvent) {
+      for (let i = 0; i < e.touches.length; i++) {
+        spawnBurst(e.touches[i].clientX, e.touches[i].clientY);
+      }
+    }
+
+    resize();
+    rafId = requestAnimationFrame(frame);
+    canvas.addEventListener("click", onClick);
+    canvas.addEventListener("touchstart", onTouch, { passive: true });
+    window.addEventListener("resize", resize);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      canvas.removeEventListener("click", onClick);
+      canvas.removeEventListener("touchstart", onTouch);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        display: "block",
+        width: "100%",
+        height: "100%",
+        cursor: "crosshair",
+      }}
+      title="Click to launch fireworks"
+    />
+  );
+}

--- a/src/experiences/NumberMuncher/NumberMuncher.css
+++ b/src/experiences/NumberMuncher/NumberMuncher.css
@@ -1,0 +1,125 @@
+.number-muncher {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: var(--spacing-lg);
+  gap: var(--spacing-md);
+  position: relative;
+}
+
+.number-muncher__hud {
+  display: flex;
+  gap: var(--spacing-xl);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+  align-items: center;
+}
+
+.number-muncher__hud strong {
+  color: #fff;
+}
+
+.number-muncher__grid {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  transition: background 0.2s;
+}
+
+.number-muncher--correct .number-muncher__grid {
+  background: rgba(68, 238, 136, 0.08);
+}
+
+.number-muncher--wrong .number-muncher__grid {
+  background: rgba(255, 68, 102, 0.1);
+}
+
+.number-muncher__cell {
+  width: 58px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.03);
+  font-variant-numeric: tabular-nums;
+  transition: background 0.1s, opacity 0.2s;
+}
+
+.number-muncher__cell--match {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.number-muncher__cell--player {
+  background: #3355ee;
+  border-color: #6688ff;
+  color: #fff;
+  box-shadow: 0 0 0 2px rgba(100, 136, 255, 0.4);
+}
+
+.number-muncher__cell--player.number-muncher__cell--match {
+  background: #4466ff;
+}
+
+.number-muncher__cell--eaten {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.number-muncher__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 6px;
+}
+
+.number-muncher__gameover {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  text-align: center;
+}
+
+.number-muncher__gameover-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #ff4466;
+}
+
+.number-muncher__gameover-score {
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.number-muncher__restart {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: #3355ee;
+  border: none;
+  color: #fff;
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.number-muncher__restart:hover {
+  background: #4466ff;
+}
+
+.number-muncher__hint {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.8rem;
+}

--- a/src/experiences/NumberMuncher/NumberMuncher.tsx
+++ b/src/experiences/NumberMuncher/NumberMuncher.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useCallback } from "react";
+import "./NumberMuncher.css";
+
+const COLS = 7;
+const ROWS = 5;
+
+function isPrime(n: number): boolean {
+  if (n < 2) return false;
+  for (let i = 2; i <= Math.sqrt(n); i++) if (n % i === 0) return false;
+  return true;
+}
+
+interface Rule {
+  label: string;
+  test: (n: number) => boolean;
+}
+
+const RULES: Rule[] = [
+  { label: "multiples of 3", test: (n) => n % 3 === 0 },
+  { label: "even numbers", test: (n) => n % 2 === 0 },
+  { label: "prime numbers", test: isPrime },
+  { label: "multiples of 5", test: (n) => n % 5 === 0 },
+  { label: "multiples of 4", test: (n) => n % 4 === 0 },
+  { label: "odd numbers", test: (n) => n % 2 !== 0 },
+];
+
+function makeGrid(rule: Rule): number[][] {
+  const grid: number[][] = Array.from({ length: ROWS }, () =>
+    Array.from({ length: COLS }, () => 1 + Math.floor(Math.random() * 99))
+  );
+  // Guarantee at least 4 matching values by placing them at random positions
+  const positions = Array.from({ length: ROWS * COLS }, (_, i) => i);
+  for (let i = positions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [positions[i], positions[j]] = [positions[j], positions[i]];
+  }
+  let placed = 0;
+  for (const idx of positions) {
+    if (placed >= 4) break;
+    const r = Math.floor(idx / COLS);
+    const c = idx % COLS;
+    if (!rule.test(grid[r][c])) {
+      let v = 1 + Math.floor(Math.random() * 99);
+      while (!rule.test(v)) v = 1 + Math.floor(Math.random() * 99);
+      grid[r][c] = v;
+    }
+    placed++;
+  }
+  return grid;
+}
+
+function makeEaten(): boolean[][] {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+}
+
+export default function NumberMuncher() {
+  const [ruleIdx, setRuleIdx] = useState(0);
+  const rule = RULES[ruleIdx % RULES.length];
+  const [grid, setGrid] = useState(() => makeGrid(RULES[0]));
+  const [eaten, setEaten] = useState(makeEaten);
+  const [pos, setPos] = useState({ row: 0, col: 0 });
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [flash, setFlash] = useState<"correct" | "wrong" | null>(null);
+  const [gameOver, setGameOver] = useState(false);
+
+  // Detect level completion and advance
+  useEffect(() => {
+    if (gameOver) return;
+    const flatGrid = grid.flat();
+    const flatEaten = eaten.flat();
+    const remaining = flatGrid.filter((v, i) => rule.test(v) && !flatEaten[i]).length;
+    if (remaining === 0) {
+      const t = setTimeout(() => {
+        const nextIdx = (ruleIdx + 1) % RULES.length;
+        const nextRule = RULES[nextIdx];
+        setRuleIdx(nextIdx);
+        setGrid(makeGrid(nextRule));
+        setEaten(makeEaten());
+        setPos({ row: 0, col: 0 });
+      }, 600);
+      return () => clearTimeout(t);
+    }
+  }, [eaten, grid, rule, gameOver, ruleIdx]);
+
+  const eat = useCallback(() => {
+    if (gameOver || eaten[pos.row][pos.col]) return;
+    const val = grid[pos.row][pos.col];
+    if (rule.test(val)) {
+      setEaten((prev) => {
+        const next = prev.map((r) => [...r]);
+        next[pos.row][pos.col] = true;
+        return next;
+      });
+      setScore((s) => s + 10);
+      setFlash("correct");
+      setTimeout(() => setFlash(null), 300);
+    } else {
+      setLives((l) => {
+        const next = l - 1;
+        if (next <= 0) setGameOver(true);
+        return next;
+      });
+      setFlash("wrong");
+      setTimeout(() => setFlash(null), 400);
+    }
+  }, [gameOver, eaten, pos, grid, rule]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (gameOver) return;
+      switch (e.key) {
+        case "ArrowUp":
+          e.preventDefault();
+          setPos((p) => ({ ...p, row: Math.max(0, p.row - 1) }));
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setPos((p) => ({ ...p, row: Math.min(ROWS - 1, p.row + 1) }));
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          setPos((p) => ({ ...p, col: Math.max(0, p.col - 1) }));
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          setPos((p) => ({ ...p, col: Math.min(COLS - 1, p.col + 1) }));
+          break;
+        case " ":
+        case "Enter":
+          e.preventDefault();
+          eat();
+          break;
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [eat, gameOver]);
+
+  function restart() {
+    const startRule = RULES[0];
+    setRuleIdx(0);
+    setGrid(makeGrid(startRule));
+    setEaten(makeEaten());
+    setPos({ row: 0, col: 0 });
+    setScore(0);
+    setLives(3);
+    setFlash(null);
+    setGameOver(false);
+  }
+
+  return (
+    <div
+      className={[
+        "number-muncher",
+        flash ? `number-muncher--${flash}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="number-muncher__hud">
+        <span>
+          Eat: <strong>{rule.label}</strong>
+        </span>
+        <span>Score: {score}</span>
+        <span>{"❤️".repeat(Math.max(0, lives))}</span>
+      </div>
+
+      <div
+        className="number-muncher__grid"
+        style={{ gridTemplateColumns: `repeat(${COLS}, 1fr)` }}
+      >
+        {grid.map((row, r) =>
+          row.map((val, c) => (
+            <div
+              key={`${r}-${c}`}
+              className={[
+                "number-muncher__cell",
+                pos.row === r && pos.col === c
+                  ? "number-muncher__cell--player"
+                  : "",
+                eaten[r][c] ? "number-muncher__cell--eaten" : "",
+                rule.test(val) && !eaten[r][c]
+                  ? "number-muncher__cell--match"
+                  : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {!eaten[r][c] && val}
+            </div>
+          ))
+        )}
+      </div>
+
+      {gameOver && (
+        <div className="number-muncher__overlay">
+          <div className="number-muncher__gameover">
+            <div className="number-muncher__gameover-title">Game Over</div>
+            <div className="number-muncher__gameover-score">
+              Final Score: {score}
+            </div>
+            <button className="number-muncher__restart" onClick={restart}>
+              Play Again
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="number-muncher__hint">
+        Arrow keys to move · Space or Enter to eat
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/TypingRacer/TypingRacer.css
+++ b/src/experiences/TypingRacer/TypingRacer.css
@@ -1,0 +1,111 @@
+.typing-racer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: var(--spacing-xl);
+  gap: var(--spacing-lg);
+}
+
+.typing-racer__stats {
+  display: flex;
+  gap: var(--spacing-lg);
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  min-height: 1.5rem;
+}
+
+.typing-racer__timer {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.typing-racer__phrase {
+  max-width: 640px;
+  font-size: 1.6rem;
+  line-height: 1.9;
+  text-align: center;
+  user-select: none;
+  letter-spacing: 0.01em;
+}
+
+.typing-racer__char {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.typing-racer__char--correct {
+  color: #44ee88;
+}
+
+.typing-racer__char--wrong {
+  color: #ff4466;
+  background: rgba(255, 68, 102, 0.18);
+  border-radius: 2px;
+}
+
+.typing-racer__char--cursor {
+  color: rgba(255, 255, 255, 0.9);
+  border-bottom: 2px solid #fff;
+}
+
+.typing-racer__input {
+  width: 100%;
+  max-width: 640px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  outline: none;
+  caret-color: transparent;
+}
+
+.typing-racer__input:focus {
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.typing-racer__result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-lg);
+}
+
+.typing-racer__result-stats {
+  display: flex;
+  gap: var(--spacing-xl);
+  text-align: center;
+}
+
+.typing-racer__result-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+}
+
+.typing-racer__result-label {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+}
+
+.typing-racer__reset {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.typing-racer__reset:hover {
+  background: rgba(255, 255, 255, 0.18);
+}

--- a/src/experiences/TypingRacer/TypingRacer.tsx
+++ b/src/experiences/TypingRacer/TypingRacer.tsx
@@ -1,0 +1,138 @@
+import { useState, useEffect, useRef } from "react";
+import "./TypingRacer.css";
+
+const PHRASES = [
+  "The quick brown fox jumps over the lazy dog.",
+  "Pack my box with five dozen liquor jugs.",
+  "How vexingly quick daft zebras jump!",
+  "The five boxing wizards jump quickly.",
+  "Sphinx of black quartz, judge my vow.",
+  "Two driven jocks help fax my big quiz.",
+  "Five quacking zephyrs jolt my wax bed.",
+  "Jackdaws love my big sphinx of quartz.",
+  "Blowzy red vixens fight for a quick jump.",
+  "The jay, pig, fox, zebra, and my wolves quack!",
+  "Bright vixens jump dozy fowl quack.",
+  "Woven silk pyjamas exchanged for blue quartz.",
+];
+
+function pickPhrase(): string {
+  return PHRASES[Math.floor(Math.random() * PHRASES.length)];
+}
+
+export default function TypingRacer() {
+  const [phrase, setPhrase] = useState(pickPhrase);
+  const [typed, setTyped] = useState("");
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [finishTime, setFinishTime] = useState<number | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const elapsed =
+    finishTime && startTime
+      ? (finishTime - startTime) / 1000
+      : startTime
+      ? (Date.now() - startTime) / 1000
+      : 0;
+
+  const wpm =
+    startTime && typed.length > 0
+      ? Math.round((typed.length / 5) / Math.max(elapsed / 60, 0.001))
+      : 0;
+
+  const correctChars = typed.split("").filter((c, i) => c === phrase[i]).length;
+  const accuracy =
+    typed.length > 0 ? Math.round((correctChars / typed.length) * 100) : 100;
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    if (value.length > phrase.length) return;
+
+    if (!startTime && value.length > 0) {
+      setStartTime(Date.now());
+    }
+
+    setTyped(value);
+
+    if (value === phrase) {
+      setFinishTime(Date.now());
+    }
+  }
+
+  function reset() {
+    setPhrase(pickPhrase());
+    setTyped("");
+    setStartTime(null);
+    setFinishTime(null);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }
+
+  return (
+    <div className="typing-racer">
+      <div className="typing-racer__stats">
+        <span>{wpm} WPM</span>
+        <span>{accuracy}% accuracy</span>
+        {startTime && !finishTime && (
+          <span className="typing-racer__timer">{elapsed.toFixed(1)}s</span>
+        )}
+      </div>
+
+      <div className="typing-racer__phrase" aria-hidden="true">
+        {phrase.split("").map((char, i) => {
+          let cls = "typing-racer__char";
+          if (i < typed.length) {
+            cls +=
+              typed[i] === char
+                ? " typing-racer__char--correct"
+                : " typing-racer__char--wrong";
+          } else if (i === typed.length) {
+            cls += " typing-racer__char--cursor";
+          }
+          return (
+            <span key={i} className={cls}>
+              {char}
+            </span>
+          );
+        })}
+      </div>
+
+      {finishTime ? (
+        <div className="typing-racer__result">
+          <div className="typing-racer__result-stats">
+            <div>
+              <div className="typing-racer__result-value">{wpm}</div>
+              <div className="typing-racer__result-label">WPM</div>
+            </div>
+            <div>
+              <div className="typing-racer__result-value">{accuracy}%</div>
+              <div className="typing-racer__result-label">accuracy</div>
+            </div>
+            <div>
+              <div className="typing-racer__result-value">
+                {((finishTime - startTime!) / 1000).toFixed(2)}s
+              </div>
+              <div className="typing-racer__result-label">time</div>
+            </div>
+          </div>
+          <button className="typing-racer__reset" onClick={reset}>
+            Try again
+          </button>
+        </div>
+      ) : (
+        <input
+          ref={inputRef}
+          className="typing-racer__input"
+          value={typed}
+          onChange={handleChange}
+          spellCheck={false}
+          autoComplete="off"
+          autoCapitalize="none"
+          placeholder="Start typing…"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/BouncingShapesPage.css
+++ b/src/pages/BouncingShapesPage.css
@@ -1,0 +1,12 @@
+.bouncing-shapes-page {
+  position: fixed;
+  inset: 0;
+  background: #111;
+}
+
+.bouncing-shapes-page__back {
+  position: fixed;
+  top: var(--spacing-md);
+  left: var(--spacing-md);
+  z-index: 10;
+}

--- a/src/pages/BouncingShapesPage.tsx
+++ b/src/pages/BouncingShapesPage.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@noahwright/design";
+import BouncingShapes from "../experiences/BouncingShapes/BouncingShapes";
+import HelpOverlay from "../components/HelpOverlay/HelpOverlay";
+import "./BouncingShapesPage.css";
+
+export default function BouncingShapesPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="bouncing-shapes-page">
+      <BouncingShapes />
+
+      <div className="bouncing-shapes-page__back">
+        <Button variant="ghost" color="#ffffff" onClick={() => navigate("/")}>
+          ← Toy Box
+        </Button>
+      </div>
+
+      <HelpOverlay title="Bouncing Shapes">
+        <ul>
+          <li>Shapes bounce around the screen</li>
+          <li>Corner hits are tracked in the bottom-left</li>
+          <li><strong>Press ?</strong> to toggle these instructions</li>
+        </ul>
+      </HelpOverlay>
+    </div>
+  );
+}

--- a/src/pages/FireworksPage.css
+++ b/src/pages/FireworksPage.css
@@ -1,0 +1,12 @@
+.fireworks-page {
+  position: fixed;
+  inset: 0;
+  background: #000;
+}
+
+.fireworks-page__back {
+  position: fixed;
+  top: var(--spacing-md);
+  left: var(--spacing-md);
+  z-index: 10;
+}

--- a/src/pages/FireworksPage.tsx
+++ b/src/pages/FireworksPage.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@noahwright/design";
+import Fireworks from "../experiences/Fireworks/Fireworks";
+import HelpOverlay from "../components/HelpOverlay/HelpOverlay";
+import "./FireworksPage.css";
+
+export default function FireworksPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="fireworks-page">
+      <Fireworks />
+
+      <div className="fireworks-page__back">
+        <Button variant="ghost" color="#ffffff" onClick={() => navigate("/")}>
+          ← Toy Box
+        </Button>
+      </div>
+
+      <HelpOverlay title="Fireworks">
+        <ul>
+          <li><strong>Click</strong> anywhere to launch a firework</li>
+          <li><strong>Tap</strong> on mobile to launch</li>
+          <li><strong>Press ?</strong> to toggle these instructions</li>
+        </ul>
+      </HelpOverlay>
+    </div>
+  );
+}

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -3,3 +3,40 @@
   font-weight: 700;
   letter-spacing: -0.01em;
 }
+
+.homepage__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  justify-content: center;
+  padding: var(--spacing-md) 0;
+}
+
+.homepage__filter-btn {
+  padding: 4px 14px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border-radius: 999px;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.15));
+  background: transparent;
+  color: var(--color-text-muted, #666);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  text-transform: capitalize;
+}
+
+.homepage__filter-btn:hover {
+  background: var(--color-surface-raised, rgba(0, 0, 0, 0.05));
+  color: var(--color-text, #111);
+}
+
+.homepage__filter-btn--active {
+  background: var(--color-primary, #3355ee);
+  border-color: var(--color-primary, #3355ee);
+  color: #fff;
+}
+
+.homepage__filter-btn--active:hover {
+  background: var(--color-primary, #3355ee);
+  color: #fff;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Layout, Header, Footer,
@@ -32,6 +32,16 @@ function RotatingAiCredit() {
 export default function HomePage() {
   const navigate = useNavigate();
   const year = new Date().getFullYear();
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+
+  const categories = useMemo(
+    () => Array.from(new Set(experiences.map((e) => e.category))).sort(),
+    []
+  );
+
+  const filtered = activeCategory
+    ? experiences.filter((e) => e.category === activeCategory)
+    : experiences;
 
   return (
     <Layout
@@ -59,9 +69,27 @@ export default function HomePage() {
           </Text>
         </Container>
 
+        <div className="homepage__filters">
+          <button
+            className={`homepage__filter-btn${activeCategory === null ? " homepage__filter-btn--active" : ""}`}
+            onClick={() => setActiveCategory(null)}
+          >
+            All
+          </button>
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              className={`homepage__filter-btn${activeCategory === cat ? " homepage__filter-btn--active" : ""}`}
+              onClick={() => setActiveCategory(cat === activeCategory ? null : cat)}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+
         <Container padding="none" margin="none">
           <CardGrid minCardWidth="260px" gap="lg">
-            {experiences.map((exp) => (
+            {filtered.map((exp) => (
               <Card
                 key={exp.id}
                 title={exp.title}

--- a/src/pages/NumberMuncherPage.css
+++ b/src/pages/NumberMuncherPage.css
@@ -1,0 +1,13 @@
+.number-muncher-page {
+  position: fixed;
+  inset: 0;
+  background: #0a0a1e;
+  overflow-y: auto;
+}
+
+.number-muncher-page__back {
+  position: fixed;
+  top: var(--spacing-md);
+  left: var(--spacing-md);
+  z-index: 10;
+}

--- a/src/pages/NumberMuncherPage.tsx
+++ b/src/pages/NumberMuncherPage.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@noahwright/design";
+import NumberMuncher from "../experiences/NumberMuncher/NumberMuncher";
+import HelpOverlay from "../components/HelpOverlay/HelpOverlay";
+import "./NumberMuncherPage.css";
+
+export default function NumberMuncherPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="number-muncher-page">
+      <NumberMuncher />
+
+      <div className="number-muncher-page__back">
+        <Button variant="ghost" color="#ffffff" onClick={() => navigate("/")}>
+          ← Toy Box
+        </Button>
+      </div>
+
+      <HelpOverlay title="Number Muncher">
+        <ul>
+          <li>
+            <strong>Arrow keys</strong> to move
+          </li>
+          <li>
+            <strong>Space / Enter</strong> to eat a number
+          </li>
+          <li>Eat numbers that match the rule shown at the top</li>
+          <li>Wrong eat = lose a life · Eat them all = next rule</li>
+          <li>
+            <strong>Press ?</strong> to toggle these instructions
+          </li>
+        </ul>
+      </HelpOverlay>
+    </div>
+  );
+}

--- a/src/pages/TypingRacerPage.css
+++ b/src/pages/TypingRacerPage.css
@@ -1,0 +1,13 @@
+.typing-racer-page {
+  position: fixed;
+  inset: 0;
+  background: #111;
+  overflow-y: auto;
+}
+
+.typing-racer-page__back {
+  position: fixed;
+  top: var(--spacing-md);
+  left: var(--spacing-md);
+  z-index: 10;
+}

--- a/src/pages/TypingRacerPage.tsx
+++ b/src/pages/TypingRacerPage.tsx
@@ -1,0 +1,30 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@noahwright/design";
+import TypingRacer from "../experiences/TypingRacer/TypingRacer";
+import HelpOverlay from "../components/HelpOverlay/HelpOverlay";
+import "./TypingRacerPage.css";
+
+export default function TypingRacerPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="typing-racer-page">
+      <TypingRacer />
+
+      <div className="typing-racer-page__back">
+        <Button variant="ghost" color="#ffffff" onClick={() => navigate("/")}>
+          ← Toy Box
+        </Button>
+      </div>
+
+      <HelpOverlay title="Typing Racer">
+        <ul>
+          <li>Type the phrase as fast as you can</li>
+          <li>Green = correct · Red = wrong</li>
+          <li>WPM and accuracy shown on completion</li>
+          <li><strong>Press ?</strong> to toggle these instructions</li>
+        </ul>
+      </HelpOverlay>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Fireworks** (`/fireworks`) — click/tap canvas toy; multi-burst particles with gravity, friction, and HSL color randomization per burst
- **Bouncing Shapes** (`/bouncing-shapes`) — retro screensaver; circles, squares, and triangles bounce off walls with corner-hit tracking
- **Typing Racer** (`/typing-racer`) — phrase typing game; live WPM/accuracy, per-character color feedback, completion screen
- **Number Muncher** (`/number-muncher`) — arrow-key grid game; eat numbers matching the rule (multiples, primes, evens…), 3 lives, level cycling
- **Category filter bar** on homepage — pill-style toggles filter the card grid; categories derived dynamically from the experience registry

## Test plan

- [ ] Visit `/fireworks` — click and tap to launch bursts; multiple simultaneous bursts work
- [ ] Visit `/bouncing-shapes` — shapes bounce, corner hit counter increments in bottom-left
- [ ] Visit `/typing-racer` — type a phrase; green/red char feedback; WPM/accuracy shown on completion; "Try again" resets
- [ ] Visit `/number-muncher` — arrow keys navigate; Space/Enter eats; correct eat = +10 score; wrong eat = lose life; all correct eaten = new rule + new grid; game over at 0 lives
- [ ] Homepage — filter buttons show correct categories; filtering hides non-matching cards; "All" shows everything
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)