### PR TITLE
Apply retro Win95 aesthetic to all experiences; add project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,164 @@
+# Toy Box — Claude Session Guide
+
+This file gives Claude the context needed to work effectively in this repo without a lengthy orientation every session.
+
+## What this project is
+
+**Toy Box** is a collection of browser-based games, toys, and screensavers built by Noah Wright. The central conceit is a **fake 1990s desktop OS** called **NS Doors 97** (a Noahsoft parody of Windows 95/98). That OS is the main entry point at `/`. Individual experiences are also accessible at their own routes.
+
+The aesthetic is retro **Windows 9X era**: beveled chrome, `#c0c0c0` gray panels, pixel font ("Press Start 2P"), orange-and-purple brand colors, and CRT-era sensibility throughout. Every new experience should fit this look.
+
+## Tech stack
+
+| Layer | What |
+|---|---|
+| Framework | React 18 + TypeScript + Vite |
+| Routing | `react-router-dom` v6 |
+| Design system | `@noahwright/design` — provides `Layout`, `Header`, `Footer`, `Card`, `CardGrid`, `Container`, `Heading`, `Text`, `Pill`, `Link`, `Button` |
+| Font | "Press Start 2P" (Google Fonts, loaded in `index.html`) |
+| Testing | Playwright |
+| Build output | Static; deployed as built files |
+
+## Routing
+
+| Path | Component | Notes |
+|---|---|---|
+| `/` | `NsDoors97Page` | The OS desktop — main entry point |
+| `/doors97` | `NsDoors97Page` | Alias |
+| `/toybox` | `HomePage` | Retro card grid launcher (secondary) |
+| `/tic-tac-toe` | `TicTacToePage` | |
+| `/word-whirlwind` | `WordWhirlwindPage` | |
+| `/typing-racer` | `TypingRacerPage` | |
+| `/number-muncher` | `NumberMuncherPage` | |
+| `/starfield` | `StarfieldPage` | Canvas screensaver |
+| `/fireworks` | `FireworksPage` | Canvas particle toy |
+| `/bouncing-shapes` | `BouncingShapesPage` | Canvas screensaver |
+
+## Source layout
+
+```
+src/
+  App.tsx                   # BrowserRouter + route table
+  main.tsx                  # Entry; imports design system CSS
+  index.css                 # Base resets
+  data/
+    experiences.ts          # Registry: id, title, path, category, description
+  pages/
+    HomePage.tsx / .css     # Retro card grid launcher
+    NsDoors97Page.tsx       # Wraps NsDoors97 experience
+    TicTacToePage.tsx / .css
+    WordWhirlwindPage.tsx / .css
+    TypingRacerPage.tsx / .css
+    NumberMuncherPage.tsx / .css
+    StarfieldPage.tsx / .css
+    FireworksPage.tsx / .css
+    BouncingShapesPage.tsx / .css
+  experiences/
+    NsDoors97/              # The fake OS (flagship)
+    TicTacToe/              # 3×3–7×7 board, AI opponent, Drop In gravity variant
+    WordWhirlwind/          # Unscramble letters, freeplay / standard / strict
+    TypingRacer/            # Type phrases against the clock, WPM + accuracy
+    NumberMuncher/          # Grid math game, arrow keys + eat
+    Starfield/              # Canvas screensaver
+    Fireworks/              # Canvas particle toy
+    BouncingShapes/         # Canvas screensaver
+  components/
+    HelpOverlay/            # ? button that shows keyboard shortcuts
+  utils/
+    wordDictionary.ts       # Shared word/dictionary logic (used by WordWhirlwind)
+```
+
+## Adding a new experience
+
+1. Create `src/experiences/{Name}/{Name}.tsx` (and `.css` if needed).
+2. Create `src/pages/{Name}Page.tsx` (and `.css`) — wraps the component with the retro page background and `HelpOverlay`.
+3. Add a route in `src/App.tsx`.
+4. Add an entry to `src/data/experiences.ts`.
+5. Embed the experience as a window inside NS Doors 97 if appropriate.
+6. Create `specs/{name}.md` documenting current behavior.
+
+## Retro aesthetic — the rules
+
+All new experiences (and refactored old ones) use this palette and style system:
+
+### Colors
+
+| Token | Hex | Used for |
+|---|---|---|
+| Win95 gray | `#c0c0c0` | Primary panel background |
+| Win95 warm gray | `#d4d0c8` | Inset / recessed areas |
+| Win95 dark | `#808080` | Shadows, borders |
+| White | `#ffffff` | Highlights |
+| Orange primary | `#cc4400` / `#ff6b00` | X player, active/hover states, buttons |
+| Purple secondary | `#5b2d8e` / `#7b3dbe` | O player, accents |
+| Green win | `#228833` | Draws / success states |
+| Page background | `radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%)` | Page backdrop for standalone experiences |
+
+### Win95 border patterns (CSS)
+
+```css
+/* Raised element (button up, panel) */
+border: 2px solid;
+border-color: #ffffff #808080 #808080 #ffffff;
+
+/* Sunken / active element (pressed button, input, inset panel) */
+border-color: #808080 #ffffff #ffffff #808080;
+
+/* Orange raised button */
+border-color: #ffcc88 #664400 #664400 #ffcc88;
+
+/* Orange sunken / active */
+border-color: #664400 #ffcc88 #ffcc88 #664400;
+```
+
+### Typography
+
+- **Labels, headings, UI chrome:** `"Press Start 2P", monospace` — keep sizes small (6–12 px) since this font is very dense
+- **Body / content text (e.g. the phrase in Typing Racer):** `"Courier New", Courier, monospace`
+
+### Page wrapper pattern
+
+Every standalone experience page follows this pattern:
+
+```css
+.{name}-page {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow-y: auto;
+  padding: 48px 16px 16px; /* room for back button */
+}
+```
+
+### Screensavers
+
+Starfield, Fireworks, and Bouncing Shapes intentionally keep their dark canvas backgrounds — they simulate old-school screensavers and look correct against black.
+
+## Spec-driven development
+
+- Specs live in `specs/` and mirror the source tree.
+- `spec.md` = current, shippable behavior.
+- `spec.todo.md` = roadmap / future work.
+- `specs/AGENTS.md` = writing conventions for specs.
+- Add a `specs/{name}.md` for every new experience.
+- See `AGENTS.md` (root) for the full workflow.
+
+## NS Doors 97 — key details
+
+NS Doors 97 is the flagship experience. It simulates a 1990s desktop:
+- Draggable windows (`react-draggable`)
+- Desktop icons, taskbar with Start menu
+- Screensaver system (activates after idle timeout)
+- Built-in apps: file browser, About Noahsoft dialog, simulated internet browser, Tic-Tac-Toe window
+- All windows use Win95-style chrome: title bar (orange/brown gradient), close/min/max buttons, beveled borders
+
+## Known conventions
+
+- Commits reference the feature or PR (see git log for style)
+- "Press Start 2P" is already loaded globally via `index.html` — no additional import needed
+- `@noahwright/design` is a private npm package owned by Noah; don't re-implement its components
+- Category values in `experiences.ts`: `"game"`, `"screensaver"`, `"toy"`, `"educational"`
+- The `HelpOverlay` component renders a `?` button in the corner; pass `title` and children (a `<ul>` of tips)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# toybox
-A place for fun little side projects.
+# Toy Box
+
+A collection of browser-based games, toys, and screensavers wrapped in a fake 1990s desktop OS.
+
+## The experience
+
+The main entry point is **NS Doors 97**, a parody of Windows 95/98 built by Noahsoft™. You get a draggable-window desktop, a Start menu, a taskbar, a screensaver, and a growing library of retro-styled games and toys accessible as windows inside the OS.
+
+Everything has a Win9X aesthetic: `#c0c0c0` chrome, beveled borders, pixel fonts, and orange-and-purple brand colors.
+
+## Stack
+
+- **React 18 + TypeScript + Vite**
+- **react-router-dom** for client-side routing
+- **@noahwright/design** for the shared design system (Layout, Card, etc.)
+- **react-draggable** for OS windows
+- **Playwright** for end-to-end tests
+
+## Experiences
+
+| Name | Route | Category |
+|---|---|---|
+| NS Doors 97 | `/` | toy |
+| Tic-Tac-Toe | `/tic-tac-toe` | game |
+| Word Whirlwind | `/word-whirlwind` | game |
+| Typing Racer | `/typing-racer` | game |
+| Number Muncher | `/number-muncher` | educational |
+| Starfield | `/starfield` | screensaver |
+| Fireworks | `/fireworks` | toy |
+| Bouncing Shapes | `/bouncing-shapes` | screensaver |
+
+## Development
+
+```bash
+npm install
+npm run dev        # dev server
+npm run build      # production build
+npm run preview    # preview built output
+npx playwright test  # e2e tests
+```
+
+## Docs
+
+- [`CLAUDE.md`](CLAUDE.md) — session guide for AI-assisted development
+- [`AGENTS.md`](AGENTS.md) — spec-driven development conventions
+- [`specs/`](specs/) — current-state specs and roadmap
+- [`CHANGELOG.md`](CHANGELOG.md) — release history

