### PR TITLE
Add Bomb Finder — a Win95-style Minesweeper game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import TypingRacerPage from "./pages/TypingRacerPage";
 import NumberMuncherPage from "./pages/NumberMuncherPage";
 import TicTacToePage from "./pages/TicTacToePage";
 import WordWhirlwindPage from "./pages/WordWhirlwindPage";
+import BombFinderPage from "./pages/BombFinderPage";
 import NsDoors97Page from "./pages/NsDoors97Page";
 
 export default function App() {
@@ -28,6 +29,7 @@ export default function App() {
         <Route path="/number-muncher" element={<NumberMuncherPage />} />
         <Route path="/tic-tac-toe" element={<TicTacToePage />} />
         <Route path="/word-whirlwind" element={<WordWhirlwindPage />} />
+        <Route path="/bomb-finder" element={<BombFinderPage />} />
         <Route path="/doors97" element={<NsDoors97Page />} />
       </Routes>
     </BrowserRouter>

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -78,6 +78,13 @@ export const experiences: Experience[] = [
     path: "/word-whirlwind",
   },
   {
+    id: "bomb-finder",
+    title: "Bomb Finder",
+    description: "Classic mine-sweeping puzzle. Flag the bombs, clear the field. Don't go boom.",
+    category: "game",
+    path: "/bomb-finder",
+  },
+  {
     id: "ns-doors-97",
     title: "NS Doors 97",
     description: "A fake 90s desktop OS. Double-click icons to open apps. It's not Windows. It's a Door.™",

--- a/src/experiences/BombFinder/BombFinder.css
+++ b/src/experiences/BombFinder/BombFinder.css
@@ -139,6 +139,42 @@
   background: #ff0000 !important;
 }
 
+/* ── Mobile mode toggle ── */
+.bomb-finder__mode-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bomb-finder__mode-label {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #c0c0c0;
+  white-space: nowrap;
+  margin-right: 2px;
+}
+
+.bomb-finder__mode-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 8px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  color: #000000;
+  white-space: nowrap;
+}
+
+.bomb-finder__mode-btn:hover {
+  background: #d0d0d0;
+}
+
+.bomb-finder__mode-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
+}
+
 /* ── Number labels inside cells ── */
 .bomb-finder__cell-num {
   font-family: "Press Start 2P", monospace;

--- a/src/experiences/BombFinder/BombFinder.css
+++ b/src/experiences/BombFinder/BombFinder.css
@@ -119,7 +119,8 @@
   line-height: 1;
   box-sizing: border-box;
   overflow: hidden;
-  touch-action: manipulation;
+  touch-action: none;
+  -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;
 }

--- a/src/experiences/BombFinder/BombFinder.css
+++ b/src/experiences/BombFinder/BombFinder.css
@@ -135,6 +135,11 @@
   background: #c0c0c0;
 }
 
+.bomb-finder__cell--pressed {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #c8c8c8;
+}
+
 .bomb-finder__cell--death {
   background: #ff0000 !important;
 }

