### PR TITLE
Add Cards app to NS Doors 97 with launcher, deck settings, and No Game mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .claude/launch.json
 playwright-report/
 test-results/
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,10 @@ NS Doors 97 is the flagship experience. It simulates a 1990s desktop:
 - Built-in apps: file browser, About Noahsoft dialog, simulated internet browser, Tic-Tac-Toe window
 - All windows use Win95-style chrome: title bar (orange/brown gradient), close/min/max buttons, beveled borders
 
+## Before finishing any task
+
+Always run `npx tsc --noEmit` before committing. The project enables `noUnusedLocals` and `noUnusedParameters`, so unused imports and variables are **build errors** that will fail the Netlify deploy. Fix every reported error before pushing.
+
 ## Known conventions
 
 - Commits reference the feature or PR (see git log for style)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,11 @@ NS Doors 97 is the flagship experience. It simulates a 1990s desktop:
 
 Always run `npx tsc --noEmit` before committing. The project enables `noUnusedLocals` and `noUnusedParameters`, so unused imports and variables are **build errors** that will fail the Netlify deploy. Fix every reported error before pushing.
 
+**Important:** Netlify's TypeScript targets an older lib than the local `tsc` sometimes allows. Avoid these patterns or they will fail the Netlify build even if they pass locally:
+- `Array.prototype.at()` — use `arr[arr.length - 1]` instead
+- Other ES2022+ array/string methods not in ES2020 lib (`findLast`, `toSorted`, `toReversed`, etc.)
+- When spreading an object and overriding a union-typed field (e.g. `phase: GamePhase`), annotate the local variable explicitly: `const phase: GamePhase = ...` to prevent TypeScript widening it to `string`.
+
 ## Known conventions
 
 - Commits reference the feature or PR (see git log for style)