--- a/specs/ns-doors-97.md
+++ b/specs/ns-doors-97.md
@@ -1,0 +1,96 @@
+# NS Doors 97 — Current State
+
+## Related
+
+- [`spec.md`](spec.md)
+- [`tic-tac-toe.md`](tic-tac-toe.md)
+
+## Overview
+
+NS Doors 97 is the flagship Toy Box experience: a simulated 1990s desktop OS (a parody of Windows 95/98) made by "Noahsoft". It is the default route (`/`) — the first thing users see. All other experiences are accessible as windows within it.
+
+## Routes
+
+- `/` — primary entry point
+- `/doors97` — alias
+
+## Desktop
+
+- Dark teal/green desktop wallpaper (`#008080`, the classic Win95 default).
+- Desktop icons arranged in a column on the left: static icons + one icon per registered experience.
+- Double-clicking (or single-clicking on touch) an icon opens a window.
+- Clicking the desktop (outside any window) deselects icons.
+
+### Static desktop icons
+
+| Icon | Title | Opens |
+|---|---|---|
+| 🖥️ | My Doors | Folder browser window |
+| 🗑️ | Recycle Bin | Placeholder / not implemented |
+| ℹ️ | About NS Doors 97 | About dialog |
+| 🌐 | Internet | Simulated browser window |
+| 💤 | Screensavers | Screensaver settings window |
+
+### Experience icons
+
+One icon per experience registered in `src/data/experiences.ts` (excluding NS Doors 97 itself). Opening launches an app-launcher window or, for Tic-Tac-Toe, an embedded game window.
+
+## Windows
+
+Windows use `react-draggable`. Each window has:
+- **Title bar** — orange/brown gradient, icon, title text, minimize/maximize/close buttons (close is functional; min/max are decorative)
+- **Beveled chrome** — Win95 raised outer border, sunken inner frame
+- **Content area** — white or gray depending on app
+
+Multiple windows can be open simultaneously. Clicking a window brings it to the front (z-index management). Windows can be dragged anywhere on the desktop.
+
+### Window types
+
+| Type | Content |
+|---|---|
+| `app-launcher` | "Open in new tab" button for external experiences |
+| `tictactoe` | Embedded `<TicTacToe />` component |
+| `screensaver-settings` | Screensaver picker and preview |
+| `about` | About Noahsoft dialog |
+| `my-doors` | Folder / file browser |
+| `internet` | Simulated internet browser |
+
+## Taskbar
+
+- Fixed to the bottom of the screen.
+- **Start button** (left): opens the Start menu.
+- **Window buttons** (middle): one pill per open window; clicking focuses the window.
+- **Clock** (right): live digital clock showing current time.
+
+## Start menu
+
+Opens when the Start button is clicked. Contains shortcuts to launch apps (About, My Doors, Internet, Screensavers, Toy Box launcher). Clicking outside closes it.
+
+## Screensaver system
+
+- Activates after an idle timeout (no mouse movement or click).
+- Screensaver overlay renders over the entire desktop.
+- Available screensavers: Starfield, Fireworks, Bouncing Shapes.
+- Moving the mouse or clicking dismisses the screensaver.
+- Settings window lets the user choose the active screensaver and preview it.
+
+## App: My Doors (folder browser)
+
+Simulates a Windows Explorer folder view. Shows a fake file tree of "drives" and folders. Clicking folders navigates in. Double-clicking files shows a placeholder message.
+
+## App: Internet (simulated browser)
+
+A fake browser window with an address bar and navigation buttons. Loads a set of hardcoded fake "websites". Not a real browser — purely decorative.
+
+## App: About NS Doors 97
+
+A Win95-style About dialog: Noahsoft logo area, version text, copyright, and an OK button.
+
+## Styling
+
+All OS chrome uses the Noahsoft Win95 palette:
+- Desktop background: `#008080`
+- Title bar: brown-orange gradient
+- Window chrome: `#c0c0c0` with beveled borders
+- Font: "Press Start 2P" for all OS UI text
+- Taskbar: dark gray with raised border

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -2,21 +2,45 @@
 
 ## Purpose
 
-A place for fun little side projects.
+A collection of browser-based games, toys, and screensavers wrapped in a fake 1990s desktop OS called **NS Doors 97**.
 
 ## Related
 
+- [`ns-doors-97.md`](ns-doors-97.md)
+- [`tic-tac-toe.md`](tic-tac-toe.md)
+- [`word-whirlwind.md`](word-whirlwind.md)
+- [`typing-racer.md`](typing-racer.md)
+- [`number-muncher.md`](number-muncher.md)
 - [`starfield.md`](starfield.md)
 - [`fireworks.md`](fireworks.md)
 - [`bouncing-shapes.md`](bouncing-shapes.md)
-- [`typing-racer.md`](typing-racer.md)
-- [`number-muncher.md`](number-muncher.md)
 
 ## Stack
 
 - **React 18 + Vite + TypeScript** — static-site friendly, hosted as built output
 - **`@noahwright/design`** (`npm i @noahwright/design`) — shared design system; provides `Layout`, `Card`, `CardGrid`, and CSS theme tokens
-- **`react-router-dom`** — client-side routing between hub (`/`) and individual experiences (`/{name}`)
+- **`react-router-dom`** — client-side routing between the OS (`/`) and individual experiences (`/{name}`)
+- **`react-draggable`** — powers draggable windows in NS Doors 97
+
+## Retro aesthetic
+
+The entire project uses a **Windows 9X era** visual identity ("Noahsoft").
+
+**Palette:**
+- Win95 gray `#c0c0c0` — primary panel background
+- Win95 warm gray `#d4d0c8` — inset / recessed areas
+- Win95 dark `#808080` — shadows and borders
+- Orange `#cc4400` / `#ff6b00` — primary brand color (X player, active states, buttons)
+- Purple `#5b2d8e` / `#7b3dbe` — secondary brand color (O player, accents)
+- Page background: `radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%)`
+
+**Typography:**
+- "Press Start 2P" (pixel monospace) for all UI chrome, labels, and headings
+- "Courier New" for body / content text (e.g. typing phrases, debug overlays)
+
+**Border style:**
+- Raised: `border-color: #ffffff #808080 #808080 #ffffff`
+- Sunken: `border-color: #808080 #ffffff #ffffff #808080`
 
 ## Structure
 
