### PR TITLE
Add fake bootup screen to NS Doors 97

### DIFF
--- a/src/experiences/NsDoors97/BootScreen.css
+++ b/src/experiences/NsDoors97/BootScreen.css
@@ -1,10 +1,18 @@
-/* ── BIOS POST terminal ─────────────────────────────────────────────────── */
+/* ── Shared black overlay ───────────────────────────────────────────────── */
 
-.boot-bios {
+.boot-overlay {
   position: fixed;
   inset: 0;
   z-index: 10000;
   background: #000;
+  /* No animation — abrupt appearance by design */
+}
+
+/* ── BIOS POST terminal ─────────────────────────────────────────────────── */
+
+.boot-bios {
+  position: absolute;
+  inset: 0;
   color: #b2b2b2;
   font-family: "Courier New", Courier, monospace;
   font-size: 13px;
@@ -14,32 +22,22 @@
 }
 
 @media (max-width: 640px) {
-  .boot-bios {
-    font-size: 10px;
-    padding: 16px 18px;
-  }
+  .boot-bios { font-size: 10px; padding: 16px 18px; }
 }
 
-.boot-bios__header {
-  color: #ffffff;
-  margin-bottom: 1px;
-}
+.boot-bios__header { color: #ffffff; }
+.boot-bios__line   { color: #b2b2b2; white-space: pre; }
+.boot-bios__skip   { color: #ff9a44; white-space: pre; }
+.boot-bios__spacer { height: 1.6em; }
 
-.boot-bios__line {
-  color: #b2b2b2;
-  white-space: pre;
-}
-
-.boot-bios__spacer {
+/* Cursor area — keeps line height consistent */
+.boot-bios__cursor-line {
   height: 1.6em;
+  display: flex;
+  align-items: center;
 }
 
-.boot-bios__skip {
-  color: #ff9a44;
-  white-space: pre;
-}
-
-/* Blinking block cursor after the last revealed line */
+/* Blinking block cursor */
 .boot-bios__cursor {
   display: inline-block;
   width: 9px;
@@ -55,113 +53,125 @@
   50%       { opacity: 0; }
 }
 
-/* ── Boot logo screen ───────────────────────────────────────────────────── */
+/* Spinning cursor character */
+.boot-bios__spin-char {
+  color: #b2b2b2;
+  font-family: "Courier New", Courier, monospace;
+}
 
-.boot-logo {
-  position: fixed;
+/* ── Splash screen ──────────────────────────────────────────────────────── */
+
+/* No fade-in — abrupt and jarring, just like the real thing */
+.boot-splash {
+  position: absolute;
   inset: 0;
-  z-index: 10000;
-  background: #000;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0;
-  animation: boot-logo-fadein 0.25s ease-out;
+  padding: 24px 16px 40px;
 }
 
-@keyframes boot-logo-fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-.boot-logo__center {
+.boot-splash__top {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   margin-bottom: 56px;
 }
 
-.boot-logo__brand {
+.boot-splash__brand {
   font-family: "Press Start 2P", monospace;
-  font-size: 9px;
+  font-size: 8px;
   color: #cc4400;
-  letter-spacing: 0.45em;
+  letter-spacing: 0.5em;
   text-transform: uppercase;
+  margin-bottom: 4px;
 }
 
-.boot-logo__title {
+.boot-splash__logo {
+  font-size: 80px;
+  line-height: 1;
+  filter: drop-shadow(0 0 24px rgba(255, 107, 0, 0.5));
+}
+
+@media (max-width: 480px) {
+  .boot-splash__logo { font-size: 56px; }
+}
+
+.boot-splash__title {
   font-family: "Press Start 2P", monospace;
-  font-size: 22px;
+  font-size: clamp(20px, 5vw, 36px);
   color: #ff6b00;
   text-shadow:
-    0 0 18px rgba(255, 107, 0, 0.65),
-    0 0 40px rgba(255, 107, 0, 0.3),
-    0 0 80px rgba(255, 107, 0, 0.12);
-  line-height: 1.35;
+    0 0 20px rgba(255, 107, 0, 0.7),
+    0 0 50px rgba(255, 107, 0, 0.35),
+    0 0 90px rgba(255, 107, 0, 0.15);
+  letter-spacing: 0.08em;
+  line-height: 1.2;
   text-align: center;
+  margin-top: 4px;
 }
 
-@media (max-width: 500px) {
-  .boot-logo__title {
-    font-size: 14px;
-  }
-}
-
-.boot-logo__tagline {
+.boot-splash__tagline {
   font-family: "Courier New", Courier, monospace;
-  font-size: 10px;
-  color: #3a3a3a;
-  letter-spacing: 0.04em;
-  margin-top: 6px;
+  font-style: italic;
+  font-size: 12px;
+  color: #555;
+  text-align: center;
+  max-width: 380px;
+  margin-top: 12px;
+  line-height: 1.6;
 }
 
-/* Progress bar — Win95-style segmented blocks */
+@media (max-width: 480px) {
+  .boot-splash__tagline { font-size: 10px; }
+}
 
-.boot-logo__progress-area {
+/* Progress area */
+.boot-splash__bottom {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
 }
 
-.boot-logo__bar {
+/* Win95-style segmented progress bar */
+.boot-splash__bar {
   display: flex;
   gap: 3px;
 }
 
-.boot-logo__segment {
+.boot-splash__segment {
   width: 13px;
   height: 13px;
   background: #111;
-  border: 1px solid #222;
+  border: 1px solid #1e1e1e;
   flex-shrink: 0;
 }
 
-.boot-logo__segment--on {
+.boot-splash__segment--on {
   background: linear-gradient(180deg, #ff9a44 0%, #cc4400 100%);
   border-color: #ff6b00;
   box-shadow: 0 0 5px rgba(255, 107, 0, 0.55);
 }
 
-.boot-logo__status {
+.boot-splash__status {
   font-family: "Courier New", Courier, monospace;
   font-size: 11px;
   color: #4a4a4a;
   text-align: center;
-  min-width: 320px;
+  min-width: 300px;
   min-height: 1.5em;
 }
 
 /* Backspace hint — bottom-right corner */
-
-.boot-logo__skip-hint {
+.boot-splash__skip {
   position: fixed;
   bottom: 14px;
   right: 18px;
   font-family: "Courier New", Courier, monospace;
   font-size: 10px;
   color: #2a2a2a;
-  letter-spacing: 0.03em;
 }

--- a/src/experiences/NsDoors97/BootScreen.css
+++ b/src/experiences/NsDoors97/BootScreen.css
@@ -1,0 +1,167 @@
+/* ── BIOS POST terminal ─────────────────────────────────────────────────── */
+
+.boot-bios {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: #000;
+  color: #b2b2b2;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 28px 36px;
+  overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .boot-bios {
+    font-size: 10px;
+    padding: 16px 18px;
+  }
+}
+
+.boot-bios__header {
+  color: #ffffff;
+  margin-bottom: 1px;
+}
+
+.boot-bios__line {
+  color: #b2b2b2;
+  white-space: pre;
+}
+
+.boot-bios__spacer {
+  height: 1.6em;
+}
+
+.boot-bios__skip {
+  color: #ff9a44;
+  white-space: pre;
+}
+
+/* Blinking block cursor after the last revealed line */
+.boot-bios__cursor {
+  display: inline-block;
+  width: 9px;
+  height: 13px;
+  background: #b2b2b2;
+  vertical-align: text-bottom;
+  margin-left: 1px;
+  animation: boot-cursor-blink 0.75s step-end infinite;
+}
+
+@keyframes boot-cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ── Boot logo screen ───────────────────────────────────────────────────── */
+
+.boot-logo {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: #000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  animation: boot-logo-fadein 0.25s ease-out;
+}
+
+@keyframes boot-logo-fadein {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.boot-logo__center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 56px;
+}
+
+.boot-logo__brand {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  color: #cc4400;
+  letter-spacing: 0.45em;
+  text-transform: uppercase;
+}
+
+.boot-logo__title {
+  font-family: "Press Start 2P", monospace;
+  font-size: 22px;
+  color: #ff6b00;
+  text-shadow:
+    0 0 18px rgba(255, 107, 0, 0.65),
+    0 0 40px rgba(255, 107, 0, 0.3),
+    0 0 80px rgba(255, 107, 0, 0.12);
+  line-height: 1.35;
+  text-align: center;
+}
+
+@media (max-width: 500px) {
+  .boot-logo__title {
+    font-size: 14px;
+  }
+}
+
+.boot-logo__tagline {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  color: #3a3a3a;
+  letter-spacing: 0.04em;
+  margin-top: 6px;
+}
+
+/* Progress bar — Win95-style segmented blocks */
+
+.boot-logo__progress-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.boot-logo__bar {
+  display: flex;
+  gap: 3px;
+}
+
+.boot-logo__segment {
+  width: 13px;
+  height: 13px;
+  background: #111;
+  border: 1px solid #222;
+  flex-shrink: 0;
+}
+
+.boot-logo__segment--on {
+  background: linear-gradient(180deg, #ff9a44 0%, #cc4400 100%);
+  border-color: #ff6b00;
+  box-shadow: 0 0 5px rgba(255, 107, 0, 0.55);
+}
+
+.boot-logo__status {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #4a4a4a;
+  text-align: center;
+  min-width: 320px;
+  min-height: 1.5em;
+}
+
+/* Backspace hint — bottom-right corner */
+
+.boot-logo__skip-hint {
+  position: fixed;
+  bottom: 14px;
+  right: 18px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  color: #2a2a2a;
+  letter-spacing: 0.03em;
+}

--- a/src/experiences/NsDoors97/BootScreen.tsx
+++ b/src/experiences/NsDoors97/BootScreen.tsx
@@ -164,6 +164,39 @@ function generateBootMessages(): string[] {
 
 // ── Audio ──────────────────────────────────────────────────────────────────
 
+export function playShutdownSound(): void {
+  try {
+    const ctx = new AudioContext();
+    // Descending arpeggio — mirror image of startup
+    const notes = [
+      { freq: 783.99, t: 0.0,  dur: 0.14 },  // G5
+      { freq: 659.25, t: 0.11, dur: 0.14 },  // E5
+      { freq: 523.25, t: 0.22, dur: 0.14 },  // C5
+      { freq: 392.0,  t: 0.33, dur: 0.14 },  // G4
+      { freq: 329.63, t: 0.44, dur: 0.14 },  // E4
+      { freq: 261.63, t: 0.55, dur: 0.55 },  // C4 — hold and fade out
+    ];
+    notes.forEach(({ freq, t, dur }) => {
+      const osc = ctx.createOscillator();
+      const gn = ctx.createGain();
+      osc.connect(gn);
+      gn.connect(ctx.destination);
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      const at = ctx.currentTime + t;
+      gn.gain.setValueAtTime(0, at);
+      gn.gain.linearRampToValueAtTime(0.12, at + 0.015);
+      gn.gain.setValueAtTime(0.12, at + dur - 0.05);
+      gn.gain.linearRampToValueAtTime(0, at + dur);
+      osc.start(at);
+      osc.stop(at + dur + 0.01);
+    });
+    setTimeout(() => ctx.close(), 2500);
+  } catch {
+    // Audio not available — ignore
+  }
+}
+
 function playPostBeep(): void {
   try {
     const ctx = new AudioContext();

--- a/src/experiences/NsDoors97/BootScreen.tsx
+++ b/src/experiences/NsDoors97/BootScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { randomDelay, chunkIncrement, makeSleep } from "../../utils/retroTiming";
 import "./BootScreen.css";
 
 // ── localStorage helpers ───────────────────────────────────────────────────
@@ -25,7 +26,7 @@ function markBooted(): void {
   }
 }
 
-// ── Random content pools ───────────────────────────────────────────────────
+// ── Random content ─────────────────────────────────────────────────────────
 
 function pick<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -87,6 +88,7 @@ const BIOS_QUIPS = [
   "Shadow RAM enabled: your secrets are safe",
   "Energy Star compliant: it uses energy, anyway",
   "Checking for Y2K issues... results inconclusive",
+  "Bus speed set to 66MHz. Bus is running late.",
 ];
 
 const SETUP_HINTS = [
@@ -95,35 +97,25 @@ const SETUP_HINTS = [
   "F2 = BIOS Setup    F10 = Boot Select    ESC = Panic",
 ];
 
-function generatePostLines(): string[] {
-  const year = 1997 + Math.floor(Math.random() * 3);
-  const ramMB = pick([32, 64, 128, 256]);
-  const drive1 = pick(DRIVES);
-  const drive2 = Math.random() > 0.35 ? pick(DRIVES) : "None";
-  const drive3 = Math.random() > 0.6 ? pick(DRIVES) : "None";
-  const irqNum = Math.floor(Math.random() * 15) + 1;
-  const pciCount = Math.floor(Math.random() * 5) + 1;
-
-  return [
-    `Noahsoft BIOS v2.6.${year}  —  Copyright (C) ${year} Noahsoft Corp.`,
-    "",
-    `CPU: ${pick(CPUS)}`,
-    `Memory: ${ramMB * 1024}K OK`,
-    "",
-    `Primary IDE Master ...... ${drive1}`,
-    `Primary IDE Slave ....... ${drive2}`,
-    `Secondary IDE Master .... ${drive3}`,
-    "",
-    `PCI Bus scan: ${pciCount} device(s) found`,
-    `IRQ${irqNum}: ${pick(IRQS)}`,
-    `USB: ${pick(USB_STATUS)}`,
-    "",
-    pick(BIOS_QUIPS),
-    "",
-    pick(SETUP_HINTS),
-    "[Press Backspace to skip]",
-  ];
-}
+const TAGLINES = [
+  '"A door to a world of possibilities."',
+  '"Knock knock. Who\'s there? The future."',
+  '"Opening doors you didn\'t know were closed."',
+  '"Built for the information superhighway. And the side streets."',
+  '"Because doors are better than windows.™"',
+  '"We put the \'soft\' in software."',
+  '"Warning: may cause excessive productivity. Or none at all."',
+  '"It\'s probably going to be fine."',
+  '"The operating system your mother warned you about."',
+  '"Now with 47% more bits."',
+  '"Certified Pre-Owned™ by Noahsoft."',
+  '"Experience the journey. Don\'t ask about the destination."',
+  '"Pushing the envelope. Occasionally opening it."',
+  '"Where do you want to go today? (Please specify.)"',
+  '"Technology for the rest of us. And also some of them."',
+  '"Not responsible for lost data, time, or dignity."',
+  '"Powered by dreams, caffeine, and questionable decisions."',
+];
 
 const STATUS_MESSAGES = [
   "Initializing NS Doors 97...",
@@ -155,11 +147,50 @@ const BOOT_QUIPS = [
   "Defragmenting your enthusiasm...",
 ];
 
-function generateBootMessages(): string[] {
+// ── Content generators ─────────────────────────────────────────────────────
+
+interface BiosData {
+  year: number;
+  cpu: string;
+  ramBytes: number;
+  drive1: string;
+  drive2: string;
+  drive3: string;
+  pciCount: number;
+  irqNum: number;
+  irqStatus: string;
+  usb: string;
+  quip: string;
+  setupKey: string;
+}
+
+function generateBiosData(): BiosData {
+  const ramMB = pick([32, 64, 128, 256]);
+  return {
+    year:      1997 + Math.floor(Math.random() * 3),
+    cpu:       pick(CPUS),
+    ramBytes:  ramMB * 1024 * 1024,
+    drive1:    pick(DRIVES),
+    drive2:    Math.random() > 0.35 ? pick(DRIVES) : "None",
+    drive3:    Math.random() > 0.6  ? pick(DRIVES) : "None",
+    pciCount:  Math.floor(Math.random() * 5) + 1,
+    irqNum:    Math.floor(Math.random() * 15) + 1,
+    irqStatus: pick(IRQS),
+    usb:       pick(USB_STATUS),
+    quip:      pick(BIOS_QUIPS),
+    setupKey:  pick(SETUP_HINTS),
+  };
+}
+
+interface SplashData {
+  tagline: string;
+  bootMessages: string[];
+}
+
+function generateSplashData(): SplashData {
   const msgs = [...STATUS_MESSAGES];
-  const quipIdx = 3 + Math.floor(Math.random() * 4);
-  msgs.splice(quipIdx, 0, pick(BOOT_QUIPS));
-  return msgs;
+  msgs.splice(3 + Math.floor(Math.random() * 4), 0, pick(BOOT_QUIPS));
+  return { tagline: pick(TAGLINES), bootMessages: msgs };
 }
 
 // ── Audio ──────────────────────────────────────────────────────────────────
@@ -167,34 +198,28 @@ function generateBootMessages(): string[] {
 export function playShutdownSound(): void {
   try {
     const ctx = new AudioContext();
-    // Descending arpeggio — mirror image of startup
     const notes = [
-      { freq: 783.99, t: 0.0,  dur: 0.14 },  // G5
-      { freq: 659.25, t: 0.11, dur: 0.14 },  // E5
-      { freq: 523.25, t: 0.22, dur: 0.14 },  // C5
-      { freq: 392.0,  t: 0.33, dur: 0.14 },  // G4
-      { freq: 329.63, t: 0.44, dur: 0.14 },  // E4
-      { freq: 261.63, t: 0.55, dur: 0.55 },  // C4 — hold and fade out
+      { freq: 783.99, t: 0.0,  dur: 0.14 },
+      { freq: 659.25, t: 0.11, dur: 0.14 },
+      { freq: 523.25, t: 0.22, dur: 0.14 },
+      { freq: 392.0,  t: 0.33, dur: 0.14 },
+      { freq: 329.63, t: 0.44, dur: 0.14 },
+      { freq: 261.63, t: 0.55, dur: 0.55 },
     ];
     notes.forEach(({ freq, t, dur }) => {
       const osc = ctx.createOscillator();
-      const gn = ctx.createGain();
-      osc.connect(gn);
-      gn.connect(ctx.destination);
-      osc.type = "sine";
-      osc.frequency.value = freq;
+      const gn  = ctx.createGain();
+      osc.connect(gn); gn.connect(ctx.destination);
+      osc.type = "sine"; osc.frequency.value = freq;
       const at = ctx.currentTime + t;
       gn.gain.setValueAtTime(0, at);
       gn.gain.linearRampToValueAtTime(0.12, at + 0.015);
       gn.gain.setValueAtTime(0.12, at + dur - 0.05);
       gn.gain.linearRampToValueAtTime(0, at + dur);
-      osc.start(at);
-      osc.stop(at + dur + 0.01);
+      osc.start(at); osc.stop(at + dur + 0.01);
     });
     setTimeout(() => ctx.close(), 2500);
-  } catch {
-    // Audio not available — ignore
-  }
+  } catch { /* ignore */ }
 }
 
 function playPostBeep(): void {
@@ -202,70 +227,139 @@ function playPostBeep(): void {
     const ctx = new AudioContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.type = "square";
-    osc.frequency.value = 1000;
+    osc.connect(gain); gain.connect(ctx.destination);
+    osc.type = "square"; osc.frequency.value = 1000;
     const t = ctx.currentTime;
     gain.gain.setValueAtTime(0.15, t);
     gain.gain.setValueAtTime(0.15, t + 0.09);
     gain.gain.linearRampToValueAtTime(0, t + 0.11);
-    osc.start(t);
-    osc.stop(t + 0.12);
+    osc.start(t); osc.stop(t + 0.12);
     setTimeout(() => ctx.close(), 400);
-  } catch {
-    // Audio not available — ignore
-  }
+  } catch { /* ignore */ }
 }
 
 function playStartupSound(): void {
   try {
     const ctx = new AudioContext();
-    // Ascending arpeggio ↑ then a held chord — C major feel
     const notes = [
-      { freq: 261.63, t: 0.0,  dur: 0.14 },  // C4
-      { freq: 329.63, t: 0.11, dur: 0.14 },  // E4
-      { freq: 392.0,  t: 0.22, dur: 0.14 },  // G4
-      { freq: 523.25, t: 0.33, dur: 0.14 },  // C5
-      { freq: 659.25, t: 0.44, dur: 0.14 },  // E5
-      { freq: 783.99, t: 0.55, dur: 0.55 },  // G5 — hold
+      { freq: 261.63, t: 0.0,  dur: 0.14 },
+      { freq: 329.63, t: 0.11, dur: 0.14 },
+      { freq: 392.0,  t: 0.22, dur: 0.14 },
+      { freq: 523.25, t: 0.33, dur: 0.14 },
+      { freq: 659.25, t: 0.44, dur: 0.14 },
+      { freq: 783.99, t: 0.55, dur: 0.55 },
     ];
     notes.forEach(({ freq, t, dur }) => {
       const osc = ctx.createOscillator();
-      const gn = ctx.createGain();
-      osc.connect(gn);
-      gn.connect(ctx.destination);
-      osc.type = "sine";
-      osc.frequency.value = freq;
+      const gn  = ctx.createGain();
+      osc.connect(gn); gn.connect(ctx.destination);
+      osc.type = "sine"; osc.frequency.value = freq;
       const at = ctx.currentTime + t;
       gn.gain.setValueAtTime(0, at);
       gn.gain.linearRampToValueAtTime(0.12, at + 0.015);
       gn.gain.setValueAtTime(0.12, at + dur - 0.04);
       gn.gain.linearRampToValueAtTime(0, at + dur);
-      osc.start(at);
-      osc.stop(at + dur + 0.01);
+      osc.start(at); osc.stop(at + dur + 0.01);
     });
     setTimeout(() => ctx.close(), 2500);
-  } catch {
-    // Audio not available — ignore
+  } catch { /* ignore */ }
+}
+
+function playRandomBeep(): void {
+  try {
+    const ctx  = new AudioContext();
+    const osc  = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain); gain.connect(ctx.destination);
+    osc.type = "square";
+    osc.frequency.value = pick([440, 660, 880, 1100, 550, 770]);
+    const t   = ctx.currentTime;
+    const dur = 0.05 + Math.random() * 0.09;
+    gain.gain.setValueAtTime(0.13, t);
+    gain.gain.setValueAtTime(0.13, t + dur - 0.01);
+    gain.gain.linearRampToValueAtTime(0, t + dur);
+    osc.start(t); osc.stop(t + dur);
+    setTimeout(() => ctx.close(), 300);
+  } catch { /* ignore */ }
+}
+
+// ── BIOS animation helpers ─────────────────────────────────────────────────
+
+type ActiveDisplay =
+  | null
+  | { kind: "spin";    frame: number }
+  | { kind: "counter"; prefix: string; value: number; unit: string }
+  | { kind: "dots";    prefix: string; count: number };
+
+const SPIN_CHARS = ["|", "/", "-", "\\"];
+
+async function animateCounter(
+  setAct: (a: ActiveDisplay) => void,
+  prefix: string,
+  target: number,
+  unit: string,
+  sleep: (ms: number) => Promise<void>
+): Promise<void> {
+  let current = 0;
+  setAct({ kind: "counter", prefix, value: 0, unit });
+  while (current < target) {
+    await sleep(randomDelay({ base: 22, variance: 0.7, panicChance: 0.01, panicMultiplier: 12 }));
+    const delta = chunkIncrement({ avgChunk: target / 20, critChance: 0.08, critMultiplier: 4 });
+    current = Math.min(Math.round(current + delta), target);
+    setAct({ kind: "counter", prefix, value: current, unit });
+  }
+}
+
+async function animateDots(
+  setAct: (a: ActiveDisplay) => void,
+  prefix: string,
+  maxDots: number,
+  sleep: (ms: number) => Promise<void>
+): Promise<void> {
+  for (let d = 1; d <= maxDots; d++) {
+    setAct({ kind: "dots", prefix, count: d });
+    await sleep(randomDelay({ base: 210, variance: 0.5, panicChance: 0.05, panicMultiplier: 7 }));
+  }
+}
+
+async function animateSpin(
+  setAct: (a: ActiveDisplay) => void,
+  totalMs: number,
+  sleep: (ms: number) => Promise<void>
+): Promise<void> {
+  const frameMs = 110;
+  let elapsed = 0;
+  let frame = 0;
+  while (elapsed < totalMs) {
+    setAct({ kind: "spin", frame });
+    await sleep(Math.min(frameMs, totalMs - elapsed));
+    elapsed += frameMs;
+    frame = (frame + 1) % 4;
   }
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
 
-const SEGMENT_COUNT = 24;
+const SEGMENT_COUNT = 22;
 
 interface BootScreenProps {
   onComplete: () => void;
 }
 
 export default function BootScreen({ onComplete }: BootScreenProps) {
-  const [phase, setPhase] = useState<"bios" | "logo">("bios");
-  const [visibleLines, setVisibleLines] = useState<string[]>([]);
-  const [progress, setProgress] = useState(0);
-  const [statusMsg, setStatusMsg] = useState("");
+  const [phase, setPhase]               = useState<"bios" | "black" | "splash">("bios");
+  const [termLines, setTermLines]        = useState<string[]>([]);
+  const [active, setActive]             = useState<ActiveDisplay>(null);
+  const [splashProgress, setSplashProgress] = useState(0);
+  const [splashMsg, setSplashMsg]        = useState("");
 
-  const doneRef = useRef(false);
+  // Generate all random content once on mount
+  const contentRef = useRef<{ bios: BiosData; splash: SplashData } | null>(null);
+  if (!contentRef.current) {
+    contentRef.current = { bios: generateBiosData(), splash: generateSplashData() };
+  }
+
+  const doneRef       = useRef(false);
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
 
@@ -278,140 +372,217 @@ export default function BootScreen({ onComplete }: BootScreenProps) {
 
   // Backspace skips at any time
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Backspace") doComplete();
-    };
+    const handler = (e: KeyboardEvent) => { if (e.key === "Backspace") doComplete(); };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [doComplete]);
 
-  // Generate content exactly once (survives re-renders)
-  const contentRef = useRef<{ postLines: string[]; bootMessages: string[] } | null>(null);
-  if (!contentRef.current) {
-    contentRef.current = {
-      postLines: generatePostLines(),
-      bootMessages: generateBootMessages(),
-    };
-  }
-
-  // ── BIOS phase: reveal lines one by one ──────────────────────────────────
+  // ── Main async sequence (drives the entire boot) ─────────────────────────
   useEffect(() => {
-    const { postLines } = contentRef.current!;
-    let cancelled = false;
-    const timers: ReturnType<typeof setTimeout>[] = [];
+    const cancelRef = { current: false };
+    const sleep     = makeSleep(cancelRef);
+    const { bios, splash } = contentRef.current!;
 
-    playPostBeep();
+    const addLine = (text: string) =>
+      setTermLines((prev) => [...prev, text]);
 
-    let delay = 350;
-    postLines.forEach((line) => {
-      const d = delay;
-      timers.push(
-        setTimeout(() => {
-          if (!cancelled) setVisibleLines((prev) => [...prev, line]);
-        }, d)
-      );
-      // Empty lines appear instantly; text lines get a semi-random stagger
-      delay += line === "" ? 40 : 55 + Math.floor(Math.random() * 95);
-    });
+    async function runAll() {
+      try {
+        // ── BIOS phase ────────────────────────────────────────────────────
 
-    // After last line, pause then transition to logo
-    timers.push(
-      setTimeout(() => {
-        if (!cancelled) setPhase("logo");
-      }, delay + 950)
-    );
+        await sleep(randomDelay({ base: 220, variance: 0.4 }));
+        playPostBeep();
+        addLine(`Noahsoft BIOS v2.6.${bios.year}  —  Copyright (C) ${bios.year} Noahsoft Corp.`);
+        addLine("");
 
-    return () => {
-      cancelled = true;
-      timers.forEach(clearTimeout);
-    };
+        // CPU
+        await sleep(randomDelay({ base: 270, variance: 0.5 }));
+        addLine(`CPU: ${bios.cpu}`);
+
+        // RAM — count up in bytes
+        await sleep(randomDelay({ base: 180, variance: 0.4 }));
+        await animateCounter(setActive, "Memory: ", bios.ramBytes, " bytes", sleep);
+        setActive(null);
+        addLine(`Memory: ${bios.ramBytes.toLocaleString()} bytes  OK`);
+
+        addLine("");
+
+        // Drive detection with dots
+        await sleep(randomDelay({ base: 320, variance: 0.5 }));
+        await animateDots(setActive, "Primary IDE Master ", 6, sleep);
+        setActive(null);
+        addLine(`Primary IDE Master ...... ${bios.drive1}`);
+
+        await sleep(randomDelay({ base: 200, variance: 0.5, panicChance: 0.06 }));
+        await animateDots(setActive, "Primary IDE Slave ", 7, sleep);
+        setActive(null);
+        addLine(`Primary IDE Slave ....... ${bios.drive2}`);
+
+        await sleep(randomDelay({ base: 160, variance: 0.5 }));
+        await animateDots(setActive, "Secondary IDE Master ", 4, sleep);
+        setActive(null);
+        addLine(`Secondary IDE Master .... ${bios.drive3}`);
+
+        addLine("");
+
+        // PCI scan with dots
+        await sleep(randomDelay({ base: 210, variance: 0.5 }));
+        await animateDots(setActive, "PCI Bus scan ", 5, sleep);
+        setActive(null);
+        addLine(`PCI Bus: ${bios.pciCount} device(s) found`);
+
+        // IRQ + USB
+        await sleep(randomDelay({ base: 200, variance: 0.5, panicChance: 0.06 }));
+        addLine(`IRQ${bios.irqNum}: ${bios.irqStatus}`);
+
+        await sleep(randomDelay({ base: 180, variance: 0.5 }));
+        addLine(`USB: ${bios.usb}`);
+
+        addLine("");
+
+        // ── Spooky long wait + quip ──
+        const spinMs = randomDelay({
+          base: 750, variance: 0.5, panicChance: 0.15, panicMultiplier: 7,
+        });
+        await animateSpin(setActive, spinMs, sleep);
+        setActive(null);
+        addLine(bios.quip);
+
+        addLine("");
+
+        // Random abrupt beep (40%)
+        if (Math.random() < 0.4) {
+          await sleep(randomDelay({ base: 140, variance: 0.4 }));
+          playRandomBeep();
+        }
+
+        // SETUP keys + skip hint
+        await sleep(randomDelay({ base: 220, variance: 0.4 }));
+        addLine(bios.setupKey);
+
+        await sleep(randomDelay({ base: 160, variance: 0.4 }));
+        addLine("[Press Backspace to skip]");
+
+        // Final pause — let the user read / panic
+        await sleep(randomDelay({ base: 1600, variance: 0.3, panicChance: 0.1, panicMultiplier: 3 }));
+
+        // ── Black screen (abrupt screen clear) ───────────────────────────
+        setPhase("black");
+        await sleep(550);
+
+        // ── Splash phase (abrupt appearance) ─────────────────────────────
+        setPhase("splash");
+        setSplashMsg(splash.bootMessages[0]);
+        setSplashProgress(0);
+        playStartupSound();
+
+        let p = 0;
+        while (p < 100) {
+          await sleep(randomDelay({ base: 185, variance: 0.7, panicChance: 0.09, panicMultiplier: 6 }));
+          const delta = chunkIncrement({ avgChunk: 3, critChance: 0.12, critMultiplier: 5 });
+          p = Math.min(p + delta, 100);
+          setSplashProgress(p);
+          const msgIdx = Math.min(
+            Math.floor((p / 100) * splash.bootMessages.length),
+            splash.bootMessages.length - 1
+          );
+          setSplashMsg(splash.bootMessages[msgIdx]);
+          // Random extra beep (7% per step)
+          if (Math.random() < 0.07) playRandomBeep();
+        }
+
+        // Brief hold at 100% then cut to desktop — no fade
+        await sleep(200);
+        doComplete();
+
+      } catch {
+        // Cancelled (backspace skip or unmount)
+      }
+    }
+
+    runAll();
+    return () => { cancelRef.current = true; };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Logo phase: animate progress bar ────────────────────────────────────
-  useEffect(() => {
-    if (phase !== "logo") return;
-    const { bootMessages } = contentRef.current!;
+  // ── Render ────────────────────────────────────────────────────────────────
 
-    let cancelled = false;
-    setProgress(0);
-    setStatusMsg(bootMessages[0]);
-    playStartupSound();
+  const filledSegments = Math.round((splashProgress / 100) * SEGMENT_COUNT);
 
-    let p = 0;
-    const id = setInterval(() => {
-      if (cancelled) return;
-      p += 1.1 + Math.random() * 2.4;
-      if (p >= 100) {
-        p = 100;
-        clearInterval(id);
-        setProgress(100);
-        setStatusMsg(bootMessages[bootMessages.length - 1]);
-        setTimeout(() => {
-          if (!cancelled) doComplete();
-        }, 750);
-      } else {
-        setProgress(p);
-        const msgIdx = Math.min(
-          Math.floor((p / 100) * bootMessages.length),
-          bootMessages.length - 1
-        );
-        setStatusMsg(bootMessages[msgIdx]);
-      }
-    }, 38);
-
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, [phase, doComplete]);
-
-  const filledSegments = Math.round((progress / 100) * SEGMENT_COUNT);
-
-  // ── BIOS terminal ────────────────────────────────────────────────────────
-  if (phase === "bios") {
-    return (
-      <div className="boot-bios">
-        {visibleLines.map((line, i) => {
-          if (line === "") return <div key={i} className="boot-bios__spacer" />;
-          if (line.startsWith("["))
-            return <div key={i} className="boot-bios__skip">{line}</div>;
-          if (i === 0)
-            return <div key={i} className="boot-bios__header">{line}</div>;
-          return <div key={i} className="boot-bios__line">{line}</div>;
-        })}
-        <span className="boot-bios__cursor" aria-hidden />
-      </div>
-    );
-  }
-
-  // ── Boot logo ────────────────────────────────────────────────────────────
   return (
-    <div className="boot-logo">
-      <div className="boot-logo__center">
-        <div className="boot-logo__brand">Noahsoft</div>
-        <div className="boot-logo__title">NS Doors 97</div>
-        <div className="boot-logo__tagline">© 1997 Noahsoft Corporation. All rights reserved.</div>
-      </div>
+    <div className="boot-overlay">
 
-      <div className="boot-logo__progress-area">
-        <div
-          className="boot-logo__bar"
-          role="progressbar"
-          aria-valuenow={Math.round(progress)}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          {Array.from({ length: SEGMENT_COUNT }, (_, i) => (
-            <div
-              key={i}
-              className={`boot-logo__segment${i < filledSegments ? " boot-logo__segment--on" : ""}`}
-            />
-          ))}
+      {/* ── BIOS terminal ── */}
+      {phase === "bios" && (
+        <div className="boot-bios">
+          {termLines.map((line, i) => {
+            if (line === "")          return <div key={i} className="boot-bios__spacer" />;
+            if (line.startsWith("[")) return <div key={i} className="boot-bios__skip">{line}</div>;
+            if (i === 0)              return <div key={i} className="boot-bios__header">{line}</div>;
+            return <div key={i} className="boot-bios__line">{line}</div>;
+          })}
+
+          {/* Active element / cursor */}
+          {active?.kind === "counter" && (
+            <div className="boot-bios__line">
+              {active.prefix}{active.value.toLocaleString()}{active.unit}
+              <span className="boot-bios__cursor" aria-hidden />
+            </div>
+          )}
+          {active?.kind === "dots" && (
+            <div className="boot-bios__line">
+              {active.prefix}{".".repeat(active.count)}
+              <span className="boot-bios__cursor" aria-hidden />
+            </div>
+          )}
+          {active?.kind === "spin" && (
+            <div className="boot-bios__cursor-line">
+              <span className="boot-bios__spin-char" aria-hidden>
+                {SPIN_CHARS[active.frame % 4]}
+              </span>
+            </div>
+          )}
+          {active === null && (
+            <div className="boot-bios__cursor-line">
+              <span className="boot-bios__cursor" aria-hidden />
+            </div>
+          )}
         </div>
-        <div className="boot-logo__status">{statusMsg}</div>
-      </div>
+      )}
 
-      <div className="boot-logo__skip-hint">Backspace to skip</div>
+      {/* phase === "black": just the overlay background — nothing rendered */}
+
+      {/* ── Splash screen (abrupt, no fade) ── */}
+      {phase === "splash" && (
+        <div className="boot-splash">
+          <div className="boot-splash__top">
+            <div className="boot-splash__brand">Noahsoft</div>
+            <div className="boot-splash__logo">🚪</div>
+            <div className="boot-splash__title">DOORS 97</div>
+            <div className="boot-splash__tagline">{contentRef.current?.splash.tagline}</div>
+          </div>
+
+          <div className="boot-splash__bottom">
+            <div
+              className="boot-splash__bar"
+              role="progressbar"
+              aria-valuenow={Math.round(splashProgress)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              {Array.from({ length: SEGMENT_COUNT }, (_, i) => (
+                <div
+                  key={i}
+                  className={`boot-splash__segment${i < filledSegments ? " boot-splash__segment--on" : ""}`}
+                />
+              ))}
+            </div>
+            <div className="boot-splash__status">{splashMsg}</div>
+          </div>
+
+          <div className="boot-splash__skip">Backspace to skip</div>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/src/experiences/NsDoors97/BootScreen.tsx
+++ b/src/experiences/NsDoors97/BootScreen.tsx
@@ -1,0 +1,384 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import "./BootScreen.css";
+
+// ── localStorage helpers ───────────────────────────────────────────────────
+
+const BOOT_KEY = "ns_doors_last_boot";
+const BOOT_COOLDOWN = 30 * 60 * 1000; // 30 minutes
+
+export function shouldShowBoot(): boolean {
+  try {
+    const raw = localStorage.getItem(BOOT_KEY);
+    if (!raw) return true;
+    const ts = parseInt(raw, 10);
+    return isNaN(ts) || Date.now() - ts > BOOT_COOLDOWN;
+  } catch {
+    return false;
+  }
+}
+
+function markBooted(): void {
+  try {
+    localStorage.setItem(BOOT_KEY, String(Date.now()));
+  } catch {
+    // ignore
+  }
+}
+
+// ── Random content pools ───────────────────────────────────────────────────
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+const CPUS = [
+  "Noahsoft Turbocore 9000 — 233MHz",
+  "NXP Munchmaster Pro — 166MHz",
+  "Generic Brand CPU — 133MHz (Patent Pending)",
+  "AMD K6-2 — 266MHz (Slightly Overcooked)",
+  "Intel Celeryon 300A (Turbo NOT Enabled)",
+  "Cyrix 6x86 PR200+ — Just Trust Us",
+  "IDT WinChip 2 — 200MHz (Smells Like Burning)",
+  "Noahsoft Hexacore Jr. — 450MHz (Theoretical)",
+];
+
+const DRIVES = [
+  "NOAHSOFT HDD — 540MB [ULTRA-SLOW MODE]",
+  "MAXHARDISK QX — 1.2GB [LBA ENABLED]",
+  "QUANTUM FIREBALL — 810MB [WARRANTY VOID]",
+  "TOSHIBA CD-ROM 4X [ATAPI] [DUSTY]",
+  "MITSUMI CD-ROM — ONLY READS AOL DISCS",
+  "IOMEGA ZIP 100 — CLICK OF DOOM DETECTED",
+  "SEAGATE MEDALIST — 2.1GB [LOUD]",
+  "GENERIC CD-RW — BURNS AT 1X OUT OF SPITE",
+];
+
+const IRQS = [
+  "Assigned to keyboard",
+  "Assigned to mouse",
+  "Assigned to unknown device",
+  "Free but haunted",
+  "Reserved (do not disturb)",
+  "Assigned to your feelings",
+  "Conflicted (aren't we all)",
+  "Claimed by a device that no longer exists",
+];
+
+const USB_STATUS = [
+  "2 ports found (neither working reliably)",
+  "No USB found — as expected",
+  "USB found but it is basically decoration",
+  "3 ports detected, 1 owned by a mystery device",
+  "USB 1.1 — enjoy your 12 Mbps",
+];
+
+const BIOS_QUIPS = [
+  "BIOS extension loaded — warranty may already be void",
+  "Running memory test... just kidding, skipping it",
+  "CMOS settings OK (probably)",
+  "BIOS update available: NoahBIOS v3.0 — requires 27 floppy disks",
+  "Plug and Pray devices detected: 3",
+  "Scanning for gremlins in memory... none found (yet)",
+  "Checking hard drive... please hold... still holding...",
+  "Boot sequence optimized for maximum nostalgia",
+  "Verifying system integrity... integrity is vibing",
+  "This BIOS has not been updated since 1997. Consider updating. (Don't.)",
+  "S.M.A.R.T. status: Drive says it's fine. It always says that.",
+  "Shadow RAM enabled: your secrets are safe",
+  "Energy Star compliant: it uses energy, anyway",
+  "Checking for Y2K issues... results inconclusive",
+];
+
+const SETUP_HINTS = [
+  "DEL to enter SETUP         F8 for Boot Menu",
+  "Press DEL for BIOS Setup     F12 for network boot",
+  "F2 = BIOS Setup    F10 = Boot Select    ESC = Panic",
+];
+
+function generatePostLines(): string[] {
+  const year = 1997 + Math.floor(Math.random() * 3);
+  const ramMB = pick([32, 64, 128, 256]);
+  const drive1 = pick(DRIVES);
+  const drive2 = Math.random() > 0.35 ? pick(DRIVES) : "None";
+  const drive3 = Math.random() > 0.6 ? pick(DRIVES) : "None";
+  const irqNum = Math.floor(Math.random() * 15) + 1;
+  const pciCount = Math.floor(Math.random() * 5) + 1;
+
+  return [
+    `Noahsoft BIOS v2.6.${year}  —  Copyright (C) ${year} Noahsoft Corp.`,
+    "",
+    `CPU: ${pick(CPUS)}`,
+    `Memory: ${ramMB * 1024}K OK`,
+    "",
+    `Primary IDE Master ...... ${drive1}`,
+    `Primary IDE Slave ....... ${drive2}`,
+    `Secondary IDE Master .... ${drive3}`,
+    "",
+    `PCI Bus scan: ${pciCount} device(s) found`,
+    `IRQ${irqNum}: ${pick(IRQS)}`,
+    `USB: ${pick(USB_STATUS)}`,
+    "",
+    pick(BIOS_QUIPS),
+    "",
+    pick(SETUP_HINTS),
+    "[Press Backspace to skip]",
+  ];
+}
+
+const STATUS_MESSAGES = [
+  "Initializing NS Doors 97...",
+  "Loading system registry...",
+  "Starting virtual device drivers...",
+  "Initializing memory manager...",
+  "Loading display driver...",
+  "Configuring system devices...",
+  "Starting network services...",
+  "Loading desktop shell...",
+  "Almost there...",
+  "NS Doors 97 ready.",
+];
+
+const BOOT_QUIPS = [
+  "Negotiating with the hamsters...",
+  "Untangling the internet cables...",
+  "Installing unnecessary toolbars...",
+  "Scanning for viruses (not finding any, feeling guilty)...",
+  "Loading 47 startup programs you didn't ask for...",
+  "Preparing to ask you to register this software...",
+  "Buffering... buffering...",
+  "Contacting Noahsoft activation servers (they're asleep)...",
+  "Applying unnecessary visual effects...",
+  "Parsing the registry (it's fine, don't look at it)...",
+  "Counting your Recycle Bin items... empty? Really?",
+  "Calibrating the cup holder driver...",
+  "Locating Clippy... please wait...",
+  "Defragmenting your enthusiasm...",
+];
+
+function generateBootMessages(): string[] {
+  const msgs = [...STATUS_MESSAGES];
+  const quipIdx = 3 + Math.floor(Math.random() * 4);
+  msgs.splice(quipIdx, 0, pick(BOOT_QUIPS));
+  return msgs;
+}
+
+// ── Audio ──────────────────────────────────────────────────────────────────
+
+function playPostBeep(): void {
+  try {
+    const ctx = new AudioContext();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "square";
+    osc.frequency.value = 1000;
+    const t = ctx.currentTime;
+    gain.gain.setValueAtTime(0.15, t);
+    gain.gain.setValueAtTime(0.15, t + 0.09);
+    gain.gain.linearRampToValueAtTime(0, t + 0.11);
+    osc.start(t);
+    osc.stop(t + 0.12);
+    setTimeout(() => ctx.close(), 400);
+  } catch {
+    // Audio not available — ignore
+  }
+}
+
+function playStartupSound(): void {
+  try {
+    const ctx = new AudioContext();
+    // Ascending arpeggio ↑ then a held chord — C major feel
+    const notes = [
+      { freq: 261.63, t: 0.0,  dur: 0.14 },  // C4
+      { freq: 329.63, t: 0.11, dur: 0.14 },  // E4
+      { freq: 392.0,  t: 0.22, dur: 0.14 },  // G4
+      { freq: 523.25, t: 0.33, dur: 0.14 },  // C5
+      { freq: 659.25, t: 0.44, dur: 0.14 },  // E5
+      { freq: 783.99, t: 0.55, dur: 0.55 },  // G5 — hold
+    ];
+    notes.forEach(({ freq, t, dur }) => {
+      const osc = ctx.createOscillator();
+      const gn = ctx.createGain();
+      osc.connect(gn);
+      gn.connect(ctx.destination);
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      const at = ctx.currentTime + t;
+      gn.gain.setValueAtTime(0, at);
+      gn.gain.linearRampToValueAtTime(0.12, at + 0.015);
+      gn.gain.setValueAtTime(0.12, at + dur - 0.04);
+      gn.gain.linearRampToValueAtTime(0, at + dur);
+      osc.start(at);
+      osc.stop(at + dur + 0.01);
+    });
+    setTimeout(() => ctx.close(), 2500);
+  } catch {
+    // Audio not available — ignore
+  }
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+const SEGMENT_COUNT = 24;
+
+interface BootScreenProps {
+  onComplete: () => void;
+}
+
+export default function BootScreen({ onComplete }: BootScreenProps) {
+  const [phase, setPhase] = useState<"bios" | "logo">("bios");
+  const [visibleLines, setVisibleLines] = useState<string[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [statusMsg, setStatusMsg] = useState("");
+
+  const doneRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const doComplete = useCallback(() => {
+    if (doneRef.current) return;
+    doneRef.current = true;
+    markBooted();
+    onCompleteRef.current();
+  }, []);
+
+  // Backspace skips at any time
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Backspace") doComplete();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [doComplete]);
+
+  // Generate content exactly once (survives re-renders)
+  const contentRef = useRef<{ postLines: string[]; bootMessages: string[] } | null>(null);
+  if (!contentRef.current) {
+    contentRef.current = {
+      postLines: generatePostLines(),
+      bootMessages: generateBootMessages(),
+    };
+  }
+
+  // ── BIOS phase: reveal lines one by one ──────────────────────────────────
+  useEffect(() => {
+    const { postLines } = contentRef.current!;
+    let cancelled = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    playPostBeep();
+
+    let delay = 350;
+    postLines.forEach((line) => {
+      const d = delay;
+      timers.push(
+        setTimeout(() => {
+          if (!cancelled) setVisibleLines((prev) => [...prev, line]);
+        }, d)
+      );
+      // Empty lines appear instantly; text lines get a semi-random stagger
+      delay += line === "" ? 40 : 55 + Math.floor(Math.random() * 95);
+    });
+
+    // After last line, pause then transition to logo
+    timers.push(
+      setTimeout(() => {
+        if (!cancelled) setPhase("logo");
+      }, delay + 950)
+    );
+
+    return () => {
+      cancelled = true;
+      timers.forEach(clearTimeout);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Logo phase: animate progress bar ────────────────────────────────────
+  useEffect(() => {
+    if (phase !== "logo") return;
+    const { bootMessages } = contentRef.current!;
+
+    let cancelled = false;
+    setProgress(0);
+    setStatusMsg(bootMessages[0]);
+    playStartupSound();
+
+    let p = 0;
+    const id = setInterval(() => {
+      if (cancelled) return;
+      p += 1.1 + Math.random() * 2.4;
+      if (p >= 100) {
+        p = 100;
+        clearInterval(id);
+        setProgress(100);
+        setStatusMsg(bootMessages[bootMessages.length - 1]);
+        setTimeout(() => {
+          if (!cancelled) doComplete();
+        }, 750);
+      } else {
+        setProgress(p);
+        const msgIdx = Math.min(
+          Math.floor((p / 100) * bootMessages.length),
+          bootMessages.length - 1
+        );
+        setStatusMsg(bootMessages[msgIdx]);
+      }
+    }, 38);
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [phase, doComplete]);
+
+  const filledSegments = Math.round((progress / 100) * SEGMENT_COUNT);
+
+  // ── BIOS terminal ────────────────────────────────────────────────────────
+  if (phase === "bios") {
+    return (
+      <div className="boot-bios">
+        {visibleLines.map((line, i) => {
+          if (line === "") return <div key={i} className="boot-bios__spacer" />;
+          if (line.startsWith("["))
+            return <div key={i} className="boot-bios__skip">{line}</div>;
+          if (i === 0)
+            return <div key={i} className="boot-bios__header">{line}</div>;
+          return <div key={i} className="boot-bios__line">{line}</div>;
+        })}
+        <span className="boot-bios__cursor" aria-hidden />
+      </div>
+    );
+  }
+
+  // ── Boot logo ────────────────────────────────────────────────────────────
+  return (
+    <div className="boot-logo">
+      <div className="boot-logo__center">
+        <div className="boot-logo__brand">Noahsoft</div>
+        <div className="boot-logo__title">NS Doors 97</div>
+        <div className="boot-logo__tagline">© 1997 Noahsoft Corporation. All rights reserved.</div>
+      </div>
+
+      <div className="boot-logo__progress-area">
+        <div
+          className="boot-logo__bar"
+          role="progressbar"
+          aria-valuenow={Math.round(progress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          {Array.from({ length: SEGMENT_COUNT }, (_, i) => (
+            <div
+              key={i}
+              className={`boot-logo__segment${i < filledSegments ? " boot-logo__segment--on" : ""}`}
+            />
+          ))}
+        </div>
+        <div className="boot-logo__status">{statusMsg}</div>
+      </div>
+
+      <div className="boot-logo__skip-hint">Backspace to skip</div>
+    </div>
+  );
+}

--- a/src/experiences/NsDoors97/NsDoors97.css
+++ b/src/experiences/NsDoors97/NsDoors97.css
@@ -143,3 +143,18 @@
   color: #555555;
   margin: 0;
 }
+
+/* ── Shutdown / restart overlay ──────────────────────────────────────────── */
+
+.ns-shutdown-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  background: #000;
+  animation: ns-shutdown-fadein 0.35s ease-out forwards;
+}
+
+@keyframes ns-shutdown-fadein {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { experiences, type Experience } from "../../data/experiences";
 import { missingFeatureMessage } from "../../utils/missingFeatureMessage";
+import { randomDelay } from "../../utils/retroTiming";
 import { useOsDialog } from "./OsDialog";
 import DesktopIcon from "./DesktopIcon";
 import Window from "./Window";
@@ -119,17 +120,81 @@ export default function NsDoors97() {
   const navigate = useNavigate();
   const { showDialog } = useOsDialog();
 
-  const [showBoot, setShowBoot] = useState(() => shouldShowBoot());
-  const [shuttingDown, setShuttingDown] = useState(false);
+  const [showBoot, setShowBoot]           = useState(() => shouldShowBoot());
+  const [shuttingDown, setShuttingDown]   = useState(false);
+  const [desktopLoading, setDesktopLoading] = useState(false);
+
+  // Icons visible on desktop — starts empty when there's a boot screen,
+  // all-visible immediately when there isn't one.
+  const [visibleIcons, setVisibleIcons] = useState<ReadonlySet<string>>(() => {
+    if (shouldShowBoot()) return new Set<string>();
+    return new Set(ALL_DESKTOP_ICONS.map((d) => d.id));
+  });
+
+  // Called when the boot screen finishes (both initial boot and after restart)
+  const handleBootComplete = useCallback(() => {
+    setShowBoot(false);
+    setDesktopLoading(true);
+  }, []);
 
   const handleRestart = useCallback(() => {
     playShutdownSound();
     setShuttingDown(true);
+    setVisibleIcons(new Set()); // icons will re-pop-in after boot
     setTimeout(() => {
       setShuttingDown(false);
       setShowBoot(true);
     }, 1500);
   }, []);
+
+  // ── Janky desktop startup ────────────────────────────────────────────────
+  useEffect(() => {
+    if (!desktopLoading) return;
+
+    let cancelled = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const t = (cb: () => void, ms: number) => {
+      const id = setTimeout(() => { if (!cancelled) cb(); }, ms);
+      timers.push(id);
+    };
+
+    // Phase 1 — hourglass while "system initialises"
+    document.body.style.cursor = "wait";
+
+    const phase1 = randomDelay({ base: 900, variance: 0.6, panicChance: 0.15, panicMultiplier: 4 });
+    t(() => {
+      document.body.style.cursor = "";
+
+      // Phase 2 — icons pop in one by one in random order
+      const shuffled = [...ALL_DESKTOP_ICONS.map((d) => d.id)];
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      }
+
+      let iconDelay = 0;
+      shuffled.forEach((id) => {
+        iconDelay += randomDelay({ base: 130, variance: 0.8, panicChance: 0.03, panicMultiplier: 5 });
+        t(() => setVisibleIcons((prev) => new Set([...prev, id])), iconDelay);
+      });
+
+      // Maybe flash hourglass again partway through — 55% chance
+      if (Math.random() < 0.55) {
+        const freezeAt  = iconDelay * (0.25 + Math.random() * 0.35);
+        const freezeFor = randomDelay({ base: 700, variance: 0.5, panicChance: 0.12, panicMultiplier: 4 });
+        t(() => { document.body.style.cursor = "wait"; }, freezeAt);
+        t(() => { document.body.style.cursor = ""; },     freezeAt + freezeFor);
+      }
+
+      t(() => setDesktopLoading(false), iconDelay + 100);
+    }, phase1);
+
+    return () => {
+      cancelled = true;
+      document.body.style.cursor = "";
+      timers.forEach(clearTimeout);
+    };
+  }, [desktopLoading]);
 
   const [openWindows, setOpenWindows] = useState<OpenWindow[]>([]);
   const [activeWindowId, setActiveWindowId] = useState<string | null>(null);
@@ -249,9 +314,9 @@ export default function NsDoors97() {
 
   return (
     <div className="ns-desktop">
-      {/* ── Icon grid ── */}
+      {/* ── Icon grid (icons pop in one by one during boot) ── */}
       <div className="ns-desktop__icons">
-        {ALL_DESKTOP_ICONS.map((def) => (
+        {ALL_DESKTOP_ICONS.filter((def) => visibleIcons.has(def.id)).map((def) => (
           <DesktopIcon
             key={def.id}
             id={def.id}
@@ -355,7 +420,7 @@ export default function NsDoors97() {
 
       {/* ── Boot screen (renders on top of everything) ── */}
       {showBoot && (
-        <BootScreen onComplete={() => setShowBoot(false)} />
+        <BootScreen onComplete={handleBootComplete} />
       )}
     </div>
   );

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -12,6 +12,7 @@ import AboutApp from "./AboutApp";
 import FolderApp from "./FolderApp";
 import InternetApp from "./InternetApp";
 import TicTacToe from "../TicTacToe/TicTacToe";
+import BootScreen, { shouldShowBoot } from "./BootScreen";
 import "./NsDoors97.css";
 
 // ── Icon / experience config ───────────────────────────────────────────────
@@ -117,6 +118,8 @@ function AppLauncher({
 export default function NsDoors97() {
   const navigate = useNavigate();
   const { showDialog } = useOsDialog();
+
+  const [showBoot, setShowBoot] = useState(() => shouldShowBoot());
 
   const [openWindows, setOpenWindows] = useState<OpenWindow[]>([]);
   const [activeWindowId, setActiveWindowId] = useState<string | null>(null);
@@ -334,6 +337,11 @@ export default function NsDoors97() {
             resetIdleTimer();
           }}
         />
+      )}
+
+      {/* ── Boot screen (renders on top of everything) ── */}
+      {showBoot && (
+        <BootScreen onComplete={() => setShowBoot(false)} />
       )}
     </div>
   );

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -12,7 +12,7 @@ import AboutApp from "./AboutApp";
 import FolderApp from "./FolderApp";
 import InternetApp from "./InternetApp";
 import TicTacToe from "../TicTacToe/TicTacToe";
-import BootScreen, { shouldShowBoot } from "./BootScreen";
+import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import "./NsDoors97.css";
 
 // ── Icon / experience config ───────────────────────────────────────────────
@@ -120,6 +120,16 @@ export default function NsDoors97() {
   const { showDialog } = useOsDialog();
 
   const [showBoot, setShowBoot] = useState(() => shouldShowBoot());
+  const [shuttingDown, setShuttingDown] = useState(false);
+
+  const handleRestart = useCallback(() => {
+    playShutdownSound();
+    setShuttingDown(true);
+    setTimeout(() => {
+      setShuttingDown(false);
+      setShowBoot(true);
+    }, 1500);
+  }, []);
 
   const [openWindows, setOpenWindows] = useState<OpenWindow[]>([]);
   const [activeWindowId, setActiveWindowId] = useState<string | null>(null);
@@ -326,6 +336,7 @@ export default function NsDoors97() {
         windows={openWindows.map((w) => ({ id: w.id, title: w.title, icon: w.icon }))}
         activeWindowId={activeWindowId}
         onWindowFocus={focusWindow}
+        onRestart={handleRestart}
       />
 
       {/* ── Screensaver overlay ── */}
@@ -338,6 +349,9 @@ export default function NsDoors97() {
           }}
         />
       )}
+
+      {/* ── Shutdown overlay (black screen while restarting) ── */}
+      {shuttingDown && <div className="ns-shutdown-overlay" />}
 
       {/* ── Boot screen (renders on top of everything) ── */}
       {showBoot && (

--- a/src/experiences/NsDoors97/Taskbar.css
+++ b/src/experiences/NsDoors97/Taskbar.css
@@ -15,6 +15,101 @@
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.6);
 }
 
+/* ── Start button area (positions the popup menu) ───────────────────────── */
+
+.ns-taskbar__start-area {
+  position: relative;
+  flex-shrink: 0;
+}
+
+/* ── Start menu popup ────────────────────────────────────────────────────── */
+
+.ns-start-menu {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 3px;
+  width: 234px;
+  display: flex;
+  background: #3a1800;
+  border: 2px solid;
+  border-color: #ff9a44 #330000 #330000 #ff9a44;
+  box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.85);
+  z-index: 9600;
+}
+
+.ns-start-menu__sidebar {
+  width: 26px;
+  flex-shrink: 0;
+  background: linear-gradient(0deg, #5b2d8e 0%, #2a0060 100%);
+  display: flex;
+  align-items: flex-end;
+  padding-bottom: 8px;
+}
+
+.ns-start-menu__sidebar-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.14em;
+  white-space: nowrap;
+  padding-left: 5px;
+}
+
+.ns-start-menu__items {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 3px 0;
+}
+
+.ns-start-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px 7px 8px;
+  cursor: pointer;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #ffcc88;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  line-height: 1.3;
+}
+
+.ns-start-menu__item:hover {
+  background: linear-gradient(90deg, #cc4400 0%, #ff6b00 100%);
+  color: #ffffff;
+}
+
+.ns-start-menu__item-icon {
+  font-size: 15px;
+  width: 22px;
+  text-align: center;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.ns-start-menu__item-label {
+  flex: 1;
+}
+
+.ns-start-menu__item-arrow {
+  font-size: 6px;
+  opacity: 0.6;
+}
+
+.ns-start-menu__divider {
+  height: 0;
+  border-top: 1px solid #330000;
+  border-bottom: 1px solid #7a3a00;
+  margin: 4px 8px;
+}
+
 /* ── Start / Open button ─────────────────────────────────────────────────── */
 
 .ns-taskbar__start {
@@ -41,7 +136,8 @@
   background: linear-gradient(180deg, #ff8a2a 0%, #dd5500 100%);
 }
 
-.ns-taskbar__start:active {
+.ns-taskbar__start:active,
+.ns-taskbar__start--active {
   border-color: #664400 #ffcc88 #ffcc88 #664400;
   background: linear-gradient(180deg, #cc4400 0%, #ff7a1a 100%);
 }

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { missingFeatureMessage } from "../../utils/missingFeatureMessage";
 import { useOsDialog } from "./OsDialog";
 import "./Taskbar.css";
@@ -13,6 +13,7 @@ interface TaskbarProps {
   windows: TaskbarWindowEntry[];
   activeWindowId: string | null;
   onWindowFocus: (id: string) => void;
+  onRestart: () => void;
 }
 
 // ── Retro clock: real time, date shifted 30 years back ────────────────────────
@@ -92,21 +93,83 @@ function FullscreenButton() {
   );
 }
 
+// ── Start menu ────────────────────────────────────────────────────────────────
+
+const START_MENU_ITEMS = [
+  { id: "programs", icon: "📂", label: "Programs",  arrow: true  },
+  { id: "settings", icon: "⚙️",  label: "Settings",  arrow: true  },
+  { id: "help",     icon: "❓",  label: "Help",       arrow: false },
+] as const;
+
 // ── Taskbar ───────────────────────────────────────────────────────────────────
 
-export default function Taskbar({ windows, activeWindowId, onWindowFocus }: TaskbarProps) {
+export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRestart }: TaskbarProps) {
   const { showDialog } = useOsDialog();
+  const [startOpen, setStartOpen] = useState(false);
+  const startAreaRef = useRef<HTMLDivElement>(null);
 
-  function handleStartClick() {
+  // Close on outside click
+  useEffect(() => {
+    if (!startOpen) return;
+    function handler(e: MouseEvent) {
+      if (startAreaRef.current && !startAreaRef.current.contains(e.target as Node)) {
+        setStartOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [startOpen]);
+
+  const handlePlaceholder = useCallback(() => {
+    setStartOpen(false);
     showDialog(missingFeatureMessage());
-  }
+  }, [showDialog]);
+
+  const handleRestart = useCallback(() => {
+    setStartOpen(false);
+    onRestart();
+  }, [onRestart]);
 
   return (
     <div className="ns-taskbar">
-      <button className="ns-taskbar__start" onClick={handleStartClick}>
-        <span className="ns-taskbar__start-logo">🚪</span>
-        <span className="ns-taskbar__start-label">Open</span>
-      </button>
+      {/* ── Start button + menu ── */}
+      <div className="ns-taskbar__start-area" ref={startAreaRef}>
+        {startOpen && (
+          <div className="ns-start-menu">
+            <div className="ns-start-menu__sidebar">
+              <span className="ns-start-menu__sidebar-text">NS DOORS 97</span>
+            </div>
+            <div className="ns-start-menu__items">
+              {START_MENU_ITEMS.map((item) => (
+                <button
+                  key={item.id}
+                  className="ns-start-menu__item"
+                  onClick={handlePlaceholder}
+                >
+                  <span className="ns-start-menu__item-icon">{item.icon}</span>
+                  <span className="ns-start-menu__item-label">{item.label}</span>
+                  {item.arrow && <span className="ns-start-menu__item-arrow">▶</span>}
+                </button>
+              ))}
+
+              <div className="ns-start-menu__divider" />
+
+              <button className="ns-start-menu__item ns-start-menu__item--restart" onClick={handleRestart}>
+                <span className="ns-start-menu__item-icon">🔄</span>
+                <span className="ns-start-menu__item-label">Restart...</span>
+              </button>
+            </div>
+          </div>
+        )}
+
+        <button
+          className={`ns-taskbar__start${startOpen ? " ns-taskbar__start--active" : ""}`}
+          onClick={() => setStartOpen((v) => !v)}
+        >
+          <span className="ns-taskbar__start-logo">🚪</span>
+          <span className="ns-taskbar__start-label">Open</span>
+        </button>
+      </div>
 
       <div className="ns-taskbar__separator" />
 

--- a/src/utils/retroTiming.ts
+++ b/src/utils/retroTiming.ts
@@ -1,0 +1,83 @@
+/**
+ * Retro timing utilities — jank on demand.
+ * Used by the boot screen and the NS Doors 97 desktop startup sequence.
+ * All functions are tunable via options so every use-site can dial in its
+ * own feel without duplicating the core logic.
+ */
+
+// ── Random delay ───────────────────────────────────────────────────────────
+
+export interface RandomDelayOpts {
+  /** Average wait in ms (default: 400) */
+  base?: number;
+  /** Fractional variance: actual range is base±(base*variance) (default: 0.5) */
+  variance?: number;
+  /** Probability of a scary-long "panic" delay (default: 0.05) */
+  panicChance?: number;
+  /** How many times longer a panic delay is vs. base (default: 7) */
+  panicMultiplier?: number;
+}
+
+/**
+ * Returns a random delay in ms.
+ * Occasionally (panicChance) returns a much longer value for that
+ * "oh god is it frozen?" 90s computer experience.
+ */
+export function randomDelay({
+  base = 400,
+  variance = 0.5,
+  panicChance = 0.05,
+  panicMultiplier = 7,
+}: RandomDelayOpts = {}): number {
+  if (Math.random() < panicChance) {
+    return Math.round(base * panicMultiplier * (0.7 + Math.random() * 0.6));
+  }
+  const lo = base * (1 - variance);
+  const hi = base * (1 + variance);
+  return Math.round(lo + Math.random() * (hi - lo));
+}
+
+// ── Chunky increment ───────────────────────────────────────────────────────
+
+export interface ChunkIncrementOpts {
+  /** Average amount to add per step (default: 5) */
+  avgChunk?: number;
+  /** Probability of a "crit" — a much bigger jump (default: 0.1) */
+  critChance?: number;
+  /** Multiplier applied to avgChunk on a crit (default: 4) */
+  critMultiplier?: number;
+}
+
+/**
+ * Returns a semi-random increment value.
+ * Occasionally crits for a large jump, giving that satisfying "whoosh"
+ * when the loading bar suddenly leaps forward.
+ */
+export function chunkIncrement({
+  avgChunk = 5,
+  critChance = 0.1,
+  critMultiplier = 4,
+}: ChunkIncrementOpts = {}): number {
+  const isCrit = Math.random() < critChance;
+  const base = avgChunk * (isCrit ? critMultiplier : 1);
+  return base * (0.4 + Math.random() * 1.2);
+}
+
+// ── Cancellable sleep ──────────────────────────────────────────────────────
+
+/**
+ * Returns a sleep function tied to a cancel ref.
+ * If cancelRef.current is true when the timeout fires, the promise rejects
+ * with a 'cancelled' error so async sequences can clean up cleanly.
+ */
+export function makeSleep(cancelRef: { current: boolean }) {
+  return function sleep(ms: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (cancelRef.current) { reject(new Error("cancelled")); return; }
+      setTimeout(() => {
+        if (cancelRef.current) reject(new Error("cancelled"));
+        else resolve();
+      }, ms);
+    });
+  };
+}


### PR DESCRIPTION
Two-phase sequence on first visit (resets after 30 min):
- BIOS POST phase: full-screen black terminal with randomized
  CPU, RAM, drive detection, IRQ, USB lines, and silly quips;
  lines stagger in with semi-random delays; PC speaker beep on start
- Boot logo phase: Noahsoft branding, NS Doors 97 title with
  orange glow, Win95-style segmented progress bar, randomized
  status messages with injected boot quips; ascending arpeggio jingle
Backspace skips at any time (shown as a boot-menu-style prompt).

https://claude.ai/code/session_01MfG5EALbsUBJzaU5oY87EQ