--- a/src/experiences/BombFinder/BombFinder.css
+++ b/src/experiences/BombFinder/BombFinder.css
@@ -1,0 +1,144 @@
+.bomb-finder {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  font-family: "Press Start 2P", monospace;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* ── Difficulty toolbar ── */
+.bomb-finder__toolbar {
+  display: flex;
+  gap: 4px;
+}
+
+.bomb-finder__diff-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 8px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  color: #000000;
+  white-space: nowrap;
+}
+
+.bomb-finder__diff-btn:hover {
+  background: #d0d0d0;
+}
+
+.bomb-finder__diff-btn:active,
+.bomb-finder__diff-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b8b8b8;
+}
+
+/* ── Main game panel ── */
+.bomb-finder__panel {
+  background: #c0c0c0;
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 8px;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Status bar ── */
+.bomb-finder__status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 5px 6px;
+  gap: 6px;
+}
+
+/* ── 7-segment style LCD displays ── */
+.bomb-finder__display {
+  background: #000000;
+  color: #dd0000;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 2px 5px;
+  min-width: 46px;
+  text-align: right;
+  letter-spacing: 3px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  line-height: 1.2;
+}
+
+/* ── Smiley face reset button ── */
+.bomb-finder__face {
+  font-size: 16px;
+  width: 34px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.bomb-finder__face--pressed {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+/* ── Game board ── */
+.bomb-finder__board {
+  display: grid;
+  border: 3px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+/* ── Cells ── */
+.bomb-finder__cell {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.bomb-finder__cell:hover:not(.bomb-finder__cell--revealed):not(:disabled) {
+  background: #d4d0c8;
+}
+
+.bomb-finder__cell--revealed {
+  border: 1px solid #808080;
+  cursor: default;
+  background: #c0c0c0;
+}
+
+.bomb-finder__cell--death {
+  background: #ff0000 !important;
+}
+
+/* ── Number labels inside cells ── */
+.bomb-finder__cell-num {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  font-weight: bold;
+  line-height: 1;
+}

--- a/src/experiences/BombFinder/BombFinder.css
+++ b/src/experiences/BombFinder/BombFinder.css
@@ -119,6 +119,9 @@
   line-height: 1;
   box-sizing: border-box;
   overflow: hidden;
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .bomb-finder__cell:hover:not(.bomb-finder__cell--revealed):not(:disabled) {

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -240,9 +240,8 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     [board, status, cfg, startTimer, stopTimer]
   );
 
-  const handleCellRightClick = useCallback(
-    (e: React.MouseEvent, row: number, col: number) => {
-      e.preventDefault();
+  const toggleFlag = useCallback(
+    (row: number, col: number) => {
       if (status === "won" || status === "lost") return;
       if (board[row][col].revealed) return;
 
@@ -253,6 +252,40 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     },
     [board, status, cfg.mines]
   );
+
+  const handleCellRightClick = useCallback(
+    (e: React.MouseEvent, row: number, col: number) => {
+      e.preventDefault();
+      toggleFlag(row, col);
+    },
+    [toggleFlag]
+  );
+
+  // Long-press for mobile flagging
+  const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressedRef = useRef(false);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent, row: number, col: number) => {
+      longPressedRef.current = false;
+      longPressRef.current = setTimeout(() => {
+        longPressedRef.current = true;
+        toggleFlag(row, col);
+      }, 500);
+    },
+    [toggleFlag]
+  );
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (longPressRef.current) {
+      clearTimeout(longPressRef.current);
+      longPressRef.current = null;
+    }
+    // Prevent the click event from firing after a long press
+    if (longPressedRef.current) {
+      e.preventDefault();
+    }
+  }, []);
 
   const faceEmoji =
     status === "won" ? "😎" : status === "lost" ? "😵" : facePressed ? "😮" : "🙂";
@@ -329,8 +362,11 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
                 <button
                   key={`${r}-${c}`}
                   className={`bomb-finder__cell${extraClass}`}
-                  onClick={() => handleCellClick(r, c)}
+                  onClick={() => { if (!longPressedRef.current) handleCellClick(r, c); }}
                   onContextMenu={(e) => handleCellRightClick(e, r, c)}
+                  onTouchStart={(e) => handleTouchStart(e, r, c)}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchMove={handleTouchEnd}
                 >
                   {content}
                 </button>

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -165,6 +165,8 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   const [deathCell, setDeathCell] = useState<{ row: number; col: number } | null>(null);
   const [facePressed, setFacePressed] = useState(false);
   const [mobileMode, setMobileMode] = useState<MobileMode>("reveal");
+  const [pressedCell, setPressedCell] = useState<[number, number] | null>(null);
+  const [chordingCell, setChordingCell] = useState<[number, number] | null>(null);
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -183,6 +185,13 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   }, [stopTimer]);
 
   useEffect(() => () => stopTimer(), [stopTimer]);