@@ -28,38 +52,62 @@ src/
   data/
     experiences.ts                # static registry of available experiences
   pages/
-    HomePage.tsx / .css           # hub — card grid launcher with category filter
+    HomePage.tsx / .css           # retro card grid launcher at /toybox
+    NsDoors97Page.tsx             # wraps NS Doors 97 (mounted at /)
+    TicTacToePage.tsx / .css      # standalone wrapper
+    WordWhirlwindPage.tsx / .css  # standalone wrapper
+    TypingRacerPage.tsx / .css    # standalone wrapper
+    NumberMuncherPage.tsx / .css  # standalone wrapper
     StarfieldPage.tsx / .css      # full-viewport wrapper for Starfield
     FireworksPage.tsx / .css      # full-viewport wrapper for Fireworks
     BouncingShapesPage.tsx / .css # full-viewport wrapper for BouncingShapes
-    TypingRacerPage.tsx / .css    # full-viewport wrapper for TypingRacer
-    NumberMuncherPage.tsx / .css  # full-viewport wrapper for NumberMuncher
   experiences/
-    Starfield/
-      Starfield.tsx               # canvas screensaver component
-    Fireworks/
-      Fireworks.tsx               # canvas particle toy
-    BouncingShapes/
-      BouncingShapes.tsx          # canvas screensaver component
-    TypingRacer/
-      TypingRacer.tsx / .css      # typing speed game
-    NumberMuncher/
-      NumberMuncher.tsx / .css    # grid-based math game
+    NsDoors97/                    # fake OS desktop
+    TicTacToe/                    # board game with AI
+    WordWhirlwind/                # unscramble word game
+    TypingRacer/                  # typing speed game
+    NumberMuncher/                # grid math game
+    Starfield/                    # canvas screensaver
+    Fireworks/                    # canvas particle toy
+    BouncingShapes/               # canvas screensaver
+  components/
+    HelpOverlay/                  # ? button overlay with keyboard hints
+  utils/
+    wordDictionary.ts             # shared word lookup used by WordWhirlwind
 ```
 
-## Homepage
+## Routing
+
+| Path | Experience | Notes |
+|---|---|---|
+| `/` | NS Doors 97 | Main entry — the fake OS desktop |
+| `/doors97` | NS Doors 97 | Alias |
+| `/toybox` | HomePage | Secondary retro card grid launcher |
+| `/tic-tac-toe` | Tic-Tac-Toe | |
+| `/word-whirlwind` | Word Whirlwind | |
+| `/typing-racer` | Typing Racer | |
+| `/number-muncher` | Number Muncher | |
+| `/starfield` | Starfield | |
+| `/fireworks` | Fireworks | |
+| `/bouncing-shapes` | Bouncing Shapes | |
+
+## Homepage (`/toybox`)
 
 - Renders a `Layout` (Header + Footer from `@noahwright/design`) wrapping a `CardGrid` of experience `Card`s.
 - Card data is driven by `src/data/experiences.ts` — add a new entry to add a new toy to the grid.
-- Cards are interactive and navigate to the experience route on click.
-- Category filter bar above the grid: pill-style toggle buttons (`All` + one per category); filters the card grid by `experience.category`. Categories are derived dynamically from the registry.
+- Cards navigate to the experience route on click.
+- Category filter bar above the grid: pill-style toggle buttons (`All` + one per category); filters the card grid by `experience.category`. Categories derive dynamically from the registry.
+- Footer shows a rotating AI credit cycling every 4 seconds.
 
 ## Experiences
 
-Each experience lives in `src/experiences/{Name}/` and is routed at `/{name}` in `App.tsx`. Currently shipped:
+Each experience lives in `src/experiences/{Name}/` and is routed at `/{name}` in `App.tsx`.
 
+- **NS Doors 97** (`/`) — see [`ns-doors-97.md`](ns-doors-97.md)
+- **Tic-Tac-Toe** (`/tic-tac-toe`) — see [`tic-tac-toe.md`](tic-tac-toe.md)
+- **Word Whirlwind** (`/word-whirlwind`) — see [`word-whirlwind.md`](word-whirlwind.md)
+- **Typing Racer** (`/typing-racer`) — see [`typing-racer.md`](typing-racer.md)
+- **Number Muncher** (`/number-muncher`) — see [`number-muncher.md`](number-muncher.md)
 - **Starfield** (`/starfield`) — see [`starfield.md`](starfield.md)
 - **Fireworks** (`/fireworks`) — see [`fireworks.md`](fireworks.md)
 - **Bouncing Shapes** (`/bouncing-shapes`) — see [`bouncing-shapes.md`](bouncing-shapes.md)
-- **Typing Racer** (`/typing-racer`) — see [`typing-racer.md`](typing-racer.md)
-- **Number Muncher** (`/number-muncher`) — see [`number-muncher.md`](number-muncher.md)

--- a/specs/tic-tac-toe.md
+++ b/specs/tic-tac-toe.md
@@ -1,0 +1,66 @@
+# Tic-Tac-Toe — Current State
+
+## Related
+
+- [`spec.md`](spec.md)
+
+## Overview
+
+A configurable Tic-Tac-Toe game with variable board sizes, two play variants, and an optional AI opponent. Styled in the Noahsoft Win95 retro aesthetic — the first experience to be fully converted.
+
+## Route
+
+`/tic-tac-toe` — also embedded as a window inside NS Doors 97.
+
+## Board sizes
+
+| Size | Win condition |
+|---|---|
+| 3×3 | 3 in a row |
+| 5×5 | 4 in a row |
+| 7×7 | 5 in a row |
+
+## Play variants
+
+**Classic** — click any empty cell to place a piece.
+
+**Drop In** — pieces fall to the lowest empty row in the chosen column (gravity-based, like Connect 4). Column hover highlights indicate the landing cell.
+
+## Opponents
+
+**vs Human** — two players share the keyboard/mouse. X always goes first.
+
+**vs Computer** — single player vs an AI at three difficulty levels:
+- Easy — picks a random valid move
+- Normal — blocks opponent wins and takes wins when available; otherwise random
+- Hard — always picks the highest-scored move (minimax-style weighting)
+
+## Setup screen
+
+Shown on first load and after "Change Settings". Options:
+- Board size (3×3 / 5×5 / 7×7)
+- Variant (Classic / Drop In)
+- Opponent (vs Human / vs Computer)
+- Difficulty (Easy / Normal / Hard) — only shown when vs Computer is selected
+- Hint text updates to describe the selected combination
+
+## Game board
+
+- Status bar shows whose turn it is, or the winner/draw result.
+- Win cells animate with a pop (scale 1.12 → 1) and get colored bevel borders.
+- X = orange (`#cc4400`), O = purple (`#5b2d8e`).
+
+## Action buttons
+
+- **New Game** — resets the board keeping current settings.
+- **Change Settings** — returns to the setup screen.
+
+## Debug overlay
+
+Shows the AI move weight for each valid cell. Toggled by:
+- Triple-tap the status text bar (mobile)
+- `Ctrl + .` (keyboard)
+
+## Styling
+
+Win95 raised/sunken beveled borders throughout. Background: dark radial gradient (`#2a1000 → #0c0400`). Game panel: `#c0c0c0`. Font: "Press Start 2P".