--- a/src/experiences/Cards/Blackjack.css
+++ b/src/experiences/Cards/Blackjack.css
@@ -1,0 +1,189 @@
+/* ─── Blackjack ─────────────────────────────────────────────────────── */
+
+.bj {
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+}
+
+/* Felt table area */
+.bj__table {
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 8px 8px 4px;
+  padding: 12px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 256px;
+}
+
+/* Hand section (dealer or player) */
+.bj__section-label {
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 4px;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.bj__score {
+  font-size: 9px;
+  color: #ffffff;
+}
+
+.bj__score--bust { color: #ff6666; }
+.bj__score--bj   { color: #ffdd44; }
+
+/* Card row with overlap */
+.bj__hand {
+  display: flex;
+  flex-wrap: nowrap;
+  min-height: 104px; /* card height + shadow */
+}
+
+.bj__card {
+  flex-shrink: 0;
+}
+
+.bj__card + .bj__card {
+  margin-left: -14px;
+}
+
+/* Outcome overlay — floats above the felt */
+.bj__outcome {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  padding: 10px 16px;
+  text-align: center;
+  white-space: nowrap;
+  font-size: 10px;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.bj__outcome--win  { color: #55ee55; }
+.bj__outcome--push { color: #eeee44; }
+.bj__outcome--lose { color: #ee5555; }
+
+/* Controls */
+.bj__controls {
+  padding: 6px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bj__info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bj__chips-label {
+  font-size: 8px;
+  color: #000;
+}
+
+.bj__divider {
+  height: 0;
+  border: none;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+}
+
+/* Bet adjustment row */
+.bj__bet-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* Shared button base */
+.bj__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 9px;
+  border: 2px solid;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* Small neutral (bet controls) */
+.bj__btn--sm {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.bj__btn--sm:hover:not(:disabled) { background: #d4d0c8; }
+.bj__btn--sm:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
+.bj__btn--sm:disabled { color: #808080; cursor: default; }
+
+/* Deal / New Hand — orange primary */
+.bj__btn--deal {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  font-size: 9px;
+  padding: 7px 14px;
+}
+.bj__btn--deal:hover { background: #ee5500; }
+.bj__btn--deal:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+.bj__btn--deal:disabled { background: #994400; cursor: default; }
+
+/* Hit — orange */
+.bj__btn--hit {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+.bj__btn--hit:hover { background: #ee5500; }
+.bj__btn--hit:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+
+/* Stand — neutral */
+.bj__btn--stand {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.bj__btn--stand:active { border-color: #808080 #ffffff #ffffff #808080; }
+
+/* Double — purple */
+.bj__btn--double {
+  background: #5b2d8e;
+  color: #fff;
+  border-color: #9966cc #331155 #331155 #9966cc;
+}
+.bj__btn--double:hover { background: #7b3dbe; }
+.bj__btn--double:active { border-color: #331155 #9966cc #9966cc #331155; }
+
+/* Action row */
+.bj__action-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+}
+
+.bj__waiting {
+  font-size: 7px;
+  color: #808080;
+  font-style: italic;
+}
+
+.bj__notice {
+  font-size: 6px;
+  color: #808080;
+  text-align: right;
+}

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -1,0 +1,384 @@
+import { useState, useCallback, useEffect } from "react";
+import "./Blackjack.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, DeckSettings } from "./types";
+import { buildDeck } from "./deckUtils";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Phase = "betting" | "player-turn" | "dealer-turn" | "resolved";
+type Outcome = "blackjack" | "win" | "push" | "dealer-blackjack" | "bust" | "lose";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const STARTING_CHIPS = 500;
+const RESHUFFLE_AT = 15;
+const DEALER_HIT_DELAY_MS = 700;
+const DEALER_STAND_DELAY_MS = 400;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function cardPoints(rank: Card["rank"]): number {
+  if (rank === "A") return 11;
+  if (rank === "J" || rank === "Q" || rank === "K") return 10;
+  if (rank === "Joker") return 0;
+  return parseInt(rank as string, 10);
+}
+
+function handTotal(cards: Card[]): number {
+  let total = 0;
+  let aces = 0;
+  for (const c of cards) {
+    if (c.rank === "A") aces++;
+    total += cardPoints(c.rank);
+  }
+  while (total > 21 && aces > 0) {
+    total -= 10;
+    aces--;
+  }
+  return total;
+}
+
+function isNaturalBlackjack(cards: Card[]): boolean {
+  return cards.length === 2 && handTotal(cards) === 21;
+}
+
+function scoreLabel(cards: Card[], holeRevealed: boolean, isDealer: boolean): string {
+  if (cards.length === 0) return "";
+  if (isDealer && !holeRevealed) {
+    return `${cardPoints(cards[0].rank)} + ?`;
+  }
+  const total = handTotal(cards);
+  if (total > 21) return `BUST (${total})`;
+  return String(total);
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface BlackjackProps {
+  settings: DeckSettings;
+}
+
+export default function Blackjack({ settings }: BlackjackProps) {
+  const [deck, setDeck] = useState<Card[]>(() => buildDeck(settings));
+  const [playerHand, setPlayerHand] = useState<Card[]>([]);
+  const [dealerHand, setDealerHand] = useState<Card[]>([]);
+  const [holeRevealed, setHoleRevealed] = useState(false);
+  const [phase, setPhase] = useState<Phase>("betting");
+  const [chips, setChips] = useState(STARTING_CHIPS);
+  const [bet, setBet] = useState(10);
+  const [outcome, setOutcome] = useState<Outcome | null>(null);
+  const [chipDelta, setChipDelta] = useState(0);
+  const [dealerDone, setDealerDone] = useState(false);
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  const deal = useCallback(() => {
+    const workDeck = deck.length < RESHUFFLE_AT ? buildDeck(settings) : deck;
+    const [c1, c2, c3, c4, ...rest] = workDeck;
+    const pHand = [c1, c3];
+    const dHand = [c2, c4];
+
+    setDeck(rest);
+    setPlayerHand(pHand);
+    setDealerHand(dHand);
+    setHoleRevealed(false);
+    setOutcome(null);
+    setChipDelta(0);
+    setDealerDone(false);
+
+    if (isNaturalBlackjack(pHand)) {
+      setHoleRevealed(true);
+      if (isNaturalBlackjack(dHand)) {
+        setOutcome("push");
+        setChipDelta(0);
+      } else {
+        const win = Math.floor(bet * 1.5);
+        setChips((c) => c + win);
+        setOutcome("blackjack");
+        setChipDelta(win);
+      }
+      setPhase("resolved");
+    } else {
+      setPhase("player-turn");
+    }
+  }, [deck, bet, settings]);
+
+  const hit = useCallback(() => {
+    if (phase !== "player-turn") return;
+    const [nextCard, ...rest] = deck;
+    const newHand = [...playerHand, nextCard];
+    const total = handTotal(newHand);
+
+    setDeck(rest);
+    setPlayerHand(newHand);
+
+    if (total > 21) {
+      setChips((c) => c - bet);
+      setOutcome("bust");
+      setChipDelta(-bet);
+      setHoleRevealed(true);
+      setPhase("resolved");
+    } else if (total === 21) {
+      // Auto-stand at 21
+      setHoleRevealed(true);
+      setDealerDone(false);
+      setPhase("dealer-turn");
+    }
+  }, [phase, deck, playerHand, bet]);
+
+  const stand = useCallback(() => {
+    if (phase !== "player-turn") return;
+    setHoleRevealed(true);
+    setDealerDone(false);
+    setPhase("dealer-turn");
+  }, [phase]);
+
+  const doubleDown = useCallback(() => {
+    if (phase !== "player-turn" || playerHand.length !== 2 || chips < bet * 2) return;
+    const newBet = bet * 2;
+    const [nextCard, ...rest] = deck;
+    const newHand = [...playerHand, nextCard];
+    const total = handTotal(newHand);
+
+    setDeck(rest);
+    setPlayerHand(newHand);
+    setBet(newBet);
+
+    if (total > 21) {
+      setChips((c) => c - newBet);
+      setOutcome("bust");
+      setChipDelta(-newBet);
+      setHoleRevealed(true);
+      setPhase("resolved");
+    } else {
+      setHoleRevealed(true);
+      setDealerDone(false);
+      setPhase("dealer-turn");
+    }
+  }, [phase, playerHand, deck, bet, chips]);
+
+  // ── Dealer auto-play ───────────────────────────────────────────────────────
+
+  // Each time dealerHand changes during dealer-turn, check whether to hit or stand.
+  useEffect(() => {
+    if (phase !== "dealer-turn" || dealerDone) return;
+
+    const total = handTotal(dealerHand);
+    const timer = setTimeout(() => {
+      if (total < 17) {
+        setDeck((prevDeck) => {
+          const [nextCard, ...rest] = prevDeck;
+          setDealerHand((prev) => [...prev, nextCard]);
+          return rest;
+        });
+      } else {
+        setDealerDone(true);
+      }
+    }, total < 17 ? DEALER_HIT_DELAY_MS : DEALER_STAND_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [phase, dealerHand, dealerDone]);
+
+  // Resolve outcome once dealer is done
+  useEffect(() => {
+    if (!dealerDone) return;
+
+    const pTotal = handTotal(playerHand);
+    const dTotal = handTotal(dealerHand);
+
+    let o: Outcome;
+    let delta: number;
+
+    if (isNaturalBlackjack(dealerHand)) {
+      o = "dealer-blackjack";
+      delta = -bet;
+    } else if (dTotal > 21 || pTotal > dTotal) {
+      o = "win";
+      delta = bet;
+    } else if (pTotal === dTotal) {
+      o = "push";
+      delta = 0;
+    } else {
+      o = "lose";
+      delta = -bet;
+    }
+
+    setChips((c) => c + delta);
+    setOutcome(o);
+    setChipDelta(delta);
+    setPhase("resolved");
+  }, [dealerDone, bet, playerHand, dealerHand]);
+
+  // ── New round / reset ──────────────────────────────────────────────────────
+
+  const newHand = useCallback(() => {
+    setBet((prev) => Math.min(prev, Math.max(5, chips)));
+    setPlayerHand([]);
+    setDealerHand([]);
+    setHoleRevealed(false);
+    setOutcome(null);
+    setDealerDone(false);
+    setChipDelta(0);
+    setPhase("betting");
+  }, [chips]);
+
+  const resetGame = useCallback(() => {
+    setChips(STARTING_CHIPS);
+    setBet(10);
+    setDeck(buildDeck(settings));
+    setPlayerHand([]);
+    setDealerHand([]);
+    setHoleRevealed(false);
+    setOutcome(null);
+    setDealerDone(false);
+    setChipDelta(0);
+    setPhase("betting");
+  }, [settings]);
+
+  // ── Derived display values ─────────────────────────────────────────────────
+
+  const dealerScore = scoreLabel(dealerHand, holeRevealed, true);
+  const playerScore = scoreLabel(playerHand, true, false);
+  const playerTotal = handTotal(playerHand);
+  const gameOver = chips < 5 && phase === "betting";
+
+  function outcomeText(): string {
+    if (!outcome) return "";
+    switch (outcome) {
+      case "blackjack":        return `BLACKJACK!  +$${chipDelta}`;
+      case "win":              return `YOU WIN!  +$${chipDelta}`;
+      case "push":             return "PUSH — bet returned";
+      case "dealer-blackjack": return `DEALER BLACKJACK  -$${Math.abs(chipDelta)}`;
+      case "bust":             return `BUST!  -$${Math.abs(chipDelta)}`;
+      case "lose":             return `DEALER WINS  -$${Math.abs(chipDelta)}`;
+    }
+  }
+
+  function outcomeClass(): string {
+    if (!outcome) return "";
+    if (outcome === "blackjack" || outcome === "win") return "bj__outcome--win";
+    if (outcome === "push") return "bj__outcome--push";
+    return "bj__outcome--lose";
+  }
+
+  const dealerTotalForClass = holeRevealed ? handTotal(dealerHand) : 0;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="bj">
+      {/* Felt table */}
+      <div className="bj__table">
+
+        {/* Dealer hand */}
+        <div>
+          <div className="bj__section-label">
+            DEALER
+            {dealerHand.length > 0 && (
+              <span className={`bj__score${dealerTotalForClass > 21 ? " bj__score--bust" : dealerTotalForClass === 21 && dealerHand.length === 2 ? " bj__score--bj" : ""}`}>
+                {dealerScore}
+              </span>
+            )}
+          </div>
+          <div className="bj__hand">
+            {dealerHand.map((card, i) => (
+              <div key={card.id} className="bj__card">
+                <PlayingCard
+                  card={card}
+                  faceDown={i === 1 && !holeRevealed}
+                  backColor={settings.cardBack}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Player hand */}
+        <div>
+          <div className="bj__section-label">
+            YOU
+            {playerHand.length > 0 && (
+              <span className={`bj__score${playerTotal > 21 ? " bj__score--bust" : playerTotal === 21 && playerHand.length === 2 ? " bj__score--bj" : ""}`}>
+                {playerScore}
+              </span>
+            )}
+          </div>
+          <div className="bj__hand">
+            {playerHand.map((card) => (
+              <div key={card.id} className="bj__card">
+                <PlayingCard card={card} backColor={settings.cardBack} />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Outcome overlay */}
+        {phase === "resolved" && outcome && (
+          <div className={`bj__outcome ${outcomeClass()}`}>
+            {outcomeText()}
+          </div>
+        )}
+      </div>
+
+      {/* Controls */}
+      <div className="bj__controls">
+        <div className="bj__info-row">
+          <span className="bj__chips-label">Chips: ${chips}</span>
+          <span className="bj__chips-label">Bet: ${bet}</span>
+        </div>
+
+        <div className="bj__divider" />
+
+        {/* Bet row — only during betting phase */}
+        {phase === "betting" && !gameOver && (
+          <div className="bj__bet-row">
+            <span className="bj__chips-label">Adjust:</span>
+            <button className="bj__btn bj__btn--sm" disabled={bet <= 5}      onClick={() => setBet((p) => Math.max(5, p - 5))}>−$5</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet + 5 > chips} onClick={() => setBet((p) => Math.min(chips, p + 5))}>+$5</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet + 25 > chips} onClick={() => setBet((p) => Math.min(chips, p + 25))}>+$25</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet === 5}       onClick={() => setBet(5)}>Min</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet === chips}   onClick={() => setBet(chips)}>All In</button>
+          </div>
+        )}
+
+        {/* Action row */}
+        <div className="bj__action-row">
+          {phase === "betting" && !gameOver && (
+            <button className="bj__btn bj__btn--deal" onClick={deal} disabled={bet < 5}>
+              ▶ DEAL
+            </button>
+          )}
+
+          {phase === "player-turn" && (
+            <>
+              <button className="bj__btn bj__btn--hit"    onClick={hit}>Hit</button>
+              <button className="bj__btn bj__btn--stand"  onClick={stand}>Stand</button>
+              {playerHand.length === 2 && chips >= bet * 2 && (
+                <button className="bj__btn bj__btn--double" onClick={doubleDown}>Double</button>
+              )}
+            </>
+          )}
+
+          {phase === "dealer-turn" && (
+            <span className="bj__waiting">Dealer playing...</span>
+          )}
+
+          {phase === "resolved" && (
+            chips >= 5
+              ? <button className="bj__btn bj__btn--deal" onClick={newHand}>New Hand</button>
+              : <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
+          )}
+
+          {gameOver && (
+            <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
+          )}
+        </div>
+
+        {deck.length < RESHUFFLE_AT && phase === "betting" && (
+          <div className="bj__notice">Shuffling next hand</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -12,6 +12,34 @@
   box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.35);
 }
 
+/* Small variant for pyramid layout */
+.playing-card--sm {
+  width: 52px;
+  height: 72px;
+}
+
+.playing-card--sm .playing-card__rank {
+  font-size: 5px;
+}
+
+.playing-card--sm .playing-card__suit-pip {
+  font-size: 6px;
+}
+
+.playing-card--sm .playing-card__center {
+  font-size: 18px;
+}
+
+.playing-card--sm .playing-card__corner--tl {
+  top: 2px;
+  left: 3px;
+}
+
+.playing-card--sm .playing-card__corner--br {
+  bottom: 2px;
+  right: 3px;
+}
+
 /* Back face — color comes from inline style --card-back */
 .playing-card--back {
   background-color: var(--card-back, #cc4400);

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -1,0 +1,384 @@
+/* ─── Playing Card ──────────────────────────────────────────────────── */
+
+.playing-card {
+  width: 72px;
+  height: 100px;
+  border-radius: 4px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  position: relative;
+  flex-shrink: 0;
+  user-select: none;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+/* Back face — color comes from inline style --card-back */
+.playing-card--back {
+  background-color: var(--card-back, #cc4400);
+  cursor: default;
+}
+
+.playing-card__back-inner {
+  position: absolute;
+  inset: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background:
+    repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 5px,
+      rgba(255, 255, 255, 0.12) 5px,
+      rgba(255, 255, 255, 0.12) 6px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 5px,
+      rgba(255, 255, 255, 0.12) 5px,
+      rgba(255, 255, 255, 0.12) 6px
+    );
+}
+
+/* Front face */
+.playing-card--front {
+  background: #ffffff;
+}
+
+.playing-card__corner {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.1;
+}
+
+.playing-card__corner--tl {
+  top: 3px;
+  left: 4px;
+}
+
+.playing-card__corner--br {
+  bottom: 3px;
+  right: 4px;
+  transform: rotate(180deg);
+}
+
+.playing-card__rank {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  display: block;
+  line-height: 1.2;
+}
+
+.playing-card__suit-pip {
+  font-size: 8px;
+  display: block;
+  margin-top: 1px;
+}
+
+.playing-card__center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 26px;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.playing-card--red { color: #cc0000; }
+.playing-card--black { color: #111111; }
+.playing-card--joker {
+  color: #5b2d8e;
+  font-family: "Press Start 2P", monospace;
+}
+
+.playing-card--empty {
+  width: 72px;
+  height: 100px;
+  border-radius: 4px;
+  border: 2px dashed #808080;
+  background: #d4d0c8;
+  flex-shrink: 0;
+}
+
+/* ─── Cards Launcher ────────────────────────────────────────────────── */
+
+.cards-launcher {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+}
+
+.cards-launcher__label {
+  font-size: 8px;
+  color: #000;
+  margin-bottom: 4px;
+  display: block;
+}
+
+.cards-launcher__select {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 4px 6px;
+  width: 100%;
+  color: #000;
+  cursor: pointer;
+}
+
+.cards-launcher__divider {
+  height: 0;
+  border: none;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 2px 0;
+}
+
+.cards-launcher__section-title {
+  font-size: 8px;
+  color: #000;
+  margin-bottom: 6px;
+}
+
+.cards-launcher__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.cards-launcher__option-label {
+  font-size: 7px;
+  flex: 1;
+  color: #000;
+}
+
+/* Stepper (deck count) */
+.cards-launcher__stepper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cards-launcher__step-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 10px;
+  width: 22px;
+  height: 22px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+}
+
+.cards-launcher__step-btn:active:not(:disabled) {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.cards-launcher__step-btn:disabled {
+  color: #808080;
+  cursor: default;
+}
+
+.cards-launcher__step-val {
+  font-size: 9px;
+  min-width: 18px;
+  text-align: center;
+}
+
+/* Suit toggles */
+.cards-launcher__suits {
+  display: flex;
+  gap: 4px;
+}
+
+.cards-launcher__suit-btn {
+  font-size: 14px;
+  width: 28px;
+  height: 28px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  opacity: 0.35;
+  transition: opacity 0.1s;
+}
+
+.cards-launcher__suit-btn--red { color: #cc0000; }
+.cards-launcher__suit-btn--black { color: #111; }
+
+.cards-launcher__suit-btn--on {
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #e8e8e8;
+  opacity: 1;
+}
+
+/* Jokers checkbox */
+.cards-launcher__checkbox-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.cards-launcher__checkbox-text {
+  font-size: 7px;
+}
+
+/* Card back color swatches */
+.cards-launcher__swatches {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.cards-launcher__swatch {
+  width: 22px;
+  height: 22px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  cursor: pointer;
+  border-radius: 2px;
+  padding: 0;
+  position: relative;
+}
+
+.cards-launcher__swatch--selected {
+  border-color: #ffffff #808080 #808080 #ffffff;
+  outline: 2px solid #000;
+  outline-offset: 1px;
+}
+
+/* Card count summary */
+.cards-launcher__count {
+  font-size: 7px;
+  color: #444;
+  text-align: right;
+}
+
+/* Launch button */
+.cards-launcher__launch-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  background: #cc4400;
+  color: #fff;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  padding: 8px 20px;
+  cursor: pointer;
+  align-self: center;
+  margin-top: 2px;
+  letter-spacing: 1px;
+}
+
+.cards-launcher__launch-btn:hover { background: #ee5500; }
+.cards-launcher__launch-btn:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+}
+
+/* ─── No Game ───────────────────────────────────────────────────────── */
+
+.no-game {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+}
+
+.no-game__info {
+  font-size: 7px;
+  color: #444;
+  text-align: center;
+}
+
+.no-game__table {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.no-game__pile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+}
+
+.no-game__pile-label {
+  font-size: 7px;
+  color: #444;
+}
+
+.no-game__pile-count {
+  font-size: 7px;
+  color: #444;
+}
+
+.no-game__pile-count--low {
+  color: #cc4400;
+}
+
+.no-game__arrow {
+  font-size: 18px;
+  color: #666;
+  padding-bottom: 16px;
+}
+
+.no-game__empty-msg {
+  font-size: 8px;
+  color: #cc4400;
+  margin-bottom: 6px;
+  text-align: center;
+}
+
+/* Buttons */
+.no-game__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 7px 14px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.no-game__btn--draw {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+
+.no-game__btn--draw:hover { background: #ee5500; }
+.no-game__btn--draw:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+}
+
+.no-game__btn--reshuffle {
+  background: #5b2d8e;
+  color: #fff;
+  border-color: #9966cc #331155 #331155 #9966cc;
+}
+
+.no-game__btn--reshuffle:hover { background: #7b3dbe; }
+.no-game__btn--reshuffle:active {
+  border-color: #331155 #9966cc #9966cc #331155;
+}

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -58,7 +58,8 @@ export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
           onChange={(e) => setGame(e.target.value as CardsGame)}
         >
           <option value="no-game">No Game</option>
-          <option disabled>── Coming Soon ──</option>
+          <option value="blackjack">Blackjack</option>
+          <option disabled>── More Coming Soon ──</option>
         </select>
       </div>
 

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import "./Cards.css";
+import { PlayingCard } from "./PlayingCard";
+import {
+  DEFAULT_DECK_SETTINGS,
+  CARD_BACK_COLORS,
+  type CardsGame,
+  type DeckSettings,
+  type Suit,
+} from "./types";
+import { totalCards } from "./deckUtils";
+
+const SUITS: { id: Suit; symbol: string; isRed: boolean }[] = [
+  { id: "spades",   symbol: "♠", isRed: false },
+  { id: "hearts",   symbol: "♥", isRed: true  },
+  { id: "diamonds", symbol: "♦", isRed: true  },
+  { id: "clubs",    symbol: "♣", isRed: false },
+];
+
+// Dummy card used to preview the card back in the launcher
+const PREVIEW_CARD = { suit: "spades" as const, rank: "A" as const, id: "preview" };
+
+interface CardsLauncherProps {
+  onLaunch: (game: CardsGame, settings: DeckSettings) => void;
+}
+
+export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
+  const [game, setGame] = useState<CardsGame>("no-game");
+  const [settings, setSettings] = useState<DeckSettings>(DEFAULT_DECK_SETTINGS);
+
+  const toggleSuit = (suit: Suit) => {
+    const active = settings.suits.includes(suit);
+    // Must keep at least one suit
+    if (active && settings.suits.length === 1) return;
+    setSettings((prev) => ({
+      ...prev,
+      suits: active ? prev.suits.filter((s) => s !== suit) : [...prev.suits, suit],
+    }));
+  };
+
+  const stepDecks = (delta: number) => {
+    setSettings((prev) => ({
+      ...prev,
+      numDecks: Math.max(1, Math.min(6, prev.numDecks + delta)),
+    }));
+  };
+
+  const count = totalCards(settings);
+
+  return (
+    <div className="cards-launcher">
+      {/* Game picker */}
+      <div>
+        <label className="cards-launcher__label">Select Game:</label>
+        <select
+          className="cards-launcher__select"
+          value={game}
+          onChange={(e) => setGame(e.target.value as CardsGame)}
+        >
+          <option value="no-game">No Game</option>
+          <option disabled>── Coming Soon ──</option>
+        </select>
+      </div>
+
+      <div className="cards-launcher__divider" />
+
+      {/* Options */}
+      <div>
+        <div className="cards-launcher__section-title">Options:</div>
+
+        {/* Deck count */}
+        <div className="cards-launcher__row">
+          <span className="cards-launcher__option-label">Number of Decks:</span>
+          <div className="cards-launcher__stepper">
+            <button
+              className="cards-launcher__step-btn"
+              onClick={() => stepDecks(-1)}
+              disabled={settings.numDecks <= 1}
+            >−</button>
+            <span className="cards-launcher__step-val">{settings.numDecks}</span>
+            <button
+              className="cards-launcher__step-btn"
+              onClick={() => stepDecks(1)}
+              disabled={settings.numDecks >= 6}
+            >+</button>
+          </div>
+        </div>
+
+        {/* Suits */}
+        <div className="cards-launcher__row">
+          <span className="cards-launcher__option-label">Suits:</span>
+          <div className="cards-launcher__suits">
+            {SUITS.map((s) => (
+              <button
+                key={s.id}
+                className={[
+                  "cards-launcher__suit-btn",
+                  s.isRed ? "cards-launcher__suit-btn--red" : "cards-launcher__suit-btn--black",
+                  settings.suits.includes(s.id) ? "cards-launcher__suit-btn--on" : "",
+                ].join(" ")}
+                title={s.id}
+                onClick={() => toggleSuit(s.id)}
+              >
+                {s.symbol}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Jokers */}
+        <div className="cards-launcher__row">
+          <span className="cards-launcher__option-label">Include Jokers:</span>
+          <label className="cards-launcher__checkbox-wrap">
+            <input
+              type="checkbox"
+              checked={settings.includeJokers}
+              onChange={(e) =>
+                setSettings((prev) => ({ ...prev, includeJokers: e.target.checked }))
+              }
+            />
+            <span className="cards-launcher__checkbox-text">
+              {settings.includeJokers ? "Yes" : "No"}
+            </span>
+          </label>
+        </div>
+
+        {/* Card back color */}
+        <div className="cards-launcher__row" style={{ alignItems: "flex-start" }}>
+          <span className="cards-launcher__option-label" style={{ paddingTop: 4 }}>
+            Card Back:
+          </span>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div className="cards-launcher__swatches">
+              {CARD_BACK_COLORS.map((cb) => (
+                <button
+                  key={cb.color}
+                  className={[
+                    "cards-launcher__swatch",
+                    settings.cardBack === cb.color ? "cards-launcher__swatch--selected" : "",
+                  ].join(" ")}
+                  style={{ background: cb.color }}
+                  title={cb.label}
+                  onClick={() => setSettings((prev) => ({ ...prev, cardBack: cb.color }))}
+                />
+              ))}
+            </div>
+            {/* Live preview */}
+            <PlayingCard card={PREVIEW_CARD} faceDown backColor={settings.cardBack} />
+          </div>
+        </div>
+
+        <div className="cards-launcher__count">{count} card{count !== 1 ? "s" : ""} total</div>
+      </div>
+
+      <div className="cards-launcher__divider" />
+
+      <button
+        className="cards-launcher__launch-btn"
+        onClick={() => onLaunch(game, settings)}
+      >
+        ▶ Launch
+      </button>
+    </div>
+  );
+}

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -7,6 +7,7 @@ import {
   type CardsGame,
   type DeckSettings,
   type Suit,
+  type WarSpeed,
 } from "./types";
 import { totalCards } from "./deckUtils";
 
@@ -17,7 +18,12 @@ const SUITS: { id: Suit; symbol: string; isRed: boolean }[] = [
   { id: "clubs",    symbol: "♣", isRed: false },
 ];
 
-// Dummy card used to preview the card back in the launcher
+const WAR_SPEEDS: { value: WarSpeed; label: string }[] = [
+  { value: "slow",   label: "Slow (2s)"   },
+  { value: "normal", label: "Normal (0.9s)" },
+  { value: "fast",   label: "Fast (0.25s)" },
+];
+
 const PREVIEW_CARD = { suit: "spades" as const, rank: "A" as const, id: "preview" };
 
 interface CardsLauncherProps {
@@ -25,12 +31,11 @@ interface CardsLauncherProps {
 }
 
 export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
-  const [game, setGame] = useState<CardsGame>("no-game");
+  const [game, setGame] = useState<CardsGame>("war");
   const [settings, setSettings] = useState<DeckSettings>(DEFAULT_DECK_SETTINGS);
 
   const toggleSuit = (suit: Suit) => {
     const active = settings.suits.includes(suit);
-    // Must keep at least one suit
     if (active && settings.suits.length === 1) return;
     setSettings((prev) => ({
       ...prev,
@@ -57,8 +62,9 @@ export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
           value={game}
           onChange={(e) => setGame(e.target.value as CardsGame)}
         >
-          <option value="no-game">No Game</option>
+          <option value="war">War</option>
           <option value="blackjack">Blackjack</option>
+          <option value="pyramid">Pyramid</option>
           <option disabled>── More Coming Soon ──</option>
         </select>
       </div>
@@ -73,17 +79,9 @@ export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
         <div className="cards-launcher__row">
           <span className="cards-launcher__option-label">Number of Decks:</span>
           <div className="cards-launcher__stepper">
-            <button
-              className="cards-launcher__step-btn"
-              onClick={() => stepDecks(-1)}
-              disabled={settings.numDecks <= 1}
-            >−</button>
+            <button className="cards-launcher__step-btn" onClick={() => stepDecks(-1)} disabled={settings.numDecks <= 1}>−</button>
             <span className="cards-launcher__step-val">{settings.numDecks}</span>
-            <button
-              className="cards-launcher__step-btn"
-              onClick={() => stepDecks(1)}
-              disabled={settings.numDecks >= 6}
-            >+</button>
+            <button className="cards-launcher__step-btn" onClick={() => stepDecks(1)}  disabled={settings.numDecks >= 6}>+</button>
           </div>
         </div>
 
@@ -115,37 +113,27 @@ export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
             <input
               type="checkbox"
               checked={settings.includeJokers}
-              onChange={(e) =>
-                setSettings((prev) => ({ ...prev, includeJokers: e.target.checked }))
-              }
+              onChange={(e) => setSettings((prev) => ({ ...prev, includeJokers: e.target.checked }))}
             />
-            <span className="cards-launcher__checkbox-text">
-              {settings.includeJokers ? "Yes" : "No"}
-            </span>
+            <span className="cards-launcher__checkbox-text">{settings.includeJokers ? "Yes" : "No"}</span>
           </label>
         </div>
 
         {/* Card back color */}
         <div className="cards-launcher__row" style={{ alignItems: "flex-start" }}>
-          <span className="cards-launcher__option-label" style={{ paddingTop: 4 }}>
-            Card Back:
-          </span>
+          <span className="cards-launcher__option-label" style={{ paddingTop: 4 }}>Card Back:</span>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             <div className="cards-launcher__swatches">
               {CARD_BACK_COLORS.map((cb) => (
                 <button
                   key={cb.color}
-                  className={[
-                    "cards-launcher__swatch",
-                    settings.cardBack === cb.color ? "cards-launcher__swatch--selected" : "",
-                  ].join(" ")}
+                  className={["cards-launcher__swatch", settings.cardBack === cb.color ? "cards-launcher__swatch--selected" : ""].join(" ")}
                   style={{ background: cb.color }}
                   title={cb.label}
                   onClick={() => setSettings((prev) => ({ ...prev, cardBack: cb.color }))}
                 />
               ))}
             </div>
-            {/* Live preview */}
             <PlayingCard card={PREVIEW_CARD} faceDown backColor={settings.cardBack} />
           </div>
         </div>
@@ -153,12 +141,47 @@ export default function CardsLauncher({ onLaunch }: CardsLauncherProps) {
         <div className="cards-launcher__count">{count} card{count !== 1 ? "s" : ""} total</div>
       </div>
 
+      {/* War-specific settings */}
+      {game === "war" && (
+        <>
+          <div className="cards-launcher__divider" />
+          <div>
+            <div className="cards-launcher__section-title">War Settings:</div>
+
+            <div className="cards-launcher__row">
+              <span className="cards-launcher__option-label">Auto-play:</span>
+              <label className="cards-launcher__checkbox-wrap">
+                <input
+                  type="checkbox"
+                  checked={settings.warAutoPlay}
+                  onChange={(e) => setSettings((prev) => ({ ...prev, warAutoPlay: e.target.checked }))}
+                />
+                <span className="cards-launcher__checkbox-text">{settings.warAutoPlay ? "On" : "Off"}</span>
+              </label>
+            </div>
+
+            {settings.warAutoPlay && (
+              <div className="cards-launcher__row">
+                <span className="cards-launcher__option-label">Speed:</span>
+                <select
+                  className="cards-launcher__select"
+                  style={{ width: "auto" }}
+                  value={settings.warSpeed}
+                  onChange={(e) => setSettings((prev) => ({ ...prev, warSpeed: e.target.value as WarSpeed }))}
+                >
+                  {WAR_SPEEDS.map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
       <div className="cards-launcher__divider" />
 
-      <button
-        className="cards-launcher__launch-btn"
-        onClick={() => onLaunch(game, settings)}
-      >
+      <button className="cards-launcher__launch-btn" onClick={() => onLaunch(game, settings)}>
         ▶ Launch
       </button>
     </div>

--- a/src/experiences/Cards/NoGame.tsx
+++ b/src/experiences/Cards/NoGame.tsx
@@ -1,0 +1,91 @@
+import { useState, useCallback } from "react";
+import "./Cards.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, DeckSettings } from "./types";
+import { buildDeck, totalCards } from "./deckUtils";
+
+const SUIT_SYMBOL: Record<string, string> = {
+  spades: "♠", hearts: "♥", diamonds: "♦", clubs: "♣",
+};
+
+interface NoGameProps {
+  settings: DeckSettings;
+}
+
+export default function NoGame({ settings }: NoGameProps) {
+  const [drawPile, setDrawPile] = useState<Card[]>(() => buildDeck(settings));
+  const [current, setCurrent] = useState<Card | null>(null);
+  const [drawCount, setDrawCount] = useState(0);
+
+  const draw = useCallback(() => {
+    setDrawPile((prev) => {
+      if (prev.length === 0) return prev;
+      const [top, ...rest] = prev;
+      setCurrent(top);
+      setDrawCount((n) => n + 1);
+      return rest;
+    });
+  }, []);
+
+  const reshuffle = useCallback(() => {
+    setDrawPile(buildDeck(settings));
+    setCurrent(null);
+    setDrawCount(0);
+  }, [settings]);
+
+  const remaining = drawPile.length;
+  const total = totalCards(settings);
+  const isEmpty = remaining === 0;
+  const isLow = !isEmpty && remaining / total <= 0.15;
+
+  const suitSummary = settings.suits.map((s) => SUIT_SYMBOL[s]).join("");
+  const jokerSuffix = settings.includeJokers ? " · Jokers" : "";
+  const deckLabel = `${settings.numDecks} deck${settings.numDecks > 1 ? "s" : ""} · ${suitSummary}${jokerSuffix}`;
+
+  return (
+    <div className="no-game">
+      <div className="no-game__info">{deckLabel}</div>
+
+      <div className="no-game__table">
+        {/* Draw pile */}
+        <div className="no-game__pile">
+          <div className="no-game__pile-label">Draw Pile</div>
+          {isEmpty
+            ? <div className="playing-card--empty" />
+            : <PlayingCard card={drawPile[0]} faceDown backColor={settings.cardBack} />
+          }
+          <div className={`no-game__pile-count${isLow ? " no-game__pile-count--low" : ""}`}>
+            {remaining} left
+          </div>
+        </div>
+
+        <div className="no-game__arrow">→</div>
+
+        {/* Last drawn card */}
+        <div className="no-game__pile">
+          <div className="no-game__pile-label">Last Drawn</div>
+          {current
+            ? <PlayingCard card={current} />
+            : <div className="playing-card--empty" />
+          }
+          <div className="no-game__pile-count">{drawCount} drawn</div>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+        {isEmpty && <div className="no-game__empty-msg">Deck is empty!</div>}
+        {isEmpty
+          ? (
+            <button className="no-game__btn no-game__btn--reshuffle" onClick={reshuffle}>
+              ↺ Reshuffle
+            </button>
+          ) : (
+            <button className="no-game__btn no-game__btn--draw" onClick={draw}>
+              ▶ Draw Card
+            </button>
+          )
+        }
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -1,0 +1,63 @@
+import "./Cards.css";
+import type { Card } from "./types";
+
+const SUIT_SYMBOL: Record<string, string> = {
+  spades:   "♠",
+  hearts:   "♥",
+  diamonds: "♦",
+  clubs:    "♣",
+};
+
+interface PlayingCardProps {
+  card: Card;
+  faceDown?: boolean;
+  /** Hex color for the card back. Only used when faceDown is true. */
+  backColor?: string;
+}
+
+export function PlayingCard({ card, faceDown = false, backColor = "#cc4400" }: PlayingCardProps) {
+  if (faceDown) {
+    return (
+      <div
+        className="playing-card playing-card--back"
+        style={{ "--card-back": backColor } as React.CSSProperties}
+      >
+        <div className="playing-card__back-inner" />
+      </div>
+    );
+  }
+
+  if (card.suit === "joker") {
+    return (
+      <div className="playing-card playing-card--front playing-card--joker">
+        <div className="playing-card__corner playing-card__corner--tl">
+          <span className="playing-card__rank">★</span>
+        </div>
+        <div className="playing-card__center" style={{ fontSize: 18, textAlign: "center", lineHeight: 1.4 }}>
+          ★<br />JOKER
+        </div>
+        <div className="playing-card__corner playing-card__corner--br">
+          <span className="playing-card__rank">★</span>
+        </div>
+      </div>
+    );
+  }
+
+  const symbol = SUIT_SYMBOL[card.suit] ?? "?";
+  const isRed = card.suit === "hearts" || card.suit === "diamonds";
+  const colorClass = isRed ? "playing-card--red" : "playing-card--black";
+
+  return (
+    <div className={`playing-card playing-card--front ${colorClass}`}>
+      <div className="playing-card__corner playing-card__corner--tl">
+        <span className="playing-card__rank">{card.rank}</span>
+        <span className="playing-card__suit-pip">{symbol}</span>
+      </div>
+      <div className="playing-card__center">{symbol}</div>
+      <div className="playing-card__corner playing-card__corner--br">
+        <span className="playing-card__rank">{card.rank}</span>
+        <span className="playing-card__suit-pip">{symbol}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -11,15 +11,18 @@ const SUIT_SYMBOL: Record<string, string> = {
 interface PlayingCardProps {
   card: Card;
   faceDown?: boolean;
-  /** Hex color for the card back. Only used when faceDown is true. */
   backColor?: string;
+  /** "sm" renders a smaller card suitable for pyramid layout */
+  size?: "sm";
 }
 
-export function PlayingCard({ card, faceDown = false, backColor = "#cc4400" }: PlayingCardProps) {
+export function PlayingCard({ card, faceDown = false, backColor = "#cc4400", size }: PlayingCardProps) {
+  const sizeClass = size === "sm" ? " playing-card--sm" : "";
+
   if (faceDown) {
     return (
       <div
-        className="playing-card playing-card--back"
+        className={`playing-card playing-card--back${sizeClass}`}
         style={{ "--card-back": backColor } as React.CSSProperties}
       >
         <div className="playing-card__back-inner" />
@@ -29,11 +32,11 @@ export function PlayingCard({ card, faceDown = false, backColor = "#cc4400" }: P
 
   if (card.suit === "joker") {
     return (
-      <div className="playing-card playing-card--front playing-card--joker">
+      <div className={`playing-card playing-card--front playing-card--joker${sizeClass}`}>
         <div className="playing-card__corner playing-card__corner--tl">
           <span className="playing-card__rank">★</span>
         </div>
-        <div className="playing-card__center" style={{ fontSize: 18, textAlign: "center", lineHeight: 1.4 }}>
+        <div className="playing-card__center" style={{ fontSize: size === "sm" ? 13 : 18, textAlign: "center", lineHeight: 1.4 }}>
           ★<br />JOKER
         </div>
         <div className="playing-card__corner playing-card__corner--br">
@@ -48,7 +51,7 @@ export function PlayingCard({ card, faceDown = false, backColor = "#cc4400" }: P
   const colorClass = isRed ? "playing-card--red" : "playing-card--black";
 
   return (
-    <div className={`playing-card playing-card--front ${colorClass}`}>
+    <div className={`playing-card playing-card--front ${colorClass}${sizeClass}`}>
       <div className="playing-card__corner playing-card__corner--tl">
         <span className="playing-card__rank">{card.rank}</span>
         <span className="playing-card__suit-pip">{symbol}</span>

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -1,0 +1,128 @@
+/* ─── Pyramid Solitaire ─────────────────────────────────────────────── */
+
+.pyramid {
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+}
+
+/* Green felt play area */
+.pyramid__table {
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 8px 8px 4px;
+  padding: 10px 8px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+/* The 7-row card triangle */
+.pyramid__grid {
+  position: relative;
+  /* width/height set by JS via style prop */
+}
+
+/* Each card slot in the pyramid */
+.pyramid__card-wrap {
+  position: absolute;
+  cursor: pointer;
+}
+
+.pyramid__card-wrap--unavailable {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.pyramid__card-wrap--selected .playing-card {
+  outline: 2px solid #ffdd00;
+  outline-offset: 1px;
+  box-shadow: 0 0 6px #ffdd00;
+}
+
+.pyramid__card-wrap--removed {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* Stock + waste row */
+.pyramid__piles {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.pyramid__pile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.pyramid__pile-label {
+  font-size: 6px;
+  color: rgba(255,255,255,0.5);
+}
+
+.pyramid__pile-count {
+  font-size: 6px;
+  color: rgba(255,255,255,0.5);
+}
+
+/* Clickable stock pile */
+.pyramid__stock-card {
+  cursor: pointer;
+}
+
+/* Controls area */
+.pyramid__controls {
+  padding: 6px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.pyramid__status {
+  font-size: 7px;
+  color: #444;
+  text-align: center;
+  min-height: 14px;
+}
+
+.pyramid__status--win  { color: #228833; }
+.pyramid__status--lose { color: #cc0000; }
+
+.pyramid__btn-row {
+  display: flex;
+  gap: 6px;
+}
+
+.pyramid__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 6px 12px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.pyramid__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+.pyramid__btn--primary:hover  { background: #ee5500; }
+.pyramid__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+
+.pyramid__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.pyramid__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }
+.pyramid__btn--secondary:disabled { color: #808080; cursor: default; }

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -1,0 +1,303 @@
+import { useState, useCallback, useMemo } from "react";
+import "./Pyramid.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, DeckSettings } from "./types";
+import { buildDeck } from "./deckUtils";
+
+// ── Layout constants ─────────────────────────────────────────────────────────
+
+const ROWS = 7;
+const CARD_W = 52;
+const CARD_H = 72;
+const H_GAP = 4;   // horizontal gap between cards in the same row
+const V_STEP = 34; // vertical distance between row tops (overlap)
+
+// Width of the bottom row (widest)
+const BASE_ROW_W = ROWS * CARD_W + (ROWS - 1) * H_GAP; // 388
+const GRID_H = (ROWS - 1) * V_STEP + CARD_H;            // 276
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function pyramidValue(card: Card): number {
+  if (card.rank === "A") return 1;
+  if (card.rank === "J") return 11;
+  if (card.rank === "Q") return 12;
+  if (card.rank === "K") return 13;
+  if (card.rank === "Joker") return 0;
+  return parseInt(card.rank as string, 10);
+}
+
+function cardX(row: number, col: number): number {
+  const rowW = row * CARD_W + (row - 1) * H_GAP;
+  const startX = (BASE_ROW_W - rowW) / 2;
+  return startX + col * (CARD_W + H_GAP);
+}
+
+function cardY(row: number): number {
+  return (row - 1) * V_STEP;
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface PyramidSlot {
+  card: Card;
+  row: number;  // 1–7
+  col: number;  // 0-indexed within row
+  removed: boolean;
+}
+
+type GamePhase = "playing" | "won" | "lost";
+
+interface PyramidState {
+  slots: PyramidSlot[];
+  stock: Card[];
+  waste: Card[];
+  selected: string | null; // card.id of currently selected card (null = none)
+  phase: GamePhase;
+  removedCount: number;
+}
+
+function buildPyramid(settings: DeckSettings): PyramidState {
+  const deck = buildDeck(settings);
+  const pyramidSize = (ROWS * (ROWS + 1)) / 2; // 28
+  const pyramidCards = deck.slice(0, pyramidSize);
+  const stock = deck.slice(pyramidSize);
+
+  const slots: PyramidSlot[] = [];
+  let idx = 0;
+  for (let row = 1; row <= ROWS; row++) {
+    for (let col = 0; col < row; col++) {
+      slots.push({ card: pyramidCards[idx++], row, col, removed: false });
+    }
+  }
+
+  return { slots, stock, waste: [], selected: null, phase: "playing", removedCount: 0 };
+}
+
+// A slot is available if both cards that cover it (row+1, col) and (row+1, col+1) are removed
+function isAvailable(slot: PyramidSlot, slots: PyramidSlot[]): boolean {
+  if (slot.removed) return false;
+  if (slot.row === ROWS) return true; // bottom row always uncovered
+  const coversLeft  = slots.find((s) => s.row === slot.row + 1 && s.col === slot.col);
+  const coversRight = slots.find((s) => s.row === slot.row + 1 && s.col === slot.col + 1);
+  return (!coversLeft || coversLeft.removed) && (!coversRight || coversRight.removed);
+}
+
+function checkLost(state: PyramidState): boolean {
+  if (state.phase !== "playing") return false;
+  const available = state.slots.filter((s) => isAvailable(s, state.slots));
+  const wasteTop = state.waste.at(-1);
+
+  // Check if any king can be removed
+  const hasKing = available.some((s) => pyramidValue(s.card) === 13) ||
+                  (wasteTop !== undefined && pyramidValue(wasteTop) === 13);
+  if (hasKing) return false;
+
+  // Check pairs among available pyramid cards
+  for (let i = 0; i < available.length; i++) {
+    for (let j = i + 1; j < available.length; j++) {
+      if (pyramidValue(available[i].card) + pyramidValue(available[j].card) === 13) return false;
+    }
+    // Check available card + waste top
+    if (wasteTop && pyramidValue(available[i].card) + pyramidValue(wasteTop) === 13) return false;
+  }
+
+  // Check if stock has cards left to draw
+  if (state.stock.length > 0) return false;
+
+  return true;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface PyramidProps {
+  settings: DeckSettings;
+}
+
+export default function Pyramid({ settings }: PyramidProps) {
+  const [state, setState] = useState<PyramidState>(() => buildPyramid(settings));
+
+  const newGame = useCallback(() => setState(buildPyramid(settings)), [settings]);
+
+  const drawFromStock = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+      if (s.stock.length === 0) return s;
+      const [top, ...rest] = s.stock;
+      const next = { ...s, stock: rest, waste: [...s.waste, top], selected: null };
+      return checkLost(next) ? { ...next, phase: "lost" } : next;
+    });
+  }, []);
+
+  const selectCard = useCallback((cardId: string, fromWaste: boolean) => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+
+      // Clicking the same card deselects
+      if (s.selected === cardId) return { ...s, selected: null };
+
+      const clickedSlot = fromWaste ? null : s.slots.find((sl) => sl.card.id === cardId);
+      const clickedCard = fromWaste
+        ? s.waste.at(-1)
+        : clickedSlot?.card;
+
+      if (!clickedCard) return s;
+
+      // King removes itself immediately
+      if (pyramidValue(clickedCard) === 13) {
+        let slots = s.slots;
+        let waste = s.waste;
+        if (fromWaste) {
+          waste = s.waste.slice(0, -1);
+        } else {
+          slots = s.slots.map((sl) => sl.card.id === cardId ? { ...sl, removed: true } : sl);
+        }
+        const removedCount = s.removedCount + 1;
+        const phase = slots.every((sl) => sl.removed) ? "won" : "playing";
+        const next = { ...s, slots, waste, selected: null, removedCount, phase };
+        return phase === "playing" && checkLost(next) ? { ...next, phase: "lost" } : next;
+      }
+
+      // No prior selection — select this card
+      if (!s.selected) return { ...s, selected: cardId };
+
+      // There IS a prior selection — try to pair
+      const prevIsWaste = s.waste.at(-1)?.id === s.selected;
+      const prevCard = prevIsWaste
+        ? s.waste.at(-1)!
+        : s.slots.find((sl) => sl.card.id === s.selected)?.card;
+
+      if (!prevCard) return { ...s, selected: cardId };
+
+      if (pyramidValue(prevCard) + pyramidValue(clickedCard) === 13) {
+        // Remove both
+        let slots = s.slots;
+        let waste = s.waste;
+
+        if (prevIsWaste) {
+          waste = waste.slice(0, -1);
+        } else {
+          slots = slots.map((sl) => sl.card.id === s.selected ? { ...sl, removed: true } : sl);
+        }
+        if (fromWaste) {
+          waste = waste.slice(0, -1);
+        } else {
+          slots = slots.map((sl) => sl.card.id === cardId ? { ...sl, removed: true } : sl);
+        }
+
+        const removedCount = s.removedCount + 2;
+        const phase = slots.every((sl) => sl.removed) ? "won" : "playing";
+        const next = { ...s, slots, waste, selected: null, removedCount, phase };
+        return phase === "playing" && checkLost(next) ? { ...next, phase: "lost" } : next;
+      }
+
+      // Doesn't pair — switch selection to clicked card
+      return { ...s, selected: cardId };
+    });
+  }, []);
+
+  // ── Derived values ────────────────────────────────────────────────────────
+
+  const availableIds = useMemo(
+    () => new Set(state.slots.filter((s) => isAvailable(s, state.slots)).map((s) => s.card.id)),
+    [state.slots]
+  );
+
+  const wasteTop = state.waste.at(-1);
+  const pyramidDone = state.slots.every((s) => s.removed);
+
+  function statusText(): string {
+    if (state.phase === "won") return "You cleared the pyramid!";
+    if (state.phase === "lost") return "No moves remaining.";
+    return `${state.removedCount} removed · ${state.stock.length} in stock`;
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="pyramid">
+      <div className="pyramid__table">
+        {/* Pyramid grid */}
+        {!pyramidDone && (
+          <div className="pyramid__grid" style={{ width: BASE_ROW_W, height: GRID_H }}>
+            {state.slots.map((slot) => {
+              const avail = availableIds.has(slot.card.id);
+              const selected = state.selected === slot.card.id;
+              const cls = [
+                "pyramid__card-wrap",
+                slot.removed      ? "pyramid__card-wrap--removed"     : "",
+                !avail            ? "pyramid__card-wrap--unavailable" : "",
+                selected          ? "pyramid__card-wrap--selected"    : "",
+              ].join(" ");
+              return (
+                <div
+                  key={slot.card.id}
+                  className={cls}
+                  style={{ left: cardX(slot.row, slot.col), top: cardY(slot.row) }}
+                  onClick={() => avail && selectCard(slot.card.id, false)}
+                >
+                  <PlayingCard card={slot.card} size="sm" backColor={settings.cardBack} />
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Stock and waste */}
+        <div className="pyramid__piles">
+          <div className="pyramid__pile">
+            <div className="pyramid__pile-label">Stock</div>
+            <div className="pyramid__stock-card" onClick={drawFromStock}>
+              {state.stock.length > 0
+                ? <PlayingCard card={state.stock[0]} faceDown size="sm" backColor={settings.cardBack} />
+                : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />
+              }
+            </div>
+            <div className="pyramid__pile-count">{state.stock.length}</div>
+          </div>
+
+          <div className="pyramid__pile">
+            <div className="pyramid__pile-label">Waste</div>
+            {wasteTop
+              ? (
+                <div
+                  className={state.selected === wasteTop.id ? "pyramid__card-wrap pyramid__card-wrap--selected" : "pyramid__card-wrap"}
+                  style={{ position: "relative" }}
+                  onClick={() => selectCard(wasteTop.id, true)}
+                >
+                  <PlayingCard card={wasteTop} size="sm" backColor={settings.cardBack} />
+                </div>
+              )
+              : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />
+            }
+            <div className="pyramid__pile-count">{state.waste.length}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="pyramid__controls">
+        <div className={`pyramid__status${state.phase === "won" ? " pyramid__status--win" : state.phase === "lost" ? " pyramid__status--lose" : ""}`}>
+          {statusText()}
+        </div>
+        <div className="pyramid__btn-row">
+          {state.phase !== "playing" && (
+            <button className="pyramid__btn pyramid__btn--primary" onClick={newGame}>
+              New Game
+            </button>
+          )}
+          {state.phase === "playing" && (
+            <button className="pyramid__btn pyramid__btn--secondary" onClick={newGame}>
+              Restart
+            </button>
+          )}
+          {state.selected && (
+            <button className="pyramid__btn pyramid__btn--secondary" onClick={() => setState((s) => ({ ...s, selected: null }))}>
+              Deselect
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -12,11 +12,15 @@ const CARD_H = 72;
 const H_GAP = 4;   // horizontal gap between cards in the same row
 const V_STEP = 34; // vertical distance between row tops (overlap)
 
-// Width of the bottom row (widest)
 const BASE_ROW_W = ROWS * CARD_W + (ROWS - 1) * H_GAP; // 388
 const GRID_H = (ROWS - 1) * V_STEP + CARD_H;            // 276
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Array.at() is ES2022 — use this instead for broader lib compat
+function last<T>(arr: T[]): T | undefined {
+  return arr[arr.length - 1];
+}
 
 function pyramidValue(card: Card): number {
   if (card.rank === "A") return 1;
@@ -41,8 +45,8 @@ function cardY(row: number): number {
 
 interface PyramidSlot {
   card: Card;
-  row: number;  // 1–7
-  col: number;  // 0-indexed within row
+  row: number;
+  col: number;
   removed: boolean;
 }
 
@@ -52,7 +56,7 @@ interface PyramidState {
   slots: PyramidSlot[];
   stock: Card[];
   waste: Card[];
-  selected: string | null; // card.id of currently selected card (null = none)
+  selected: string | null;
   phase: GamePhase;
   removedCount: number;
 }
@@ -74,10 +78,9 @@ function buildPyramid(settings: DeckSettings): PyramidState {
   return { slots, stock, waste: [], selected: null, phase: "playing", removedCount: 0 };
 }
 
-// A slot is available if both cards that cover it (row+1, col) and (row+1, col+1) are removed
 function isAvailable(slot: PyramidSlot, slots: PyramidSlot[]): boolean {
   if (slot.removed) return false;
-  if (slot.row === ROWS) return true; // bottom row always uncovered
+  if (slot.row === ROWS) return true;
   const coversLeft  = slots.find((s) => s.row === slot.row + 1 && s.col === slot.col);
   const coversRight = slots.find((s) => s.row === slot.row + 1 && s.col === slot.col + 1);
   return (!coversLeft || coversLeft.removed) && (!coversRight || coversRight.removed);
@@ -86,23 +89,19 @@ function isAvailable(slot: PyramidSlot, slots: PyramidSlot[]): boolean {
 function checkLost(state: PyramidState): boolean {
   if (state.phase !== "playing") return false;
   const available = state.slots.filter((s) => isAvailable(s, state.slots));
-  const wasteTop = state.waste.at(-1);
+  const wasteTop = last(state.waste);
 
-  // Check if any king can be removed
   const hasKing = available.some((s) => pyramidValue(s.card) === 13) ||
                   (wasteTop !== undefined && pyramidValue(wasteTop) === 13);
   if (hasKing) return false;
 
-  // Check pairs among available pyramid cards
   for (let i = 0; i < available.length; i++) {
     for (let j = i + 1; j < available.length; j++) {
       if (pyramidValue(available[i].card) + pyramidValue(available[j].card) === 13) return false;
     }
-    // Check available card + waste top
     if (wasteTop && pyramidValue(available[i].card) + pyramidValue(wasteTop) === 13) return false;
   }
 
-  // Check if stock has cards left to draw
   if (state.stock.length > 0) return false;
 
   return true;
@@ -124,7 +123,7 @@ export default function Pyramid({ settings }: PyramidProps) {
       if (s.phase !== "playing") return s;
       if (s.stock.length === 0) return s;
       const [top, ...rest] = s.stock;
-      const next = { ...s, stock: rest, waste: [...s.waste, top], selected: null };
+      const next: PyramidState = { ...s, stock: rest, waste: [...s.waste, top], selected: null };
       return checkLost(next) ? { ...next, phase: "lost" } : next;
     });
   }, []);
@@ -133,13 +132,10 @@ export default function Pyramid({ settings }: PyramidProps) {
     setState((s) => {
       if (s.phase !== "playing") return s;
 
-      // Clicking the same card deselects
       if (s.selected === cardId) return { ...s, selected: null };
 
       const clickedSlot = fromWaste ? null : s.slots.find((sl) => sl.card.id === cardId);
-      const clickedCard = fromWaste
-        ? s.waste.at(-1)
-        : clickedSlot?.card;
+      const clickedCard = fromWaste ? last(s.waste) : clickedSlot?.card;
 
       if (!clickedCard) return s;
 
@@ -153,24 +149,23 @@ export default function Pyramid({ settings }: PyramidProps) {
           slots = s.slots.map((sl) => sl.card.id === cardId ? { ...sl, removed: true } : sl);
         }
         const removedCount = s.removedCount + 1;
-        const phase = slots.every((sl) => sl.removed) ? "won" : "playing";
-        const next = { ...s, slots, waste, selected: null, removedCount, phase };
+        const phase: GamePhase = slots.every((sl) => sl.removed) ? "won" : "playing";
+        const next: PyramidState = { ...s, slots, waste, selected: null, removedCount, phase };
         return phase === "playing" && checkLost(next) ? { ...next, phase: "lost" } : next;
       }
 
-      // No prior selection — select this card
       if (!s.selected) return { ...s, selected: cardId };
 
-      // There IS a prior selection — try to pair
-      const prevIsWaste = s.waste.at(-1)?.id === s.selected;
+      // Try to pair with previously selected card
+      const wasteTop = last(s.waste);
+      const prevIsWaste = wasteTop?.id === s.selected;
       const prevCard = prevIsWaste
-        ? s.waste.at(-1)!
+        ? wasteTop!
         : s.slots.find((sl) => sl.card.id === s.selected)?.card;
 
       if (!prevCard) return { ...s, selected: cardId };
 
       if (pyramidValue(prevCard) + pyramidValue(clickedCard) === 13) {
-        // Remove both
         let slots = s.slots;
         let waste = s.waste;
 
@@ -186,12 +181,11 @@ export default function Pyramid({ settings }: PyramidProps) {
         }
 
         const removedCount = s.removedCount + 2;
-        const phase = slots.every((sl) => sl.removed) ? "won" : "playing";
-        const next = { ...s, slots, waste, selected: null, removedCount, phase };
+        const phase: GamePhase = slots.every((sl) => sl.removed) ? "won" : "playing";
+        const next: PyramidState = { ...s, slots, waste, selected: null, removedCount, phase };
         return phase === "playing" && checkLost(next) ? { ...next, phase: "lost" } : next;
       }
 
-      // Doesn't pair — switch selection to clicked card
       return { ...s, selected: cardId };
     });
   }, []);
@@ -203,7 +197,7 @@ export default function Pyramid({ settings }: PyramidProps) {
     [state.slots]
   );
 
-  const wasteTop = state.waste.at(-1);
+  const wasteTop = last(state.waste);
   const pyramidDone = state.slots.every((s) => s.removed);
 
   function statusText(): string {
@@ -217,7 +211,6 @@ export default function Pyramid({ settings }: PyramidProps) {
   return (
     <div className="pyramid">
       <div className="pyramid__table">
-        {/* Pyramid grid */}
         {!pyramidDone && (
           <div className="pyramid__grid" style={{ width: BASE_ROW_W, height: GRID_H }}>
             {state.slots.map((slot) => {
@@ -225,9 +218,9 @@ export default function Pyramid({ settings }: PyramidProps) {
               const selected = state.selected === slot.card.id;
               const cls = [
                 "pyramid__card-wrap",
-                slot.removed      ? "pyramid__card-wrap--removed"     : "",
-                !avail            ? "pyramid__card-wrap--unavailable" : "",
-                selected          ? "pyramid__card-wrap--selected"    : "",
+                slot.removed ? "pyramid__card-wrap--removed"     : "",
+                !avail       ? "pyramid__card-wrap--unavailable" : "",
+                selected     ? "pyramid__card-wrap--selected"    : "",
               ].join(" ");
               return (
                 <div
@@ -243,7 +236,6 @@ export default function Pyramid({ settings }: PyramidProps) {
           </div>
         )}
 
-        {/* Stock and waste */}
         <div className="pyramid__piles">
           <div className="pyramid__pile">
             <div className="pyramid__pile-label">Stock</div>
@@ -261,7 +253,9 @@ export default function Pyramid({ settings }: PyramidProps) {
             {wasteTop
               ? (
                 <div
-                  className={state.selected === wasteTop.id ? "pyramid__card-wrap pyramid__card-wrap--selected" : "pyramid__card-wrap"}
+                  className={state.selected === wasteTop.id
+                    ? "pyramid__card-wrap pyramid__card-wrap--selected"
+                    : "pyramid__card-wrap"}
                   style={{ position: "relative" }}
                   onClick={() => selectCard(wasteTop.id, true)}
                 >
@@ -275,7 +269,6 @@ export default function Pyramid({ settings }: PyramidProps) {
         </div>
       </div>
 
-      {/* Controls */}
       <div className="pyramid__controls">
         <div className={`pyramid__status${state.phase === "won" ? " pyramid__status--win" : state.phase === "lost" ? " pyramid__status--lose" : ""}`}>
           {statusText()}
@@ -292,7 +285,8 @@ export default function Pyramid({ settings }: PyramidProps) {
             </button>
           )}
           {state.selected && (
-            <button className="pyramid__btn pyramid__btn--secondary" onClick={() => setState((s) => ({ ...s, selected: null }))}>
+            <button className="pyramid__btn pyramid__btn--secondary"
+              onClick={() => setState((s) => ({ ...s, selected: null }))}>
               Deselect
             </button>
           )}

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -1,0 +1,144 @@
+/* ─── War ───────────────────────────────────────────────────────────── */
+
+.war {
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+}
+
+.war__scoreboard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px 4px;
+  font-size: 7px;
+  color: #000;
+  border-bottom: 1px solid #808080;
+}
+
+.war__table {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px 10px;
+  gap: 8px;
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 8px 8px 4px;
+  min-height: 200px;
+}
+
+/* Side columns (player / dealer) */
+.war__side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.war__side-label {
+  font-size: 7px;
+  color: rgba(255,255,255,0.6);
+}
+
+.war__pile-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.war__pile-count {
+  font-size: 7px;
+  color: rgba(255,255,255,0.55);
+}
+
+/* Flipped card revealed in battle */
+.war__flipped {
+  margin-top: 6px;
+}
+
+/* War cards row (face-down × 3 + face-up) */
+.war__war-cards {
+  display: flex;
+  gap: -8px;
+  align-items: flex-end;
+}
+
+.war__war-cards > * + * {
+  margin-left: -8px;
+}
+
+/* Center column */
+.war__center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 40px;
+  min-width: 40px;
+}
+
+.war__vs {
+  font-size: 9px;
+  color: rgba(255,255,255,0.4);
+  letter-spacing: 1px;
+}
+
+/* Controls */
+.war__controls {
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.war__banner {
+  font-size: 9px;
+  padding: 5px 12px;
+  border: 2px solid;
+  text-align: center;
+}
+
+.war__banner--win  { color: #44cc44; border-color: #44cc44; background: rgba(68,204,68,0.1); }
+.war__banner--lose { color: #cc4444; border-color: #cc4444; background: rgba(204,68,68,0.1); }
+.war__banner--war  { color: #ffcc00; border-color: #ffcc00; background: rgba(255,204,0,0.1); }
+
+.war__btn-row {
+  display: flex;
+  gap: 6px;
+}
+
+.war__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 6px 12px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.war__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+.war__btn--primary:hover  { background: #ee5500; }
+.war__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+.war__btn--primary:disabled { background: #884400; cursor: default; }
+
+.war__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.war__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }
+
+.war__auto-notice {
+  font-size: 7px;
+  color: #808080;
+}

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -1,0 +1,407 @@
+import { useState, useCallback, useEffect } from "react";
+import "./Cards.css";
+import "./War.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, DeckSettings } from "./types";
+import { buildDeck, shuffle } from "./deckUtils";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const RANK_ORDER = ["2","3","4","5","6","7","8","9","10","J","Q","K","A"] as const;
+
+function warValue(card: Card): number {
+  if (card.rank === "Joker") return -1;
+  return RANK_ORDER.indexOf(card.rank as typeof RANK_ORDER[number]);
+}
+
+const WAR_SPEED_MS: Record<string, number> = {
+  slow: 2000,
+  normal: 900,
+  fast: 250,
+};
+const GAME_OVER_DELAY_MS = 2500;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Phase =
+  | "ready"       // waiting to flip
+  | "revealed"    // cards flipped, showing result
+  | "war-ready"   // tie — waiting to place war cards
+  | "war-revealed"// war cards flipped
+  | "game-over";
+
+interface WarState {
+  playerPile: Card[];
+  dealerPile: Card[];
+  playerCard: Card | null;
+  dealerCard: Card | null;
+  warPlayerCards: Card[];  // face-down war cards
+  warDealerCards: Card[];
+  warPlayerFinal: Card | null;
+  warDealerFinal: Card | null;
+  phase: Phase;
+  roundResult: "player" | "dealer" | "war" | null;
+  gameResult: "player" | "dealer" | null;
+  roundCount: number;
+}
+
+function makeInitialState(settings: DeckSettings): WarState {
+  const deck = buildDeck(settings);
+  const mid = Math.floor(deck.length / 2);
+  return {
+    playerPile: deck.slice(0, mid),
+    dealerPile: deck.slice(mid),
+    playerCard: null,
+    dealerCard: null,
+    warPlayerCards: [],
+    warDealerCards: [],
+    warPlayerFinal: null,
+    warDealerFinal: null,
+    phase: "ready",
+    roundResult: null,
+    gameResult: null,
+    roundCount: 0,
+  };
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface WarProps {
+  settings: DeckSettings;
+}
+
+export default function War({ settings }: WarProps) {
+  const [state, setState] = useState<WarState>(() => makeInitialState(settings));
+
+  const autoPlay = settings.warAutoPlay;
+  const speedMs = WAR_SPEED_MS[settings.warSpeed] ?? 900;
+
+  // ── Core actions ──────────────────────────────────────────────────────────
+
+  const flip = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "ready") return s;
+      if (s.playerPile.length === 0 || s.dealerPile.length === 0) return s;
+
+      const [pc, ...pRest] = s.playerPile;
+      const [dc, ...dRest] = s.dealerPile;
+      const pv = warValue(pc);
+      const dv = warValue(dc);
+
+      const roundResult: "player" | "dealer" | "war" =
+        pv > dv ? "player" : pv < dv ? "dealer" : "war";
+
+      let playerPile = pRest;
+      let dealerPile = dRest;
+
+      if (roundResult === "player") {
+        playerPile = [...pRest, ...shuffle([pc, dc])];
+      } else if (roundResult === "dealer") {
+        dealerPile = [...dRest, ...shuffle([pc, dc])];
+      }
+      // war: cards go to warCards, resolved after war
+
+      return {
+        ...s,
+        playerPile,
+        dealerPile,
+        playerCard: pc,
+        dealerCard: dc,
+        roundResult,
+        phase: "revealed",
+        roundCount: s.roundCount + 1,
+      };
+    });
+  }, []);
+
+  const resolveRevealed = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "revealed") return s;
+
+      if (s.roundResult === "war") {
+        // Check if both players have cards for war (need at least 1 for face-up)
+        if (s.playerPile.length === 0) {
+          return { ...s, phase: "game-over", gameResult: "dealer" };
+        }
+        if (s.dealerPile.length === 0) {
+          return { ...s, phase: "game-over", gameResult: "player" };
+        }
+        return { ...s, phase: "war-ready" };
+      }
+
+      // Check game over
+      if (s.playerPile.length === 0) {
+        return { ...s, phase: "game-over", gameResult: "dealer" };
+      }
+      if (s.dealerPile.length === 0) {
+        return { ...s, phase: "game-over", gameResult: "player" };
+      }
+
+      return { ...s, phase: "ready", playerCard: null, dealerCard: null };
+    });
+  }, []);
+
+  const flipWar = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "war-ready") return s;
+
+      // Each player puts up to 3 face-down + 1 face-up
+      const pSlice = s.playerPile.length;
+      const dSlice = s.dealerPile.length;
+
+      const pFaceDownCount = Math.min(3, pSlice - 1);
+      const dFaceDownCount = Math.min(3, dSlice - 1);
+
+      const pFaceDown = s.playerPile.slice(0, pFaceDownCount);
+      const pFaceUp   = s.playerPile[pFaceDownCount] ?? null;
+      const pRemain   = s.playerPile.slice(pFaceDownCount + 1);
+
+      const dFaceDown = s.dealerPile.slice(0, dFaceDownCount);
+      const dFaceUp   = s.dealerPile[dFaceDownCount] ?? null;
+      const dRemain   = s.dealerPile.slice(dFaceDownCount + 1);
+
+      // All battle cards: original face-up + war face-down + war face-up
+      const allBattleCards = [
+        s.playerCard!, s.dealerCard!,
+        ...pFaceDown, ...dFaceDown,
+      ];
+
+      let playerPile = pRemain;
+      let dealerPile = dRemain;
+      let roundResult: "player" | "dealer" | "war" = "war";
+
+      if (!pFaceUp) {
+        roundResult = "dealer";
+        dealerPile = [...dRemain, ...shuffle([...allBattleCards, ...dFaceDown])];
+      } else if (!dFaceUp) {
+        roundResult = "player";
+        playerPile = [...pRemain, ...shuffle([...allBattleCards, ...pFaceDown])];
+      } else {
+        const pv = warValue(pFaceUp);
+        const dv = warValue(dFaceUp);
+        roundResult = pv > dv ? "player" : pv < dv ? "dealer" : "war";
+        const spoils = shuffle([...allBattleCards, pFaceUp, dFaceUp]);
+        if (roundResult === "player") playerPile = [...pRemain, ...spoils];
+        else if (roundResult === "dealer") dealerPile = [...dRemain, ...spoils];
+        // war again: cards stay off table until next war resolution
+      }
+
+      return {
+        ...s,
+        playerPile,
+        dealerPile,
+        warPlayerCards: pFaceDown,
+        warDealerCards: dFaceDown,
+        warPlayerFinal: pFaceUp,
+        warDealerFinal: dFaceUp,
+        roundResult,
+        phase: "war-revealed",
+        roundCount: s.roundCount + 1,
+      };
+    });
+  }, []);
+
+  const resolveWarRevealed = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "war-revealed") return s;
+
+      if (s.roundResult === "war") {
+        if (s.playerPile.length === 0) return { ...s, phase: "game-over", gameResult: "dealer" };
+        if (s.dealerPile.length === 0) return { ...s, phase: "game-over", gameResult: "player" };
+        return { ...s, phase: "war-ready" };
+      }
+      if (s.playerPile.length === 0) return { ...s, phase: "game-over", gameResult: "dealer" };
+      if (s.dealerPile.length === 0) return { ...s, phase: "game-over", gameResult: "player" };
+
+      return {
+        ...s,
+        phase: "ready",
+        playerCard: null,
+        dealerCard: null,
+        warPlayerCards: [],
+        warDealerCards: [],
+        warPlayerFinal: null,
+        warDealerFinal: null,
+        roundResult: null,
+      };
+    });
+  }, []);
+
+  const newGame = useCallback(() => {
+    setState(makeInitialState(settings));
+  }, [settings]);
+
+  // ── Auto-play ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!autoPlay) return;
+
+    const advance = () => {
+      setState((s) => {
+        switch (s.phase) {
+          case "ready":       { flip(); return s; }
+          case "revealed":    { resolveRevealed(); return s; }
+          case "war-ready":   { flipWar(); return s; }
+          case "war-revealed":{ resolveWarRevealed(); return s; }
+          default: return s;
+        }
+      });
+    };
+
+    // For game-over, use a longer fixed delay then restart
+    if (state.phase === "game-over") {
+      const t = setTimeout(newGame, GAME_OVER_DELAY_MS);
+      return () => clearTimeout(t);
+    }
+
+    const t = setTimeout(() => {
+      if (state.phase === "ready") flip();
+      else if (state.phase === "revealed") resolveRevealed();
+      else if (state.phase === "war-ready") flipWar();
+      else if (state.phase === "war-revealed") resolveWarRevealed();
+    }, speedMs);
+
+    return () => { clearTimeout(t); void advance; };
+  }, [autoPlay, speedMs, state.phase, flip, resolveRevealed, flipWar, resolveWarRevealed, newGame]);
+
+  // ── Render helpers ────────────────────────────────────────────────────────
+
+  const { phase, playerCard, dealerCard, playerPile, dealerPile,
+          warPlayerCards, warDealerCards, warPlayerFinal, warDealerFinal,
+          roundResult, gameResult, roundCount } = state;
+
+  const isWar = phase === "war-ready" || phase === "war-revealed";
+
+  function resultBanner(): string {
+    if (phase === "revealed" || phase === "war-revealed") {
+      if (roundResult === "player") return "You win the round!";
+      if (roundResult === "dealer") return "Dealer wins the round.";
+      if (roundResult === "war") return "WAR!";
+    }
+    if (phase === "game-over") {
+      if (gameResult === "player") return "🏆 YOU WIN!";
+      return "Dealer wins.";
+    }
+    return "";
+  }
+
+  function cardCount(pile: Card[], extra?: (Card | null)[]): number {
+    return pile.length + (extra ?? []).filter(Boolean).length;
+  }
+
+  return (
+    <div className="war">
+      {/* Scoreboard */}
+      <div className="war__scoreboard">
+        <span>Round {roundCount}</span>
+        <span>You: {cardCount(playerPile, [playerCard, warPlayerFinal, ...warPlayerCards])} cards</span>
+        <span>Dealer: {cardCount(dealerPile, [dealerCard, warDealerFinal, ...warDealerCards])} cards</span>
+      </div>
+
+      {/* Battle area */}
+      <div className="war__table">
+        {/* Player side */}
+        <div className="war__side war__side--player">
+          <div className="war__side-label">You</div>
+          <div className="war__pile-stack">
+            {playerPile.length > 0
+              ? <PlayingCard card={playerPile[0]} faceDown backColor={settings.cardBack} />
+              : <div className="playing-card--empty" />
+            }
+            <div className="war__pile-count">{playerPile.length} left</div>
+          </div>
+          {isWar && (
+            <div className="war__war-cards">
+              {warPlayerCards.map((c) => (
+                <PlayingCard key={c.id} card={c} faceDown backColor={settings.cardBack} />
+              ))}
+              {warPlayerFinal
+                ? <PlayingCard card={warPlayerFinal} />
+                : phase === "war-ready" ? null : null
+              }
+            </div>
+          )}
+          {playerCard && (
+            <div className="war__flipped">
+              <PlayingCard card={playerCard} />
+            </div>
+          )}
+        </div>
+
+        {/* Center VS */}
+        <div className="war__center">
+          <span className="war__vs">{isWar ? "WAR" : "VS"}</span>
+        </div>
+
+        {/* Dealer side */}
+        <div className="war__side war__side--dealer">
+          <div className="war__side-label">Dealer</div>
+          <div className="war__pile-stack">
+            {dealerPile.length > 0
+              ? <PlayingCard card={dealerPile[0]} faceDown backColor={settings.cardBack} />
+              : <div className="playing-card--empty" />
+            }
+            <div className="war__pile-count">{dealerPile.length} left</div>
+          </div>
+          {isWar && (
+            <div className="war__war-cards">
+              {warDealerCards.map((c) => (
+                <PlayingCard key={c.id} card={c} faceDown backColor={settings.cardBack} />
+              ))}
+              {warDealerFinal && <PlayingCard card={warDealerFinal} />}
+            </div>
+          )}
+          {dealerCard && (
+            <div className="war__flipped">
+              <PlayingCard card={dealerCard} />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Result / controls */}
+      <div className="war__controls">
+        {resultBanner() && (
+          <div className={`war__banner ${gameResult === "player" ? "war__banner--win" : gameResult === "dealer" ? "war__banner--lose" : roundResult === "player" ? "war__banner--win" : roundResult === "dealer" ? "war__banner--lose" : "war__banner--war"}`}>
+            {resultBanner()}
+          </div>
+        )}
+
+        {!autoPlay && (
+          <div className="war__btn-row">
+            {phase === "ready" && (
+              <button className="war__btn war__btn--primary"
+                disabled={playerPile.length === 0 || dealerPile.length === 0}
+                onClick={flip}>
+                ▶ Flip
+              </button>
+            )}
+            {phase === "revealed" && (
+              <button className="war__btn war__btn--secondary" onClick={resolveRevealed}>
+                {roundResult === "war" ? "Go to War →" : "Next Round →"}
+              </button>
+            )}
+            {phase === "war-ready" && (
+              <button className="war__btn war__btn--primary" onClick={flipWar}>
+                ⚔ Flip War Cards
+              </button>
+            )}
+            {phase === "war-revealed" && (
+              <button className="war__btn war__btn--secondary" onClick={resolveWarRevealed}>
+                {roundResult === "war" ? "War Again →" : "Next Round →"}
+              </button>
+            )}
+            {phase === "game-over" && (
+              <button className="war__btn war__btn--primary" onClick={newGame}>
+                New Game
+              </button>
+            )}
+          </div>
+        )}
+        {autoPlay && phase === "game-over" && (
+          <div className="war__auto-notice">Starting new game…</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/deckUtils.ts
+++ b/src/experiences/Cards/deckUtils.ts
@@ -1,0 +1,33 @@
+import type { Card, DeckSettings, Rank, Suit } from "./types";
+
+const RANKS: Rank[] = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"];
+
+export function buildDeck(settings: DeckSettings): Card[] {
+  const cards: Card[] = [];
+  for (let d = 0; d < settings.numDecks; d++) {
+    for (const suit of settings.suits) {
+      for (const rank of RANKS) {
+        cards.push({ suit, rank, id: `${d}-${suit}-${rank}` });
+      }
+    }
+    if (settings.includeJokers) {
+      cards.push({ suit: "joker", rank: "Joker", id: `${d}-joker-red` });
+      cards.push({ suit: "joker", rank: "Joker", id: `${d}-joker-black` });
+    }
+  }
+  return shuffle(cards);
+}
+
+export function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export function totalCards(settings: DeckSettings): number {
+  const perDeck = settings.suits.length * 13 + (settings.includeJokers ? 2 : 0);
+  return settings.numDecks * perDeck;
+}

--- a/src/experiences/Cards/deckUtils.ts
+++ b/src/experiences/Cards/deckUtils.ts
@@ -1,4 +1,4 @@
-import type { Card, DeckSettings, Rank, Suit } from "./types";
+import type { Card, DeckSettings, Rank } from "./types";
 
 const RANKS: Rank[] = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"];
 

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -21,18 +21,24 @@ export const CARD_BACK_COLORS: CardBackColor[] = [
   { label: "Black",   color: "#1a1a1a" },
 ];
 
+export type WarSpeed = "slow" | "normal" | "fast";
+
 export interface DeckSettings {
   numDecks: number;
   suits: Suit[];
   includeJokers: boolean;
-  cardBack: string; // hex color
+  cardBack: string;
+  warAutoPlay: boolean;
+  warSpeed: WarSpeed;
 }
 
-export type CardsGame = "no-game" | "blackjack";
+export type CardsGame = "war" | "blackjack" | "pyramid";
 
 export const DEFAULT_DECK_SETTINGS: DeckSettings = {
   numDecks: 1,
   suits: ["spades", "hearts", "diamonds", "clubs"],
   includeJokers: false,
   cardBack: "#cc4400",
+  warAutoPlay: false,
+  warSpeed: "normal",
 };

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -1,0 +1,38 @@
+export type Suit = "spades" | "hearts" | "diamonds" | "clubs";
+export type Rank = "A" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "J" | "Q" | "K";
+
+export interface Card {
+  suit: Suit | "joker";
+  rank: Rank | "Joker";
+  id: string;
+}
+
+export interface CardBackColor {
+  label: string;
+  color: string;
+}
+
+export const CARD_BACK_COLORS: CardBackColor[] = [
+  { label: "Orange",  color: "#cc4400" },
+  { label: "Purple",  color: "#5b2d8e" },
+  { label: "Blue",    color: "#1a4a8a" },
+  { label: "Green",   color: "#1a5c2a" },
+  { label: "Red",     color: "#8a1a1a" },
+  { label: "Black",   color: "#1a1a1a" },
+];
+
+export interface DeckSettings {
+  numDecks: number;
+  suits: Suit[];
+  includeJokers: boolean;
+  cardBack: string; // hex color
+}
+
+export type CardsGame = "no-game";
+
+export const DEFAULT_DECK_SETTINGS: DeckSettings = {
+  numDecks: 1,
+  suits: ["spades", "hearts", "diamonds", "clubs"],
+  includeJokers: false,
+  cardBack: "#cc4400",
+};

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -28,7 +28,7 @@ export interface DeckSettings {
   cardBack: string; // hex color
 }
 
-export type CardsGame = "no-game";
+export type CardsGame = "no-game" | "blackjack";
 
 export const DEFAULT_DECK_SETTINGS: DeckSettings = {
   numDecks: 1,

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -26,6 +26,7 @@ import NumberMuncher from "../NumberMuncher/NumberMuncher";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import CardsLauncher from "../Cards/CardsLauncher";
 import NoGame from "../Cards/NoGame";
+import Blackjack from "../Cards/Blackjack";
 import type { CardsGame, DeckSettings } from "../Cards/types";
 import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import "./NsDoors97.css";
@@ -125,6 +126,8 @@ let windowSeq = 0;
 let maxZ = 100;
 
 const TTT_WINDOW_WIDTHS: Record<3 | 5 | 7, number> = { 3: 380, 5: 480, 7: 580 };
+const CARDS_GAME_TITLES: Record<CardsGame, string> = { "no-game": "No Game", "blackjack": "Blackjack" };
+const CARDS_GAME_WIDTHS: Record<CardsGame, number> = { "no-game": 380, "blackjack": 520 };
 const BF_WINDOW_WIDTHS: Record<BfDifficulty, number> = {
   beginner: 310,
   intermediate: 470,
@@ -417,12 +420,12 @@ export default function NsDoors97() {
           ...filtered,
           {
             id: "cards-game",
-            title: "No Game",
+            title: CARDS_GAME_TITLES[game],
             icon: "🃏",
             content: { type: "cards-game" as const, game, settings },
             zIndex: maxZ,
             defaultPosition: { x: 80 + offset, y: 48 + offset },
-            width: 380,
+            width: CARDS_GAME_WIDTHS[game],
           },
         ];
       });
@@ -520,8 +523,11 @@ export default function NsDoors97() {
               onLaunch={(game, settings) => handleCardsLaunch(win.id, game, settings)}
             />
           )}
-          {win.content.type === "cards-game" && (
+          {win.content.type === "cards-game" && win.content.game === "no-game" && (
             <NoGame settings={win.content.settings} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "blackjack" && (
+            <Blackjack settings={win.content.settings} />
           )}
           {win.content.type === "bombfinder" && (
             <BombFinder

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -25,8 +25,9 @@ import TicTacToe from "../TicTacToe/TicTacToe";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import CardsLauncher from "../Cards/CardsLauncher";
-import NoGame from "../Cards/NoGame";
+import War from "../Cards/War";
 import Blackjack from "../Cards/Blackjack";
+import Pyramid from "../Cards/Pyramid";
 import type { CardsGame, DeckSettings } from "../Cards/types";
 import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import "./NsDoors97.css";
@@ -126,8 +127,8 @@ let windowSeq = 0;
 let maxZ = 100;
 
 const TTT_WINDOW_WIDTHS: Record<3 | 5 | 7, number> = { 3: 380, 5: 480, 7: 580 };
-const CARDS_GAME_TITLES: Record<CardsGame, string> = { "no-game": "No Game", "blackjack": "Blackjack" };
-const CARDS_GAME_WIDTHS: Record<CardsGame, number> = { "no-game": 380, "blackjack": 520 };
+const CARDS_GAME_TITLES: Record<CardsGame, string> = { "war": "War", "blackjack": "Blackjack", "pyramid": "Pyramid" };
+const CARDS_GAME_WIDTHS: Record<CardsGame, number> = { "war": 440, "blackjack": 520, "pyramid": 460 };
 const BF_WINDOW_WIDTHS: Record<BfDifficulty, number> = {
   beginner: 310,
   intermediate: 470,
@@ -523,11 +524,14 @@ export default function NsDoors97() {
               onLaunch={(game, settings) => handleCardsLaunch(win.id, game, settings)}
             />
           )}
-          {win.content.type === "cards-game" && win.content.game === "no-game" && (
-            <NoGame settings={win.content.settings} />
+          {win.content.type === "cards-game" && win.content.game === "war" && (
+            <War settings={win.content.settings} />
           )}
           {win.content.type === "cards-game" && win.content.game === "blackjack" && (
             <Blackjack settings={win.content.settings} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "pyramid" && (
+            <Pyramid settings={win.content.settings} />
           )}
           {win.content.type === "bombfinder" && (
             <BombFinder

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -24,6 +24,9 @@ import InternetApp from "./InternetApp";
 import TicTacToe from "../TicTacToe/TicTacToe";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
+import CardsLauncher from "../Cards/CardsLauncher";
+import NoGame from "../Cards/NoGame";
+import type { CardsGame, DeckSettings } from "../Cards/types";
 import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import "./NsDoors97.css";
 
@@ -51,6 +54,7 @@ type DesktopIconAction =
   | "tictactoe"
   | "nomnom"
   | "bombfinder"
+  | "cards"
   | "about"
   | "my-doors"
   | "internet"
@@ -72,6 +76,7 @@ const STATIC_ICONS: DesktopIconDef[] = [
   { id: "about",        title: "About NS Doors 97", icon: "ℹ️", action: "about"   },
   { id: "internet",     title: "Internet",     icon: "🌐", action: "internet"     },
   { id: "screensavers", title: "Screensavers", icon: "💤", action: "screensavers" },
+  { id: "cards",        title: "Cards",        icon: "🃏", action: "cards"        },
 ];
 
 const EXPERIENCE_ICON_DEFS: DesktopIconDef[] = experiences
@@ -98,6 +103,8 @@ type WindowContent =
   | { type: "tictactoe" }
   | { type: "nomnom" }
   | { type: "bombfinder" }
+  | { type: "cards-launcher" }
+  | { type: "cards-game"; game: CardsGame; settings: DeckSettings }
   | { type: "about" }
   | { type: "my-doors" }
   | { type: "internet" }
@@ -304,6 +311,7 @@ export default function NsDoors97() {
         case "tictactoe":    content = { type: "tictactoe" };            width = TTT_WINDOW_WIDTHS[3]; break;
         case "nomnom":       content = { type: "nomnom" };               width = 700; break;
         case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
+        case "cards":        content = { type: "cards-launcher" };       width = 320; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -396,6 +404,55 @@ export default function NsDoors97() {
     []
   );
 
+  // Close the Cards launcher and open the chosen game in a new window
+  const handleCardsLaunch = useCallback(
+    (launcherWinId: string, game: CardsGame, settings: DeckSettings) => {
+      setOpenWindows((prev) => {
+        const filtered = prev.filter((w) => w.id !== launcherWinId);
+        const offset = (windowSeq % 8) * 32;
+        windowSeq++;
+        maxZ++;
+        setActiveWindowId("cards-game");
+        return [
+          ...filtered,
+          {
+            id: "cards-game",
+            title: "No Game",
+            icon: "🃏",
+            content: { type: "cards-game" as const, game, settings },
+            zIndex: maxZ,
+            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            width: 380,
+          },
+        ];
+      });
+    },
+    []
+  );
+
+  // Close the Cards game and reopen the launcher
+  const handleCardsGameClose = useCallback((id: string) => {
+    setOpenWindows((prev) => {
+      const filtered = prev.filter((w) => w.id !== id);
+      const offset = (windowSeq % 8) * 32;
+      windowSeq++;
+      maxZ++;
+      setActiveWindowId("cards");
+      return [
+        ...filtered,
+        {
+          id: "cards",
+          title: "Cards",
+          icon: "🃏",
+          content: { type: "cards-launcher" as const },
+          zIndex: maxZ,
+          defaultPosition: { x: 80 + offset, y: 48 + offset },
+          width: 320,
+        },
+      ];
+    });
+  }, []);
+
   return (
     <div className="ns-desktop">
       {/* ── Icon grid (icons pop in one by one during boot) ── */}
@@ -436,7 +493,7 @@ export default function NsDoors97() {
           zIndex={win.zIndex}
           defaultPosition={win.defaultPosition}
           width={win.width}
-          onClose={closeWindow}
+          onClose={win.content.type === "cards-game" ? handleCardsGameClose : closeWindow}
           onFocus={focusWindow}
         >
           {win.content.type === "app-launcher" && (
@@ -458,6 +515,14 @@ export default function NsDoors97() {
             />
           )}
           {win.content.type === "nomnom" && <NumberMuncher />}
+          {win.content.type === "cards-launcher" && (
+            <CardsLauncher
+              onLaunch={(game, settings) => handleCardsLaunch(win.id, game, settings)}
+            />
+          )}
+          {win.content.type === "cards-game" && (
+            <NoGame settings={win.content.settings} />
+          )}
           {win.content.type === "bombfinder" && (
             <BombFinder
               onDifficultyChange={(diff) =>

--- a/src/experiences/NsDoors97/fileSystem.ts
+++ b/src/experiences/NsDoors97/fileSystem.ts
@@ -273,6 +273,7 @@ export const ROOT: FsFolder = {
             { kind: "file", name: "Tic-Tac-Toe.exe",    type: "exe", action: "tic-tac-toe"    },
             { kind: "file", name: "Word Whirlwind.exe",  type: "exe", action: "word-whirlwind" },
             { kind: "file", name: "Number Muncher.exe",  type: "exe", action: "number-muncher" },
+            { kind: "file", name: "Cards.exe",           type: "exe", action: "cards"          },
             { kind: "file", name: "Solitaire.exe",       type: "exe", action: "noop"           },
             { kind: "file", name: "Minesweeper.exe",     type: "exe", action: "noop"           },
             { kind: "file", name: "SkiFree.exe",         type: "exe", action: "noop"           },


### PR DESCRIPTION
- CardsLauncher window lets you pick a game (No Game or Coming Soon placeholder),
  configure number of decks (1-6), which suits to include, jokers toggle, and
  card back color (6 presets: orange default, purple, blue, green, red, black)
  with a live preview of the selected back
- No Game mode shows a draw pile and last-drawn card; warns when low on cards;
  reshuffle button appears when the deck is empty
- Launching closes the launcher and opens the game window; closing the game
  reopens the launcher
- PlayingCard component renders face-up or face-down with Win95 beveled border;
  card backs use a crosshatch pattern over the chosen color
- Cards.exe added to Programs > Games in the virtual filesystem
- Cards desktop icon (🃏) added to NS Doors 97 desktop

https://claude.ai/code/session_01MmWS2XikoZiUuwYTNRR5XD