+
+  // Clear press state if the mouse is released anywhere outside a cell
+  useEffect(() => {
+    const cleanup = () => { setPressedCell(null); setChordingCell(null); };
+    document.addEventListener("mouseup", cleanup);
+    return () => document.removeEventListener("mouseup", cleanup);
+  }, []);
 
   const resetGame = useCallback(
     (newDiff?: Difficulty) => {
@@ -388,7 +397,8 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   );
 
   const faceEmoji =
-    status === "won" ? "😎" : status === "lost" ? "😵" : facePressed ? "😮" : "🙂";
+    status === "won" ? "😎" : status === "lost" ? "😵"
+    : (facePressed || pressedCell || chordingCell) ? "😮" : "🙂";
 
   return (
     <div className="bomb-finder">
@@ -426,19 +436,32 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
         <div
           className="bomb-finder__board"
           style={{ gridTemplateColumns: `repeat(${cfg.cols}, 24px)` }}
+          onMouseLeave={() => { setPressedCell(null); setChordingCell(null); }}
         >
           {board.map((row, r) =>
             row.map((cell, c) => {
               const isDeath = deathCell?.row === r && deathCell?.col === c;
-              let content: React.ReactNode = null;
-              let extraClass = "";
 
+              // Pressed visual: single-cell press or chord-neighbor press
+              const isSinglePressed =
+                !cell.revealed && !cell.flagged &&
+                pressedCell?.[0] === r && pressedCell?.[1] === c;
+              const isChordPressed =
+                chordingCell !== null && !cell.revealed && !cell.flagged &&
+                Math.abs(r - chordingCell[0]) <= 1 && Math.abs(c - chordingCell[1]) <= 1 &&
+                !(r === chordingCell[0] && c === chordingCell[1]);
+
+              let extraClass = "";
               if (cell.revealed) {
                 extraClass += " bomb-finder__cell--revealed";
-                if (isDeath) {
-                  extraClass += " bomb-finder__cell--death";
-                  content = "💣";
-                } else if (cell.hasBomb) {
+                if (isDeath) extraClass += " bomb-finder__cell--death";
+              } else if (isSinglePressed || isChordPressed) {
+                extraClass += " bomb-finder__cell--pressed";
+              }
+
+              let content: React.ReactNode = null;
+              if (cell.revealed) {
+                if (isDeath || cell.hasBomb) {
                   content = "💣";
                 } else if (cell.adjacentCount > 0) {
                   content = (
@@ -450,30 +473,51 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
                     </span>
                   );
                 }
-              } else {
-                if (cell.wrongFlag) {
-                  content = "❌";
-                } else if (cell.flagged) {
-                  content = "🚩";
-                }
+              } else if (!isSinglePressed && !isChordPressed) {
+                // Only show flag/wrong-flag when not visually pressed
+                if (cell.wrongFlag) content = "❌";
+                else if (cell.flagged) content = "🚩";
               }
 
               return (
                 <button
                   key={`${r}-${c}`}
                   className={`bomb-finder__cell${extraClass}`}
-                  onClick={() => {
-                    if (longPressedRef.current) { longPressedRef.current = false; return; }
-                    if (pointerTypeRef.current === "touch") {
-                      if (mobileMode === "reveal") handleCellClick(r, c);
-                      else if (mobileMode === "flag") toggleFlag(r, c);
-                      else chordReveal(r, c);
-                    } else {
-                      handleCellClick(r, c);
+                  // Mouse: press visual on mousedown, execute on mouseup
+                  onMouseDown={(e) => {
+                    if (pointerTypeRef.current === "touch") return;
+                    if (e.buttons === 3) {
+                      setPressedCell(null);
+                      setChordingCell([r, c]);
+                    } else if (e.button === 0 && !cell.revealed && !cell.flagged) {
+                      setPressedCell([r, c]);
                     }
                   }}
-                  onMouseDown={(e) => { if (e.buttons === 3) chordReveal(r, c); }}
+                  onMouseUp={() => {
+                    if (pointerTypeRef.current === "touch") return;
+                    if (chordingCell) {
+                      chordReveal(chordingCell[0], chordingCell[1]);
+                      setChordingCell(null);
+                      setPressedCell(null);
+                    } else if (pressedCell?.[0] === r && pressedCell?.[1] === c) {
+                      handleCellClick(r, c);
+                      setPressedCell(null);
+                    }
+                  }}
+                  onMouseLeave={() => {
+                    if (pressedCell?.[0] === r && pressedCell?.[1] === c) {
+                      setPressedCell(null);
+                    }
+                  }}
                   onContextMenu={(e) => handleCellRightClick(e, r, c)}
+                  // Touch: mode toggle via onClick, long-press via pointer events
+                  onClick={() => {
+                    if (pointerTypeRef.current !== "touch") return;
+                    if (longPressedRef.current) { longPressedRef.current = false; return; }
+                    if (mobileMode === "reveal") handleCellClick(r, c);
+                    else if (mobileMode === "flag") toggleFlag(r, c);
+                    else chordReveal(r, c);
+                  }}
                   onPointerDown={(e) => handlePointerDown(e, r, c)}
                   onPointerUp={() => cancelLongPress()}
                   onPointerCancel={() => cancelLongPress()}

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -266,7 +266,7 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   const longPressedRef = useRef(false);
 
   const handleTouchStart = useCallback(
-    (e: React.TouchEvent, row: number, col: number) => {
+    (_e: React.TouchEvent, row: number, col: number) => {
       longPressedRef.current = false;
       longPressRef.current = setTimeout(() => {
         longPressedRef.current = true;

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -261,31 +261,40 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     [toggleFlag]
   );
 
-  // Long-press for mobile flagging
+  // Keep a ref so the long-press timeout always calls the latest toggleFlag
+  // without needing to re-create the touchstart handler on every board change.
+  const toggleFlagRef = useRef(toggleFlag);
+  useEffect(() => { toggleFlagRef.current = toggleFlag; }, [toggleFlag]);
+
   const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressedRef = useRef(false);
 
-  const handleTouchStart = useCallback(
-    (_e: React.TouchEvent, row: number, col: number) => {
-      longPressedRef.current = false;
-      longPressRef.current = setTimeout(() => {
-        longPressedRef.current = true;
-        toggleFlag(row, col);
-      }, 500);
-    },
-    [toggleFlag]
-  );
-
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+  const cancelLongPress = useCallback(() => {
     if (longPressRef.current) {
       clearTimeout(longPressRef.current);
       longPressRef.current = null;
     }
-    // Prevent the click event from firing after a long press
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (_e: React.TouchEvent, row: number, col: number) => {
+      longPressedRef.current = false;
+      cancelLongPress();
+      longPressRef.current = setTimeout(() => {
+        longPressedRef.current = true;
+        longPressRef.current = null;
+        toggleFlagRef.current(row, col);
+      }, 500);
+    },
+    [cancelLongPress]
+  );
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    cancelLongPress();
     if (longPressedRef.current) {
       e.preventDefault();
     }
-  }, []);
+  }, [cancelLongPress]);
 
   const faceEmoji =
     status === "won" ? "😎" : status === "lost" ? "😵" : facePressed ? "😮" : "🙂";
@@ -362,11 +371,15 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
                 <button
                   key={`${r}-${c}`}
                   className={`bomb-finder__cell${extraClass}`}
-                  onClick={() => { if (!longPressedRef.current) handleCellClick(r, c); }}
+                  onClick={() => {
+                    if (longPressedRef.current) { longPressedRef.current = false; return; }
+                    handleCellClick(r, c);
+                  }}
                   onContextMenu={(e) => handleCellRightClick(e, r, c)}
                   onTouchStart={(e) => handleTouchStart(e, r, c)}
                   onTouchEnd={handleTouchEnd}
-                  onTouchMove={handleTouchEnd}
+                  onTouchMove={cancelLongPress}
+                  onTouchCancel={cancelLongPress}
                 >
                   {content}
                 </button>

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -142,6 +142,14 @@ function fmt(n: number): string {
   return clamped.toString().padStart(3, "0");
 }
 
+type MobileMode = "reveal" | "flag" | "chord";
+
+const MOBILE_MODE_LABELS: Record<MobileMode, string> = {
+  reveal: "Reveal",
+  flag:   "Flag",
+  chord:  "Safe Reveal",
+};
+
 interface BombFinderProps {
   onDifficultyChange?: (difficulty: Difficulty) => void;
 }
@@ -156,6 +164,7 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   const [time, setTime] = useState(0);
   const [deathCell, setDeathCell] = useState<{ row: number; col: number } | null>(null);
   const [facePressed, setFacePressed] = useState(false);
+  const [mobileMode, setMobileMode] = useState<MobileMode>("reveal");
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -261,6 +270,78 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     [toggleFlag]
   );
 
+  // Chord reveal: if a numbered revealed cell has exactly N adjacent flags,
+  // reveal all remaining adjacent cells. Wrong flags = boom.
+  const chordReveal = useCallback(
+    (row: number, col: number) => {
+      if (status === "won" || status === "lost") return;
+      const cell = board[row][col];
+      if (!cell.revealed || cell.adjacentCount === 0) return;
+
+      const { rows, cols, mines } = cfg;
+
+      let flagCount = 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const nr = row + dr, nc = col + dc;
+          if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && board[nr][nc].flagged)
+            flagCount++;
+        }
+      }
+      if (flagCount !== cell.adjacentCount) return;
+
+      const toReveal: [number, number][] = [];
+      let firstBomb: { row: number; col: number } | null = null;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const nr = row + dr, nc = col + dc;
+          if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) continue;
+          const neighbor = board[nr][nc];
+          if (!neighbor.revealed && !neighbor.flagged) {
+            if (neighbor.hasBomb && !firstBomb) firstBomb = { row: nr, col: nc };
+            toReveal.push([nr, nc]);
+          }
+        }
+      }
+      if (toReveal.length === 0) return;
+
+      if (firstBomb) {
+        const lostBoard = board.map((r) =>
+          r.map((c) => {
+            if (c.hasBomb && !c.flagged) return { ...c, revealed: true };
+            if (!c.hasBomb && c.flagged) return { ...c, wrongFlag: true };
+            return { ...c };
+          })
+        );
+        setBoard(lostBoard);
+        setDeathCell(firstBomb);
+        setStatus("lost");
+        stopTimer();
+        return;
+      }
+
+      let newBoard = board;
+      for (const [nr, nc] of toReveal) {
+        newBoard = floodReveal(newBoard, rows, cols, nr, nc);
+      }
+
+      if (checkWin(newBoard, rows, cols, mines)) {
+        const wonBoard = newBoard.map((r) =>
+          r.map((c) => ({ ...c, flagged: c.hasBomb ? true : c.flagged }))
+        );
+        setBoard(wonBoard);
+        setStatus("won");
+        setMinesLeft(0);
+        stopTimer();
+      } else {
+        setBoard(newBoard);
+      }
+    },
+    [board, status, cfg, stopTimer]
+  );
+
   // Ref to always call latest toggleFlag from inside the setTimeout
   const toggleFlagRef = useRef(toggleFlag);
   useEffect(() => { toggleFlagRef.current = toggleFlag; }, [toggleFlag]);
@@ -268,6 +349,7 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressedRef = useRef(false);
   const pointerStartPos = useRef({ x: 0, y: 0 });
+  const pointerTypeRef = useRef<"mouse" | "touch">("mouse");
 
   const cancelLongPress = useCallback(() => {
     if (longPressRef.current) {
@@ -280,6 +362,7 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
   // and desktop, unlike Touch Events which have iOS-specific quirks.
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>, row: number, col: number) => {
+      pointerTypeRef.current = e.pointerType === "mouse" ? "mouse" : "touch";
       if (e.pointerType === "mouse") return;
       e.currentTarget.setPointerCapture(e.pointerId);
       pointerStartPos.current = { x: e.clientX, y: e.clientY };
@@ -381,8 +464,15 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
                   className={`bomb-finder__cell${extraClass}`}
                   onClick={() => {
                     if (longPressedRef.current) { longPressedRef.current = false; return; }
-                    handleCellClick(r, c);
+                    if (pointerTypeRef.current === "touch") {
+                      if (mobileMode === "reveal") handleCellClick(r, c);
+                      else if (mobileMode === "flag") toggleFlag(r, c);
+                      else chordReveal(r, c);
+                    } else {
+                      handleCellClick(r, c);
+                    }
                   }}
+                  onMouseDown={(e) => { if (e.buttons === 3) chordReveal(r, c); }}
                   onContextMenu={(e) => handleCellRightClick(e, r, c)}
                   onPointerDown={(e) => handlePointerDown(e, r, c)}
                   onPointerUp={() => cancelLongPress()}
@@ -395,6 +485,19 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
             })
           )}
         </div>
+      </div>
+
+      <div className="bomb-finder__mode-bar">
+        <span className="bomb-finder__mode-label">Tap:</span>
+        {(Object.keys(MOBILE_MODE_LABELS) as MobileMode[]).map((mode) => (
+          <button
+            key={mode}
+            className={`bomb-finder__mode-btn${mobileMode === mode ? " bomb-finder__mode-btn--active" : ""}`}
+            onClick={() => setMobileMode(mode)}
+          >
+            {MOBILE_MODE_LABELS[mode]}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -261,13 +261,13 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     [toggleFlag]
   );
 
-  // Keep a ref so the long-press timeout always calls the latest toggleFlag
-  // without needing to re-create the touchstart handler on every board change.
+  // Ref to always call latest toggleFlag from inside the setTimeout
   const toggleFlagRef = useRef(toggleFlag);
   useEffect(() => { toggleFlagRef.current = toggleFlag; }, [toggleFlag]);
 
   const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressedRef = useRef(false);
+  const pointerStartPos = useRef({ x: 0, y: 0 });
 
   const cancelLongPress = useCallback(() => {
     if (longPressRef.current) {
@@ -276,8 +276,13 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     }
   }, []);
 
-  const handleTouchStart = useCallback(
-    (_e: React.TouchEvent, row: number, col: number) => {
+  // Pointer Events API long press — works uniformly on iOS Safari, Android,
+  // and desktop, unlike Touch Events which have iOS-specific quirks.
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>, row: number, col: number) => {
+      if (e.pointerType === "mouse") return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      pointerStartPos.current = { x: e.clientX, y: e.clientY };
       longPressedRef.current = false;
       cancelLongPress();
       longPressRef.current = setTimeout(() => {
@@ -289,12 +294,15 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
     [cancelLongPress]
   );
 
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    cancelLongPress();
-    if (longPressedRef.current) {
-      e.preventDefault();
-    }
-  }, [cancelLongPress]);
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerType === "mouse") return;
+      const dx = e.clientX - pointerStartPos.current.x;
+      const dy = e.clientY - pointerStartPos.current.y;
+      if (dx * dx + dy * dy > 25) cancelLongPress(); // cancel if moved > 5px
+    },
+    [cancelLongPress]
+  );
 
   const faceEmoji =
     status === "won" ? "😎" : status === "lost" ? "😵" : facePressed ? "😮" : "🙂";
@@ -376,10 +384,10 @@ export default function BombFinder({ onDifficultyChange }: BombFinderProps = {})
                     handleCellClick(r, c);
                   }}
                   onContextMenu={(e) => handleCellRightClick(e, r, c)}
-                  onTouchStart={(e) => handleTouchStart(e, r, c)}
-                  onTouchEnd={handleTouchEnd}
-                  onTouchMove={cancelLongPress}
-                  onTouchCancel={cancelLongPress}
+                  onPointerDown={(e) => handlePointerDown(e, r, c)}
+                  onPointerUp={() => cancelLongPress()}
+                  onPointerCancel={() => cancelLongPress()}
+                  onPointerMove={handlePointerMove}
                 >
                   {content}
                 </button>

--- a/src/experiences/BombFinder/BombFinder.tsx
+++ b/src/experiences/BombFinder/BombFinder.tsx
@@ -1,0 +1,344 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import "./BombFinder.css";
+
+export type Difficulty = "beginner" | "intermediate" | "expert";
+type GameStatus = "idle" | "playing" | "won" | "lost";
+
+interface Cell {
+  hasBomb: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  adjacentCount: number;
+  wrongFlag?: boolean;
+}
+
+const DIFFICULTIES: Record<Difficulty, { rows: number; cols: number; mines: number; label: string }> = {
+  beginner:     { rows: 9,  cols: 9,  mines: 10, label: "Beginner"     },
+  intermediate: { rows: 16, cols: 16, mines: 40, label: "Intermediate" },
+  expert:       { rows: 16, cols: 30, mines: 99, label: "Expert"       },
+};
+
+// Classic Minesweeper number colors
+const NUMBER_COLORS: string[] = [
+  "",          // 0 (not shown)
+  "#0000cc",   // 1 blue
+  "#007700",   // 2 green
+  "#cc0000",   // 3 red
+  "#000077",   // 4 dark blue
+  "#770000",   // 5 dark red
+  "#007777",   // 6 teal
+  "#000000",   // 7 black
+  "#777777",   // 8 gray
+];
+
+function createEmptyBoard(rows: number, cols: number): Cell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({
+      hasBomb: false,
+      revealed: false,
+      flagged: false,
+      adjacentCount: 0,
+    }))
+  );
+}
+
+function placeBombs(
+  board: Cell[][],
+  rows: number,
+  cols: number,
+  mines: number,
+  safeRow: number,
+  safeCol: number
+): Cell[][] {
+  const newBoard = board.map((row) => row.map((cell) => ({ ...cell })));
+
+  // Collect positions outside the 3×3 safe zone around first click
+  const positions: [number, number][] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (Math.abs(r - safeRow) > 1 || Math.abs(c - safeCol) > 1) {
+        positions.push([r, c]);
+      }
+    }
+  }
+
+  for (let i = positions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [positions[i], positions[j]] = [positions[j], positions[i]];
+  }
+
+  const count = Math.min(mines, positions.length);
+  for (let i = 0; i < count; i++) {
+    const [r, c] = positions[i];
+    newBoard[r][c].hasBomb = true;
+  }
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (newBoard[r][c].hasBomb) continue;
+      let adj = 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const nr = r + dr, nc = c + dc;
+          if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && newBoard[nr][nc].hasBomb) {
+            adj++;
+          }
+        }
+      }
+      newBoard[r][c].adjacentCount = adj;
+    }
+  }
+
+  return newBoard;
+}
+
+function floodReveal(
+  board: Cell[][],
+  rows: number,
+  cols: number,
+  startRow: number,
+  startCol: number
+): Cell[][] {
+  const newBoard = board.map((row) => row.map((cell) => ({ ...cell })));
+  const stack: [number, number][] = [[startRow, startCol]];
+
+  while (stack.length > 0) {
+    const [r, c] = stack.pop()!;
+    if (r < 0 || r >= rows || c < 0 || c >= cols) continue;
+    const cell = newBoard[r][c];
+    if (cell.revealed || cell.flagged || cell.hasBomb) continue;
+
+    cell.revealed = true;
+
+    if (cell.adjacentCount === 0) {
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr !== 0 || dc !== 0) stack.push([r + dr, c + dc]);
+        }
+      }
+    }
+  }
+
+  return newBoard;
+}
+
+function countFlags(board: Cell[][]): number {
+  return board.flat().filter((c) => c.flagged).length;
+}
+
+function checkWin(board: Cell[][], rows: number, cols: number, mines: number): boolean {
+  let revealed = 0;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (board[r][c].revealed) revealed++;
+    }
+  }
+  return revealed === rows * cols - mines;
+}
+
+function fmt(n: number): string {
+  const clamped = Math.max(-99, Math.min(999, n));
+  if (clamped < 0) return "-" + Math.abs(clamped).toString().padStart(2, "0");
+  return clamped.toString().padStart(3, "0");
+}
+
+interface BombFinderProps {
+  onDifficultyChange?: (difficulty: Difficulty) => void;
+}
+
+export default function BombFinder({ onDifficultyChange }: BombFinderProps = {}) {
+  const [difficulty, setDifficulty] = useState<Difficulty>("beginner");
+  const cfg = DIFFICULTIES[difficulty];
+
+  const [board, setBoard] = useState<Cell[][]>(() => createEmptyBoard(9, 9));
+  const [status, setStatus] = useState<GameStatus>("idle");
+  const [minesLeft, setMinesLeft] = useState(DIFFICULTIES.beginner.mines);
+  const [time, setTime] = useState(0);
+  const [deathCell, setDeathCell] = useState<{ row: number; col: number } | null>(null);
+  const [facePressed, setFacePressed] = useState(false);
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    stopTimer();
+    timerRef.current = setInterval(() => {
+      setTime((t) => Math.min(t + 1, 999));
+    }, 1000);
+  }, [stopTimer]);
+
+  useEffect(() => () => stopTimer(), [stopTimer]);
+
+  const resetGame = useCallback(
+    (newDiff?: Difficulty) => {
+      stopTimer();
+      const d = newDiff ?? difficulty;
+      const newCfg = DIFFICULTIES[d];
+      if (newDiff !== undefined && newDiff !== difficulty) {
+        setDifficulty(d);
+        onDifficultyChange?.(d);
+      }
+      setBoard(createEmptyBoard(newCfg.rows, newCfg.cols));
+      setStatus("idle");
+      setMinesLeft(newCfg.mines);
+      setTime(0);
+      setDeathCell(null);
+    },
+    [difficulty, stopTimer, onDifficultyChange]
+  );
+
+  const handleCellClick = useCallback(
+    (row: number, col: number) => {
+      if (status === "won" || status === "lost") return;
+      const cell = board[row][col];
+      if (cell.revealed || cell.flagged) return;
+
+      let currentBoard = board;
+      const isFirstClick = status === "idle";
+
+      if (isFirstClick) {
+        currentBoard = placeBombs(board, cfg.rows, cfg.cols, cfg.mines, row, col);
+        startTimer();
+      }
+
+      if (currentBoard[row][col].hasBomb) {
+        const lostBoard = currentBoard.map((r) =>
+          r.map((c) => {
+            if (c.hasBomb && !c.flagged) return { ...c, revealed: true };
+            if (!c.hasBomb && c.flagged) return { ...c, wrongFlag: true };
+            return { ...c };
+          })
+        );
+        setBoard(lostBoard);
+        setDeathCell({ row, col });
+        setStatus("lost");
+        stopTimer();
+        return;
+      }
+
+      const newBoard = floodReveal(currentBoard, cfg.rows, cfg.cols, row, col);
+
+      if (checkWin(newBoard, cfg.rows, cfg.cols, cfg.mines)) {
+        const wonBoard = newBoard.map((r) =>
+          r.map((c) => ({ ...c, flagged: c.hasBomb ? true : c.flagged }))
+        );
+        setBoard(wonBoard);
+        setStatus("won");
+        setMinesLeft(0);
+        stopTimer();
+      } else {
+        setBoard(newBoard);
+        if (isFirstClick) setStatus("playing");
+      }
+    },
+    [board, status, cfg, startTimer, stopTimer]
+  );
+
+  const handleCellRightClick = useCallback(
+    (e: React.MouseEvent, row: number, col: number) => {
+      e.preventDefault();
+      if (status === "won" || status === "lost") return;
+      if (board[row][col].revealed) return;
+
+      const newBoard = board.map((r) => r.map((c) => ({ ...c })));
+      newBoard[row][col].flagged = !newBoard[row][col].flagged;
+      setBoard(newBoard);
+      setMinesLeft(cfg.mines - countFlags(newBoard));
+    },
+    [board, status, cfg.mines]
+  );
+
+  const faceEmoji =
+    status === "won" ? "😎" : status === "lost" ? "😵" : facePressed ? "😮" : "🙂";
+
+  return (
+    <div className="bomb-finder">
+      <div className="bomb-finder__toolbar">
+        {(Object.keys(DIFFICULTIES) as Difficulty[]).map((d) => (
+          <button
+            key={d}
+            className={`bomb-finder__diff-btn${difficulty === d ? " bomb-finder__diff-btn--active" : ""}`}
+            onClick={() => resetGame(d)}
+          >
+            {DIFFICULTIES[d].label}
+          </button>
+        ))}
+      </div>
+
+      <div className="bomb-finder__panel">
+        <div className="bomb-finder__status-bar">
+          <div className="bomb-finder__display">{fmt(minesLeft)}</div>
+
+          <button
+            className={`bomb-finder__face${facePressed ? " bomb-finder__face--pressed" : ""}`}
+            onMouseDown={() => setFacePressed(true)}
+            onMouseUp={() => {
+              setFacePressed(false);
+              resetGame();
+            }}
+            onMouseLeave={() => setFacePressed(false)}
+          >
+            {faceEmoji}
+          </button>
+
+          <div className="bomb-finder__display">{fmt(time)}</div>
+        </div>
+
+        <div
+          className="bomb-finder__board"
+          style={{ gridTemplateColumns: `repeat(${cfg.cols}, 24px)` }}
+        >
+          {board.map((row, r) =>
+            row.map((cell, c) => {
+              const isDeath = deathCell?.row === r && deathCell?.col === c;
+              let content: React.ReactNode = null;
+              let extraClass = "";
+
+              if (cell.revealed) {
+                extraClass += " bomb-finder__cell--revealed";
+                if (isDeath) {
+                  extraClass += " bomb-finder__cell--death";
+                  content = "💣";
+                } else if (cell.hasBomb) {
+                  content = "💣";
+                } else if (cell.adjacentCount > 0) {
+                  content = (
+                    <span
+                      className="bomb-finder__cell-num"
+                      style={{ color: NUMBER_COLORS[cell.adjacentCount] }}
+                    >
+                      {cell.adjacentCount}
+                    </span>
+                  );
+                }
+              } else {
+                if (cell.wrongFlag) {
+                  content = "❌";
+                } else if (cell.flagged) {
+                  content = "🚩";
+                }
+              }
+
+              return (
+                <button
+                  key={`${r}-${c}`}
+                  className={`bomb-finder__cell${extraClass}`}
+                  onClick={() => handleCellClick(r, c)}
+                  onContextMenu={(e) => handleCellRightClick(e, r, c)}
+                >
+                  {content}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -22,6 +22,7 @@ import FilesApp from "./FilesApp";
 import NotebookApp from "./NotebookApp";
 import InternetApp from "./InternetApp";
 import TicTacToe from "../TicTacToe/TicTacToe";
+import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import "./NsDoors97.css";
 
@@ -38,6 +39,7 @@ const EXPERIENCE_ICONS: Record<string, string> = {
   "number-muncher":     "🔢",
   "tic-tac-toe":        "✖️",
   "word-whirlwind":     "🌪️",
+  "bomb-finder":        "💣",
   "ns-doors-97":        "🚪",
 };
 
@@ -46,6 +48,7 @@ type DesktopIconAction =
   | "experience"
   | "screensavers"
   | "tictactoe"
+  | "bombfinder"
   | "about"
   | "my-doors"
   | "internet"
@@ -75,7 +78,11 @@ const EXPERIENCE_ICON_DEFS: DesktopIconDef[] = experiences
     id: e.id,
     title: e.title,
     icon: EXPERIENCE_ICONS[e.id] ?? "🖥️",
-    action: (e.id === "tic-tac-toe" ? "tictactoe" : "experience") as DesktopIconAction,
+    action: (
+      e.id === "tic-tac-toe" ? "tictactoe" :
+      e.id === "bomb-finder" ? "bombfinder" :
+      "experience"
+    ) as DesktopIconAction,
   }));
 
 const ALL_DESKTOP_ICONS = [...STATIC_ICONS, ...EXPERIENCE_ICON_DEFS];
@@ -86,6 +93,7 @@ type WindowContent =
   | { type: "app-launcher"; experience: Experience }
   | { type: "screensaver-settings" }
   | { type: "tictactoe" }
+  | { type: "bombfinder" }
   | { type: "about" }
   | { type: "my-doors" }
   | { type: "internet" }
@@ -106,6 +114,11 @@ let windowSeq = 0;
 let maxZ = 100;
 
 const TTT_WINDOW_WIDTHS: Record<3 | 5 | 7, number> = { 3: 380, 5: 480, 7: 580 };
+const BF_WINDOW_WIDTHS: Record<BfDifficulty, number> = {
+  beginner: 310,
+  intermediate: 470,
+  expert: 820,
+};
 
 // ── App Launcher card ──────────────────────────────────────────────────────
 
@@ -285,6 +298,7 @@ export default function NsDoors97() {
         case "files":        content = { type: "files" };                width = 600; break;
         case "notebook":     content = { type: "notebook", filePath: "(new file)", fileName: "Untitled.txt", initialContent: "" }; width = 560; break;
         case "tictactoe":    content = { type: "tictactoe" };            width = TTT_WINDOW_WIDTHS[3]; break;
+        case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -365,6 +379,18 @@ export default function NsDoors97() {
     []
   );
 
+  // Called by BombFinder when difficulty changes — resize the window
+  const handleBfDifficultyChange = useCallback(
+    (winId: string, diff: BfDifficulty) => {
+      setOpenWindows((prev) =>
+        prev.map((w) =>
+          w.id === winId ? { ...w, width: BF_WINDOW_WIDTHS[diff] } : w
+        )
+      );
+    },
+    []
+  );
+
   return (
     <div className="ns-desktop">
       {/* ── Icon grid (icons pop in one by one during boot) ── */}
@@ -423,6 +449,13 @@ export default function NsDoors97() {
             <TicTacToe
               onBoardSizeChange={(size) =>
                 handleTttBoardSizeChange(win.id, size)
+              }
+            />
+          )}
+          {win.content.type === "bombfinder" && (
+            <BombFinder
+              onDifficultyChange={(diff) =>
+                handleBfDifficultyChange(win.id, diff)
               }
             />
           )}

--- a/src/pages/BombFinderPage.css
+++ b/src/pages/BombFinderPage.css
@@ -1,0 +1,17 @@
+.bomb-finder-page {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, #2a1000 0%, #180800 55%, #0c0400 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow-y: auto;
+  padding: 48px 16px 16px;
+}
+
+.bomb-finder-page__back {
+  position: fixed;
+  top: var(--spacing-md);
+  left: var(--spacing-md);
+  z-index: 10;
+}

--- a/src/pages/BombFinderPage.tsx
+++ b/src/pages/BombFinderPage.tsx
@@ -27,10 +27,15 @@ export default function BombFinderPage() {
         </ul>
         <hr />
         <ul>
+          <li><strong>Safe Reveal</strong> — left+right click a number whose adjacent flags match it to reveal surrounding cells</li>
+          <li>Wrong flags mean Safe Reveal can still hit a bomb!</li>
+        </ul>
+        <hr />
+        <ul>
           <li><strong>Beginner</strong> — 9×9 grid, 10 bombs</li>
           <li><strong>Intermediate</strong> — 16×16 grid, 40 bombs</li>
           <li><strong>Expert</strong> — 30×16 grid, 99 bombs</li>
-          <li>Click 🙂 to reset the current difficulty</li>
+          <li>Click 🙂 to reset · Use <strong>Tap:</strong> buttons for mobile</li>
         </ul>
       </HelpOverlay>
     </div>

--- a/src/pages/BombFinderPage.tsx
+++ b/src/pages/BombFinderPage.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@noahwright/design";
+import BombFinder from "../experiences/BombFinder/BombFinder";
+import HelpOverlay from "../components/HelpOverlay/HelpOverlay";
+import "./BombFinderPage.css";
+
+export default function BombFinderPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="bomb-finder-page">
+      <BombFinder />
+
+      <div className="bomb-finder-page__back">
+        <Button variant="ghost" color="#ffffff" onClick={() => navigate("/")}>
+          ← Toy Box
+        </Button>
+      </div>
+
+      <HelpOverlay title="Bomb Finder">
+        <ul>
+          <li><strong>Left-click</strong> to reveal a cell</li>
+          <li><strong>Right-click</strong> to place or remove a flag 🚩</li>
+          <li>Your first click is always safe — no bomb within 1 square</li>
+          <li>Numbers show how many bombs touch that cell</li>
+          <li>Clear all non-bomb cells to win</li>
+        </ul>
+        <hr />
+        <ul>
+          <li><strong>Beginner</strong> — 9×9 grid, 10 bombs</li>
+          <li><strong>Intermediate</strong> — 16×16 grid, 40 bombs</li>
+          <li><strong>Expert</strong> — 30×16 grid, 99 bombs</li>
+          <li>Click 🙂 to reset the current difficulty</li>
+        </ul>
+      </HelpOverlay>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements full Minesweeper gameplay as 'Bomb Finder' with three
difficulty levels (Beginner/Intermediate/Expert), first-click safety
zone, flood-fill reveal, flag placement, 7-segment LCD displays,
smiley reset button, and win/loss states with wrong-flag indicators.

Embedded as a resizable window in NS Doors 97 (difficulty change
resizes the window), and accessible at /bomb-finder standalone.

https://claude.ai/code/session_01FZG5Qv2aedZtRhVdJHTRq9