--- a/specs/word-whirlwind.md
+++ b/specs/word-whirlwind.md
@@ -1,0 +1,63 @@
+# Word Whirlwind — Current State
+
+## Related
+
+- [`spec.md`](spec.md)
+
+## Overview
+
+An unscramble/word-finding game. A set of scrambled letters is shown; the player builds words by clicking letter tiles. Multiple word groups (2–7 letter words) are hidden and must be found. Built on a shared word dictionary utility.
+
+## Route
+
+`/word-whirlwind`
+
+## Game modes
+
+| Mode | Description |
+|---|---|
+| Freeplay | No timer; play at your own pace |
+| Standard | Timed rounds; lose time for wrong guesses |
+| Strict | Timed rounds; no second chances |
+
+## Setup screen
+
+- Title with gradient treatment
+- Mode selector (Freeplay / Standard / Strict) with hint text
+- Start button
+
+## Game layout
+
+Three zones stacked vertically:
+1. **Game bar** — round counter, mode pill, timer (Standard/Strict), score, quit button
+2. **Word groups panel** — scrollable list of collapsible groups, each showing hidden word slots. Found words reveal letter-by-letter with staggered animation. Neighbor-deducible letters show as hints.
+3. **Input area** — flash message, letter board (selected tiles in order), controls row (Clear / Shuffle / Submit / Advance), letter pool
+
+## Letter tiles
+
+- Pool tiles are clickable; clicking moves a letter to the board.
+- Board slots are clickable to remove a letter back to the pool.
+- Shuffle randomizes the remaining pool.
+- Submit checks the built word against the dictionary and word list.
+
+## Scoring
+
+- Points awarded per word found (longer words score more).
+- Bonus points for finding all words in a group.
+- Round summary overlay shows per-word breakdown, bonus, and running total.
+- Game-over screen shows final score and rounds completed.
+
+## Flash messages
+
+- "Nice!" / word value on correct guess — green pill
+- "Not a word" / "Already found" / "No letters" on wrong — red pill
+
+## Animations
+
+- Tile enter: scale + translateY bounce
+- Found word: staggered letter reveal with pop
+- Advance button: appears with scale-in animation after all words in a group are found
+
+## Utilities
+
+Word validation and dictionary lookups use `src/utils/wordDictionary.ts`, shared with other word-based experiences.

--- a/src/experiences/NumberMuncher/NumberMuncher.css
+++ b/src/experiences/NumberMuncher/NumberMuncher.css
@@ -1,79 +1,107 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Number Muncher — Noahsoft Win95 Redesign
+   Win95 chrome; orange player cursor; green/red flash states.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
 .number-muncher {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  min-height: 100%;
-  padding: var(--spacing-lg);
-  gap: var(--spacing-md);
+  padding: 12px 14px 16px;
+  gap: 10px;
+  background: #c0c0c0;
   position: relative;
 }
 
+/* ── HUD — Win95 sunken status bar ─────────────────────────────────────── */
+
 .number-muncher__hud {
   display: flex;
-  gap: var(--spacing-xl);
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 1rem;
+  gap: 16px;
+  width: 100%;
+  padding: 4px 8px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #000;
   align-items: center;
+  box-sizing: border-box;
+  flex-wrap: wrap;
+  min-height: 24px;
 }
 
 .number-muncher__hud strong {
-  color: #fff;
+  color: #cc4400;
 }
+
+/* ── Grid — Win95 raised panel ─────────────────────────────────────────── */
 
 .number-muncher__grid {
   display: grid;
-  gap: 4px;
-  padding: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  transition: background 0.2s;
+  gap: 3px;
+  padding: 6px;
+  background: #808080;
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.35);
+  transition: background 0.15s;
 }
 
 .number-muncher--correct .number-muncher__grid {
-  background: rgba(68, 238, 136, 0.08);
+  background: #338833;
+  border-color: #88cc88 #224422 #224422 #88cc88;
 }
 
 .number-muncher--wrong .number-muncher__grid {
-  background: rgba(255, 68, 102, 0.1);
+  background: #883333;
+  border-color: #cc8888 #441111 #441111 #cc8888;
 }
 
+/* ── Cell — Win95 sunken box ───────────────────────────────────────────── */
+
 .number-muncher__cell {
-  width: 58px;
-  height: 46px;
+  width: 52px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.15rem;
-  font-weight: 600;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 4px;
-  color: rgba(255, 255, 255, 0.55);
-  background: rgba(255, 255, 255, 0.03);
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #c8c8c8;
+  color: #555;
   font-variant-numeric: tabular-nums;
-  transition: background 0.1s, opacity 0.2s;
+  transition: background 0.08s, opacity 0.2s;
 }
 
+/* Numbers that match the current rule */
 .number-muncher__cell--match {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.07);
+  color: #000;
+  background: #d4d0c8;
 }
 
+/* Player position — orange raised bevel */
 .number-muncher__cell--player {
-  background: #3355ee;
-  border-color: #6688ff;
+  background: #ff6b00;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
   color: #fff;
-  box-shadow: 0 0 0 2px rgba(100, 136, 255, 0.4);
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 .number-muncher__cell--player.number-muncher__cell--match {
-  background: #4466ff;
+  background: #ff7a1a;
 }
 
+/* Eaten (invisible) */
 .number-muncher__cell--eaten {
   opacity: 0;
   pointer-events: none;
 }
+
+/* ── Game over overlay ──────────────────────────────────────────────────── */
 
 .number-muncher__overlay {
   position: absolute;
@@ -81,45 +109,61 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.8);
-  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.75);
 }
 
 .number-muncher__gameover {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-md);
+  gap: 12px;
   text-align: center;
+  background: #c0c0c0;
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 20px 28px;
 }
 
 .number-muncher__gameover-title {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: #ff4466;
+  font-family: "Press Start 2P", monospace;
+  font-size: 13px;
+  color: #cc0000;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
 }
 
 .number-muncher__gameover-score {
-  font-size: 1.4rem;
-  color: rgba(255, 255, 255, 0.8);
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  color: #000;
 }
 
+/* Win95 orange button */
 .number-muncher__restart {
-  padding: var(--spacing-sm) var(--spacing-lg);
-  background: #3355ee;
-  border: none;
+  padding: 7px 20px;
+  background: #ff6b00;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
   color: #fff;
-  font-size: 1rem;
-  border-radius: 6px;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
   cursor: pointer;
-  transition: background 0.15s;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 .number-muncher__restart:hover {
-  background: #4466ff;
+  background: #ff7a1a;
 }
 
+.number-muncher__restart:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(1px);
+}
+
+/* ── Hint bar ───────────────────────────────────────────────────────────── */
+
 .number-muncher__hint {
-  color: rgba(255, 255, 255, 0.3);
-  font-size: 0.8rem;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  color: #555;
 }

--- a/src/experiences/TypingRacer/TypingRacer.css
+++ b/src/experiences/TypingRacer/TypingRacer.css
@@ -1,111 +1,165 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Typing Racer — Noahsoft Win95 Redesign
+   Win95 chrome throughout; Courier New for the phrase (legibility);
+   Press Start 2P for all HUD / status labels.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
 .typing-racer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  min-height: 100%;
-  padding: var(--spacing-xl);
-  gap: var(--spacing-lg);
+  padding: 14px 16px 18px;
+  gap: 12px;
+  background: #c0c0c0;
+  width: min(560px, 94vw);
 }
+
+/* ── Stats bar — Win95 sunken status strip ─────────────────────────────── */
 
 .typing-racer__stats {
   display: flex;
-  gap: var(--spacing-lg);
-  color: rgba(255, 255, 255, 0.45);
-  font-size: 1rem;
+  gap: 16px;
+  width: 100%;
+  padding: 4px 8px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #000;
+  box-sizing: border-box;
   font-variant-numeric: tabular-nums;
-  min-height: 1.5rem;
+  min-height: 22px;
+  align-items: center;
 }
 
 .typing-racer__timer {
-  color: rgba(255, 255, 255, 0.25);
+  color: #cc4400;
+  margin-left: auto;
 }
 
+/* ── Phrase display — Win95 inset panel ───────────────────────────────── */
+
 .typing-racer__phrase {
-  max-width: 640px;
-  font-size: 1.6rem;
-  line-height: 1.9;
-  text-align: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 1.15rem;
+  line-height: 1.8;
+  text-align: left;
   user-select: none;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
+  word-break: break-word;
 }
 
 .typing-racer__char {
-  color: rgba(255, 255, 255, 0.25);
+  color: #888;
 }
 
 .typing-racer__char--correct {
-  color: #44ee88;
+  color: #228833;
 }
 
 .typing-racer__char--wrong {
-  color: #ff4466;
-  background: rgba(255, 68, 102, 0.18);
-  border-radius: 2px;
+  color: #cc0000;
+  background: rgba(204, 0, 0, 0.12);
 }
 
 .typing-racer__char--cursor {
-  color: rgba(255, 255, 255, 0.9);
-  border-bottom: 2px solid #fff;
+  color: #000;
+  border-bottom: 2px solid #cc4400;
 }
+
+/* ── Input — Win95 text field ────────────────────────────────────────── */
 
 .typing-racer__input {
   width: 100%;
-  max-width: 640px;
-  padding: var(--spacing-sm) var(--spacing-md);
+  box-sizing: border-box;
+  padding: 5px 8px;
+  font-family: "Courier New", Courier, monospace;
   font-size: 1rem;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 6px;
-  color: #fff;
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #000;
   outline: none;
-  caret-color: transparent;
+  caret-color: #cc4400;
 }
 
 .typing-racer__input:focus {
-  border-color: rgba(255, 255, 255, 0.4);
-  background: rgba(255, 255, 255, 0.08);
+  border-color: #000000 #c0c0c0 #c0c0c0 #000000;
 }
+
+/* ── Result screen ──────────────────────────────────────────────────── */
 
 .typing-racer__result {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-lg);
+  gap: 12px;
+  width: 100%;
 }
 
 .typing-racer__result-stats {
   display: flex;
-  gap: var(--spacing-xl);
+  gap: 0;
+  width: 100%;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+.typing-racer__result-stats > div {
+  flex: 1;
   text-align: center;
+  padding: 10px 8px;
+  border-right: 1px solid #808080;
+}
+
+.typing-racer__result-stats > div:last-child {
+  border-right: none;
 }
 
 .typing-racer__result-value {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: #fff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 14px;
+  color: #cc4400;
   font-variant-numeric: tabular-nums;
 }
 
 .typing-racer__result-label {
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.45);
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #555;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-top: 2px;
+  letter-spacing: 0.1em;
+  margin-top: 6px;
 }
 
+/* Win95 orange primary button */
 .typing-racer__reset {
-  padding: var(--spacing-sm) var(--spacing-lg);
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 7px 24px;
+  background: #ff6b00;
   color: #fff;
-  font-size: 1rem;
-  border-radius: 6px;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
   cursor: pointer;
-  transition: background 0.15s;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
+  letter-spacing: 0.04em;
 }
 
 .typing-racer__reset:hover {
-  background: rgba(255, 255, 255, 0.18);
+  background: #ff7a1a;
+}
+
+.typing-racer__reset:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(1px);
 }

--- a/src/experiences/WordWhirlwind/WordWhirlwind.css
+++ b/src/experiences/WordWhirlwind/WordWhirlwind.css
@@ -1,19 +1,24 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Word Whirlwind — Noahsoft Win95 Redesign
+   Orange accent, Win95 chrome throughout.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
 /* ── Shared tokens ───────────────────────────────────────────────────────── */
 
 :root {
-  --ww-accent:   #06b6d4;
-  --ww-accent2:  #0891b2;
-  --ww-found:    #10b981;
-  --ww-found-bg: #064e3b;
-  --ww-danger:   #ef4444;
-  --ww-warn:     #f59e0b;
-  --ww-text:     #e2e8f0;
-  --ww-muted:    #64748b;
-  --ww-surface:  #0f172a;
-  --ww-surface2: #1e293b;
-  --ww-surface3: #334155;
-  --ww-border:   #1e293b;
-  --ww-tile-w:   clamp(40px, 9.5vw, 54px);
+  --ww-accent:   #cc4400;
+  --ww-accent2:  #ff6b00;
+  --ww-found:    #228833;
+  --ww-found-bg: #d4ecd4;
+  --ww-danger:   #cc0000;
+  --ww-warn:     #cc8800;
+  --ww-text:     #000000;
+  --ww-muted:    #555555;
+  --ww-surface:  #c0c0c0;
+  --ww-surface2: #d4d0c8;
+  --ww-surface3: #a0a0a0;
+  --ww-border:   #808080;
+  --ww-tile-w:   clamp(40px, 9.5vw, 52px);
 }
 
 /* ── Setup screen ─────────────────────────────────────────────────────────── */
@@ -25,26 +30,26 @@
   justify-content: center;
   min-height: 100vh;
   padding: 2rem 1.5rem;
-  gap: 2.25rem;
+  gap: 2rem;
   color: var(--ww-text);
 }
 
 .ww-setup__title {
-  font-size: clamp(2.2rem, 7vw, 3.5rem);
-  font-weight: 900;
-  letter-spacing: 0.03em;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(14px, 4vw, 22px);
+  font-weight: normal;
   margin: 0;
-  background: linear-gradient(135deg, #06b6d4, #3b82f6);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #cc4400;
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.3);
+  letter-spacing: 0.04em;
 }
 
 .ww-setup__subtitle {
-  margin: -1.5rem 0 0;
-  font-size: 0.9rem;
+  margin: -1.25rem 0 0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   color: var(--ww-muted);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -54,11 +59,12 @@
   align-items: center;
   gap: 0.6rem;
   width: 100%;
-  max-width: 480px;
+  max-width: 440px;
 }
 
 .ww-setup__label {
-  font-size: 0.7rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   text-transform: uppercase;
   letter-spacing: 0.2em;
   color: var(--ww-muted);
@@ -66,32 +72,37 @@
 
 .ww-setup__options {
   display: flex;
-  gap: 0.6rem;
+  gap: 6px;
   flex-wrap: wrap;
   justify-content: center;
 }
 
+/* Win95 raised button */
 .ww-setup__option {
-  padding: 0.5rem 1.2rem;
-  border: 2px solid var(--ww-surface3);
-  border-radius: 0.5rem;
-  background: transparent;
-  color: var(--ww-muted);
-  font-size: 0.95rem;
-  font-weight: 600;
+  padding: 6px 14px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #c0c0c0;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  transition: background 0.08s;
 }
 
 .ww-setup__option:hover {
-  border-color: var(--ww-accent2);
-  color: var(--ww-text);
+  background: #cccccc;
 }
 
+/* Active = sunken + orange text */
 .ww-setup__option--active {
-  border-color: var(--ww-accent);
-  background: rgba(6, 182, 212, 0.12);
-  color: #cffafe;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
+  color: #cc4400;
+}
+
+.ww-setup__option--active:hover {
+  background: #b8b8b8;
 }
 
 .ww-setup__option--standalone {
@@ -99,47 +110,50 @@
 }
 
 .ww-setup__hint {
-  font-size: 0.78rem;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
   color: var(--ww-muted);
   text-align: center;
-  min-height: 1.2em;
+  min-height: 1.3em;
 }
 
+/* Start button */
 .ww-setup__start {
   margin-top: 0.25rem;
-  padding: 0.85rem 3.5rem;
-  background: var(--ww-accent);
-  color: #083344;
-  border: none;
-  border-radius: 0.6rem;
-  font-size: 1.15rem;
-  font-weight: 800;
+  padding: 8px 36px;
+  background: #ff6b00;
+  color: #fff;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
   cursor: pointer;
-  letter-spacing: 0.05em;
-  transition: background 0.15s, transform 0.1s;
+  letter-spacing: 0.04em;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 .ww-setup__start:hover {
-  background: #22d3ee;
-  transform: translateY(-2px);
+  background: #ff7a1a;
 }
 
 .ww-setup__start:active {
-  transform: translateY(0);
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(1px);
 }
 
 .ww-setup__home {
   background: transparent;
   border: none;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   color: var(--ww-muted);
-  font-size: 0.85rem;
   cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  transition: color 0.15s;
+  padding: 4px 8px;
 }
 
 .ww-setup__home:hover {
-  color: var(--ww-text);
+  color: #000;
 }
 
 /* ── Game layout ──────────────────────────────────────────────────────────── */
@@ -151,56 +165,60 @@
   overflow: hidden;
   color: var(--ww-text);
   background: var(--ww-surface);
+  width: min(560px, 100vw);
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
 }
 
-/* ── Game bar ─────────────────────────────────────────────────────────────── */
+/* ── Game bar — Win95 menu bar style ─────────────────────────────────────── */
 
 .ww-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1rem;
-  background: var(--ww-surface2);
-  border-bottom: 1px solid var(--ww-border);
+  padding: 4px 8px;
+  background: #c0c0c0;
+  border-bottom: 2px solid #808080;
   flex-shrink: 0;
-  gap: 0.75rem;
-  min-height: 48px;
+  gap: 8px;
+  min-height: 32px;
 }
 
 .ww-bar__left {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 8px;
   flex: 1;
 }
 
 .ww-bar__right {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 8px;
   flex: 1;
   justify-content: flex-end;
 }
 
 .ww-bar__round {
-  font-weight: 700;
-  font-size: 0.95rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   color: var(--ww-text);
 }
 
 .ww-bar__mode {
-  font-size: 0.72rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   color: var(--ww-muted);
-  padding: 0.15rem 0.5rem;
-  border: 1px solid var(--ww-surface3);
-  border-radius: 999px;
+  padding: 2px 6px;
+  border: 1px solid #808080;
+  background: #d4d0c8;
 }
 
 .ww-bar__timer {
-  font-size: 1.3rem;
-  font-weight: 800;
+  font-family: "Press Start 2P", monospace;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
   color: var(--ww-text);
   min-width: 3.5ch;
@@ -216,31 +234,35 @@
 
 @keyframes ww-pulse {
   from { opacity: 1; }
-  to   { opacity: 0.4; }
+  to   { opacity: 0.35; }
 }
 
 .ww-bar__score {
-  font-size: 1rem;
-  font-weight: 700;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
   font-variant-numeric: tabular-nums;
-  color: var(--ww-accent);
+  color: #cc4400;
 }
 
+/* Win95 secondary button */
 .ww-bar__quit {
-  padding: 0.25rem 0.75rem;
-  background: transparent;
-  color: var(--ww-muted);
-  border: 1px solid var(--ww-surface3);
-  border-radius: 0.375rem;
-  font-size: 0.78rem;
-  font-weight: 600;
+  padding: 3px 10px;
+  background: #c0c0c0;
+  color: #000;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
 }
 
 .ww-bar__quit:hover {
-  color: var(--ww-danger);
-  border-color: var(--ww-danger);
+  background: #cccccc;
+}
+
+.ww-bar__quit:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
 }
 
 /* ── Word groups panel ────────────────────────────────────────────────────── */
@@ -248,66 +270,69 @@
 .ww-word-groups {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem 0.75rem 0;
+  padding: 4px 6px 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  /* Custom scrollbar */
+  gap: 3px;
+  background: var(--ww-surface2);
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 4px 4px 0;
   scrollbar-width: thin;
-  scrollbar-color: var(--ww-surface3) transparent;
+  scrollbar-color: #808080 #d4d0c8;
 }
 
-.ww-word-groups::-webkit-scrollbar { width: 6px; }
+.ww-word-groups::-webkit-scrollbar { width: 12px; }
+.ww-word-groups::-webkit-scrollbar-track { background: #d4d0c8; }
 .ww-word-groups::-webkit-scrollbar-thumb {
-  background: var(--ww-surface3);
-  border-radius: 3px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
 }
 
 .ww-group {
-  border: 1px solid var(--ww-border);
-  border-radius: 0.5rem;
-  overflow: hidden;
-  background: var(--ww-surface2);
-  transition: border-color 0.2s;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #c0c0c0;
 }
 
 .ww-group--complete {
-  border-color: var(--ww-found);
-  background: rgba(16, 185, 129, 0.06);
+  border-color: #228833 #88cc88 #88cc88 #228833;
+  background: #d4ecd4;
 }
 
 .ww-group__header {
   width: 100%;
   display: flex;
   align-items: center;
-  padding: 0.4rem 0.75rem;
+  padding: 4px 8px;
   background: transparent;
   border: none;
   color: var(--ww-text);
   cursor: pointer;
-  gap: 0.5rem;
+  gap: 6px;
   text-align: left;
-  transition: background 0.1s;
 }
 
 .ww-group__header:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .ww-group--complete .ww-group__header {
-  color: #6ee7b7;
+  color: #116622;
 }
 
 .ww-group__title {
-  font-size: 0.8rem;
-  font-weight: 700;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   flex: 1;
 }
 
 .ww-group__count {
-  font-size: 0.75rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   font-variant-numeric: tabular-nums;
   color: var(--ww-muted);
 }
@@ -317,7 +342,7 @@
 }
 
 .ww-group__chevron {
-  font-size: 0.75rem;
+  font-size: 8px;
   color: var(--ww-muted);
   width: 1em;
   text-align: center;
@@ -326,8 +351,8 @@
 .ww-group__words {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
-  padding: 0.35rem 0.75rem 0.5rem;
+  gap: 4px;
+  padding: 3px 8px 6px;
 }
 
 /* ── Individual word slot ─────────────────────────────────────────────────── */
@@ -341,13 +366,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: clamp(15px, 3.5vw, 19px);
-  height: clamp(19px, 4.5vw, 23px);
-  border: 1px solid var(--ww-surface3);
-  border-radius: 3px;
-  font-size: clamp(0.6rem, 1.5vw, 0.75rem);
-  font-weight: 800;
-  background: var(--ww-surface);
+  width: clamp(14px, 3.2vw, 18px);
+  height: clamp(18px, 4.2vw, 22px);
+  border: 1px solid #808080;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(5px, 1.2vw, 7px);
+  background: #d4d0c8;
   color: transparent;
   user-select: none;
 }
@@ -355,7 +379,7 @@
 .ww-word--found .ww-word__letter {
   background: var(--ww-found-bg);
   border-color: var(--ww-found);
-  color: #6ee7b7;
+  color: #116622;
   animation: ww-found-pop 0.3s ease-out both;
 }
 
@@ -377,19 +401,19 @@
 
 /* Hint letters (deducible from found neighbors) */
 .ww-word__letter--hint {
-  background: rgba(59, 130, 246, 0.15);
-  border-color: #3b82f6;
-  color: #93c5fd;
+  background: #dde0f0;
+  border-color: #5b2d8e;
+  color: #5b2d8e;
 }
 
 /* Collapsed run placeholder */
 .ww-word-ellipsis {
-  font-size: 0.68rem;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
   color: var(--ww-muted);
   font-style: italic;
   padding: 0 0.2rem;
   align-self: center;
-  letter-spacing: 0.04em;
 }
 
 /* ── Input area ───────────────────────────────────────────────────────────── */
@@ -399,89 +423,92 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 1rem 0.9rem;
-  background: var(--ww-surface2);
-  border-top: 1px solid var(--ww-border);
+  gap: 6px;
+  padding: 6px 8px 10px;
+  background: #c0c0c0;
+  border-top: 2px solid #808080;
+  margin: 0 4px 4px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  margin: 0 4px 4px;
 }
 
 /* Flash */
 
 .ww-flash-wrap {
-  height: 1.6rem;
+  height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .ww-flash {
-  font-size: 0.9rem;
-  font-weight: 700;
-  padding: 0.2rem 0.9rem;
-  border-radius: 999px;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 3px 10px;
+  border: 2px solid;
   animation: ww-flash-in 0.15s ease-out;
 }
 
 @keyframes ww-flash-in {
-  from { opacity: 0; transform: translateY(-4px) scale(0.95); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
+  from { opacity: 0; transform: translateY(-3px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .ww-flash--good {
-  background: rgba(16, 185, 129, 0.15);
-  color: #6ee7b7;
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  background: #d4ecd4;
+  color: #116622;
+  border-color: #228833 #88cc88 #88cc88 #228833;
 }
 
 .ww-flash--bad {
-  background: rgba(239, 68, 68, 0.12);
-  color: #fca5a5;
-  border: 1px solid rgba(239, 68, 68, 0.25);
+  background: #f0d4d4;
+  color: #880000;
+  border-color: #cc0000 #ffaaaa #ffaaaa #cc0000;
 }
 
 /* Board */
 
 .ww-board {
   display: flex;
-  gap: 0.35rem;
+  gap: 3px;
   justify-content: center;
   flex-wrap: wrap;
 }
 
+/* Win95 sunken input slot */
 .ww-board__slot {
   width: var(--ww-tile-w);
   height: var(--ww-tile-w);
-  border-radius: 6px;
-  border: 2px dashed var(--ww-surface3);
-  background: var(--ww-surface);
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
   color: var(--ww-text);
-  font-size: clamp(1.1rem, 2.8vw, 1.5rem);
-  font-weight: 900;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(10px, 2.4vw, 14px);
   cursor: default;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s, border-color 0.1s;
 }
 
+/* Filled slot — raised, orange-tinted */
 .ww-board__slot--filled {
-  border-style: solid;
-  border-color: var(--ww-accent2);
-  background: rgba(6, 182, 212, 0.1);
-  color: #a5f3fc;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #ffe0cc;
+  color: #cc4400;
   cursor: pointer;
   animation: ww-tile-enter 0.18s ease-out;
 }
 
 @keyframes ww-tile-enter {
   0%   { transform: scale(0.65) translateY(-6px); opacity: 0.4; }
-  65%  { transform: scale(1.1); }
+  65%  { transform: scale(1.08); }
   100% { transform: scale(1) translateY(0); opacity: 1; }
 }
 
 .ww-board__slot--filled:hover {
-  background: rgba(6, 182, 212, 0.2);
-  border-color: var(--ww-accent);
+  background: #ffd0aa;
 }
 
 /* Controls */
@@ -490,47 +517,63 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
-  max-width: 480px;
-  gap: 0.5rem;
+  max-width: 440px;
+  gap: 4px;
 }
 
 .ww-controls__left,
 .ww-controls__right {
   display: flex;
-  gap: 0.4rem;
+  gap: 4px;
   align-items: center;
 }
 
+/* Win95 button base */
 .ww-btn {
-  padding: 0.4rem 1rem;
-  border-radius: 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 700;
+  padding: 5px 12px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #c0c0c0;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   cursor: pointer;
-  border: none;
-  transition: background 0.15s, transform 0.1s;
 }
 
-.ww-btn:active { transform: scale(0.96); }
+.ww-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
+  transform: translateY(1px);
+}
 
 .ww-btn--secondary {
-  background: var(--ww-surface3);
-  color: var(--ww-text);
+  /* inherits base Win95 style */
 }
 
-.ww-btn--secondary:hover { background: #475569; }
+.ww-btn--secondary:hover { background: #cccccc; }
 
+/* Submit — orange primary */
 .ww-btn--submit {
-  background: var(--ww-accent);
-  color: #083344;
+  background: #ff6b00;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
-.ww-btn--submit:hover { background: #22d3ee; }
+.ww-btn--submit:hover { background: #ff7a1a; }
 
+.ww-btn--submit:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+}
+
+/* Advance — green success */
 .ww-btn--advance {
-  background: var(--ww-found);
-  color: #022c22;
+  background: #228833;
+  color: #fff;
+  border-color: #88cc88 #114422 #114422 #88cc88;
   animation: ww-advance-appear 0.35s ease-out;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 @keyframes ww-advance-appear {
@@ -538,42 +581,45 @@
   to   { opacity: 1; transform: scale(1); }
 }
 
-.ww-btn--advance:hover { background: #34d399; }
+.ww-btn--advance:hover { background: #339944; }
 
 /* Pool */
 
 .ww-pool {
   display: flex;
-  gap: 0.4rem;
+  gap: 4px;
   justify-content: center;
   flex-wrap: wrap;
   min-height: var(--ww-tile-w);
 }
 
+/* Win95 raised tile — orange-branded */
 .ww-pool__tile {
   width: var(--ww-tile-w);
   height: var(--ww-tile-w);
-  border-radius: 8px;
-  background: var(--ww-accent2);
-  color: #ecfeff;
-  font-size: clamp(1.1rem, 2.8vw, 1.5rem);
-  font-weight: 900;
-  border: 2px solid var(--ww-accent);
+  background: #ff6b00;
+  color: #fff;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(10px, 2.4vw, 14px);
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
   cursor: pointer;
-  transition: background 0.12s, transform 0.1s, box-shadow 0.12s;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background 0.08s, transform 0.08s;
 }
 
 .ww-pool__tile:hover {
-  background: var(--ww-accent);
-  transform: translateY(-3px);
-  box-shadow: 0 4px 14px rgba(6, 182, 212, 0.4);
+  background: #ff7a1a;
+  transform: translateY(-2px);
 }
 
 .ww-pool__tile:active {
-  transform: translateY(-1px);
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(0);
 }
 
 /* ── Round summary overlay ────────────────────────────────────────────────── */
@@ -581,12 +627,12 @@
 .ww-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.72);
+  background: rgba(0, 0, 0, 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
-  animation: ww-overlay-in 0.2s ease-out;
+  animation: ww-overlay-in 0.15s ease-out;
 }
 
 @keyframes ww-overlay-in {
@@ -594,38 +640,41 @@
   to   { opacity: 1; }
 }
 
+/* Win95 dialog box */
 .ww-overlay__box {
-  background: #0f1f35;
-  border: 1px solid var(--ww-accent2);
-  border-radius: 1rem;
-  padding: 2rem 2.5rem;
+  background: #c0c0c0;
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 16px 24px 20px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.25rem;
-  min-width: 280px;
+  gap: 12px;
+  min-width: 260px;
   max-width: 90vw;
-  animation: ww-box-in 0.2s ease-out;
-  box-shadow: 0 16px 60px rgba(0, 0, 0, 0.6);
+  animation: ww-box-in 0.18s ease-out;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.4);
 }
 
 @keyframes ww-box-in {
-  from { transform: scale(0.9) translateY(10px); }
+  from { transform: scale(0.9) translateY(8px); }
   to   { transform: scale(1) translateY(0); }
 }
 
 .ww-overlay__title {
-  font-size: 1.6rem;
-  font-weight: 900;
-  color: var(--ww-accent);
+  font-family: "Press Start 2P", monospace;
+  font-size: 11px;
+  color: #cc4400;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
 }
 
 .ww-overlay__title--gameover {
-  color: var(--ww-danger);
+  color: #cc0000;
 }
 
 .ww-overlay__answer {
-  font-size: 0.9rem;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
   color: var(--ww-muted);
 }
 
@@ -633,48 +682,59 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 3px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 6px 8px;
 }
 
 .ww-overlay__row {
   display: flex;
   justify-content: space-between;
-  font-size: 0.9rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
   color: var(--ww-muted);
-  padding: 0.2rem 0;
-  border-bottom: 1px solid var(--ww-border);
+  padding: 3px 0;
+  border-bottom: 1px solid #808080;
 }
 
 .ww-overlay__row--bonus {
-  color: #6ee7b7;
+  color: #228833;
 }
 
 .ww-overlay__row--total {
-  color: var(--ww-text);
-  font-weight: 700;
-  font-size: 1rem;
+  color: #000;
+  font-size: 7px;
   border-bottom: none;
-  margin-top: 0.25rem;
+  margin-top: 2px;
 }
 
+/* Orange primary button */
 .ww-overlay__btn {
-  padding: 0.7rem 2.5rem;
-  background: var(--ww-accent);
-  color: #083344;
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  font-weight: 800;
+  padding: 8px 28px;
+  background: #ff6b00;
+  color: #fff;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
   cursor: pointer;
-  transition: background 0.15s;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
-.ww-overlay__btn:hover { background: #22d3ee; }
+.ww-overlay__btn:hover { background: #ff7a1a; }
+
+.ww-overlay__btn:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(1px);
+}
 
 /* ── Game over screen ─────────────────────────────────────────────────────── */
 
 .ww-word-groups__spacer {
-  height: 1.25rem;
+  height: 16px;
   flex-shrink: 0;
 }
 
@@ -684,35 +744,39 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  gap: 1rem;
+  gap: 12px;
   color: var(--ww-text);
+  background: #c0c0c0;
 }
 
 .ww-gameover__label {
-  font-size: 0.75rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   text-transform: uppercase;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.15em;
   color: var(--ww-muted);
 }
 
 .ww-gameover__score {
-  font-size: clamp(3rem, 12vw, 5.5rem);
-  font-weight: 900;
-  color: var(--ww-accent);
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(24px, 8vw, 48px);
+  color: #cc4400;
   font-variant-numeric: tabular-nums;
   line-height: 1;
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.2);
 }
 
 .ww-gameover__rounds {
-  font-size: 0.9rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
   color: var(--ww-muted);
-  margin-bottom: 0.5rem;
+  margin-bottom: 4px;
 }
 
 .ww-gameover__actions {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
+  gap: 8px;
+  margin-top: 4px;
 }

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,42 +1,44 @@
 .toybox-wordmark {
-  font-size: var(--text-lg);
-  font-weight: 700;
-  letter-spacing: -0.01em;
+  font-family: "Press Start 2P", monospace;
+  font-size: 13px;
+  color: #cc4400;
+  letter-spacing: 0.04em;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.25);
 }
 
 .homepage__filters {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-sm);
+  gap: 6px;
   justify-content: center;
   padding: var(--spacing-md) 0;
 }
 
+/* Win95 raised filter button */
 .homepage__filter-btn {
-  padding: 4px 14px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  border-radius: 999px;
-  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.15));
-  background: transparent;
-  color: var(--color-text-muted, #666);
+  padding: 5px 14px;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #c0c0c0;
+  color: #000;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
   text-transform: capitalize;
+  letter-spacing: 0.04em;
 }
 
 .homepage__filter-btn:hover {
-  background: var(--color-surface-raised, rgba(0, 0, 0, 0.05));
-  color: var(--color-text, #111);
+  background: #cccccc;
 }
 
+/* Active = sunken + orange text */
 .homepage__filter-btn--active {
-  background: var(--color-primary, #3355ee);
-  border-color: var(--color-primary, #3355ee);
-  color: #fff;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
+  color: #cc4400;
 }
 
 .homepage__filter-btn--active:hover {
-  background: var(--color-primary, #3355ee);
-  color: #fff;
+  background: #b8b8b8;
 }

--- a/src/pages/NumberMuncherPage.css
+++ b/src/pages/NumberMuncherPage.css
@@ -1,8 +1,12 @@
 .number-muncher-page {
   position: fixed;
   inset: 0;
-  background: #0a0a1e;
+  background: radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow-y: auto;
+  padding: 48px 16px 16px;
 }
 
 .number-muncher-page__back {

--- a/src/pages/TypingRacerPage.css
+++ b/src/pages/TypingRacerPage.css
@@ -1,8 +1,12 @@
 .typing-racer-page {
   position: fixed;
   inset: 0;
-  background: #111;
+  background: radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow-y: auto;
+  padding: 48px 16px 16px;
 }
 
 .typing-racer-page__back {

--- a/src/pages/WordWhirlwindPage.css
+++ b/src/pages/WordWhirlwindPage.css
@@ -1,6 +1,9 @@
 .word-whirlwind-page {
   position: fixed;
   inset: 0;
-  background: #0a0f1a;
+  background: radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow-y: auto;
 }


### PR DESCRIPTION
- Convert TypingRacer, NumberMuncher, WordWhirlwind to Win95 chrome:
  Win95 gray panels, beveled raised/sunken borders, Press Start 2P font,
  orange (#cc4400/#ff6b00) primary, green success, dark radial gradient
  page backgrounds — matching the TicTacToe aesthetic already in place
- Retro-ify HomePage filter buttons (Win95 raised/sunken pattern)
- Add CLAUDE.md: comprehensive session guide covering project purpose,
  routing, retro aesthetic rules, border patterns, typography, and
  conventions so future sessions need no orientation
- Update README.md with table of experiences, stack, and doc links
- Update specs/spec.md to reflect full current state including
  NsDoors97, TicTacToe, WordWhirlwind, and the retro aesthetic section
- Add specs/tic-tac-toe.md, specs/word-whirlwind.md, specs/ns-doors-97.md

https://claude.ai/code/session_01BddqwwTdTWK17QKdps9GwF