### PR TITLE
Add dial-up modem experience — Interwebs icon + synthesized handshake sounds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import TicTacToePage from "./pages/TicTacToePage";
 import WordWhirlwindPage from "./pages/WordWhirlwindPage";
 import BombFinderPage from "./pages/BombFinderPage";
 import NsDoors97Page from "./pages/NsDoors97Page";
+import ModemLabPage from "./pages/ModemLabPage";
 
 export default function App() {
   return (
@@ -31,6 +32,7 @@ export default function App() {
         <Route path="/word-whirlwind" element={<WordWhirlwindPage />} />
         <Route path="/bomb-finder" element={<BombFinderPage />} />
         <Route path="/doors97" element={<NsDoors97Page />} />
+        <Route path="/modem-lab" element={<ModemLabPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/experiences/NsDoors97/DialUpApp.css
+++ b/src/experiences/NsDoors97/DialUpApp.css
@@ -1,0 +1,211 @@
+/* Win95-style dial-up networking dialog */
+
+.dialup {
+  background: #c0c0c0;
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  font-family: "Press Start 2P", monospace;
+  user-select: none;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.dialup__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 6px;
+  border-bottom: 1px solid #808080;
+}
+
+.dialup__header-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.dialup__header-title {
+  font-size: 8px;
+  color: #000;
+  line-height: 1.5;
+}
+
+/* ── Sections ────────────────────────────────────────────────────────────── */
+
+.dialup__section {
+  padding: 8px 10px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dialup__section--box {
+  margin: 4px 8px 6px;
+  padding: 10px 8px 8px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  position: relative;
+}
+
+.dialup__box-title {
+  position: absolute;
+  top: -7px;
+  left: 8px;
+  background: #c0c0c0;
+  padding: 0 4px;
+  font-size: 6px;
+  color: #000;
+}
+
+.dialup__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 22px;
+}
+
+.dialup__label {
+  font-size: 6px;
+  color: #000;
+  white-space: nowrap;
+  min-width: 76px;
+  flex-shrink: 0;
+}
+
+/* ── Form controls ───────────────────────────────────────────────────────── */
+
+.dialup__select {
+  flex: 1;
+  height: 20px;
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  color: #000;
+  padding: 0 2px;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.dialup__select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dialup__phone-display {
+  flex: 1;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #000080;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 2px 6px;
+  letter-spacing: 0.5px;
+}
+
+/* ── Checkboxes ──────────────────────────────────────────────────────────── */
+
+.dialup__checks {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #808080;
+}
+
+.dialup__check-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 6px;
+  color: #000;
+  cursor: pointer;
+  line-height: 1.6;
+}
+
+.dialup__check-label input[type="checkbox"] {
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.dialup__check-label input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* ── Status bar ──────────────────────────────────────────────────────────── */
+
+.dialup__statusbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 8px 6px;
+  padding: 4px 8px;
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  min-height: 22px;
+}
+
+.dialup__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid #555;
+}
+
+.dialup__dot--idle    { background: #c0c0c0; }
+.dialup__dot--working { background: #ffcc00; }
+.dialup__dot--ok      { background: #22aa22; }
+.dialup__dot--error   { background: #cc2200; }
+
+.dialup__status-text {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  color: #000;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Footer buttons ──────────────────────────────────────────────────────── */
+
+.dialup__footer {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 4px 10px 10px;
+}
+
+.dialup__btn {
+  min-width: 80px;
+  padding: 5px 14px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #000;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.dialup__btn:active:not(:disabled) {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.dialup__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.dialup__btn--primary {
+  font-weight: bold;
+}

--- a/src/experiences/NsDoors97/DialUpApp.tsx
+++ b/src/experiences/NsDoors97/DialUpApp.tsx
@@ -1,0 +1,442 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { randomDelay, makeSleep } from "../../utils/retroTiming";
+import { ModemSounds, getDialDuration, type DialType } from "./ModemSounds";
+import "./DialUpApp.css";
+
+// ── ISP list ───────────────────────────────────────────────────────────────
+// successBonus: added to the 0.85 base success rate
+// Funny phone numbers: too few/too many digits always fail
+
+interface ISP {
+  name: string;
+  phone: string;   // display label
+  digits: string;  // raw digits to dial
+  bonus: number;
+}
+
+const ISPS: ISP[] = [
+  { name: "AOL 3.0",           phone: "1-800-827-6364",       digits: "18008276364",          bonus:  0.05 },
+  { name: "CompuServe 2000",   phone: "1-800-395-0550",       digits: "18003950550",          bonus:  0.00 },
+  { name: "EarthLink",         phone: "1-800-395-8425",       digits: "18003958425",          bonus:  0.02 },
+  { name: "Prodigy",           phone: "1-800-776-3449",       digits: "18007763449",          bonus: -0.05 },
+  { name: "NetZero (FREE!)",   phone: "867-5309",             digits: "8675309",              bonus: -0.45 }, // Jenny — 7 digits, too short
+  { name: "Noahsoft Online",   phone: "1-800-NOAHSOFT",       digits: "180066247638",         bonus: -0.50 }, // 12 digits — one too many
+  { name: "Juno",              phone: "4-8-15-16-23-42",      digits: "481516234200",         bonus: -0.60 }, // The Numbers — way too many
+  { name: "@Home Network",     phone: "1-NCC-1701-D",         digits: "162217013",            bonus: -0.55 }, // Enterprise — 9 digits
+  { name: "WebTV",             phone: "3.14159265358979...", digits: "314159265358979323846", bonus: -1.00 }, // Pi — always fails
+];
+
+// ── Settings ────────────────────────────────────────────────────────────────
+
+interface Settings {
+  ispIdx: number;
+  baudRate: string;
+  dialType: DialType;
+  flowControl: string;
+  initString: string;
+  speakerVol: string;
+  errorCorrection: boolean;
+  compression: boolean;
+  turboBoost: boolean;
+  quantumTunneling: boolean;
+  y2kProtection: boolean;
+}
+
+const DEFAULTS: Settings = {
+  ispIdx: 0,
+  baudRate: "56K V.90",
+  dialType: "touchtone",
+  flowControl: "hardware",
+  initString: "at_f",
+  speakerVol: "low",
+  errorCorrection: true,
+  compression: true,
+  turboBoost: false,
+  quantumTunneling: false,
+  y2kProtection: false,
+};
+
+const SPEED_RANGES: Record<string, [number, number]> = {
+  "56K V.90":      [44000, 49333],
+  "33.6K V.34":    [28800, 33600],
+  "28.8K V.34":    [24000, 28800],
+  "14.4K V.32bis": [12000, 14400],
+  "2400 V.22bis":  [2000,  2400 ],
+};
+
+// ── Success rate ───────────────────────────────────────────────────────────
+
+function calcSuccessRate(s: Settings, isp: ISP): number {
+  let r = 0.85 + isp.bonus;
+
+  const baudMod: Record<string, number> = {
+    "56K V.90": 0, "33.6K V.34": -0.05, "28.8K V.34": -0.10,
+    "14.4K V.32bis": -0.20, "2400 V.22bis": -0.50,
+  };
+  r += baudMod[s.baudRate] ?? 0;
+
+  if (s.dialType === "pulse") r -= 0.15;
+  if (!s.errorCorrection)     r -= 0.10;
+  if (!s.compression)         r -= 0.05;
+  if (s.flowControl === "software") r -= 0.05;
+  if (s.flowControl === "none")     r -= 0.15;
+
+  const initMod: Record<string, number> = {
+    at_f: 0, atz: 0, safe: 0.05, aggressive: -0.15, turbo_mode: -0.20,
+  };
+  r += initMod[s.initString] ?? 0;
+
+  if (s.turboBoost)       r -= 0.20;
+  if (s.quantumTunneling) r  = 0;
+  if (s.y2kProtection)    r -= 0.25;
+
+  return Math.max(0, Math.min(0.95, r));
+}
+
+type FailMode = "busy" | "no-answer" | "no-carrier";
+
+function pickFailMode(digits: string, s: Settings): FailMode {
+  const len = digits.length;
+  if (len < 10) return "busy";
+  if (len > 11) return Math.random() < 0.5 ? "no-answer" : "no-carrier";
+  if (s.quantumTunneling) return "no-carrier";
+  if (s.baudRate === "2400 V.22bis") return "no-carrier";
+  const r = Math.random();
+  if (r < 0.30) return "busy";
+  if (r < 0.60) return "no-answer";
+  return "no-carrier";
+}
+
+// ── Phase ──────────────────────────────────────────────────────────────────
+
+type Phase =
+  | "idle" | "dialing" | "ringing" | "handshaking" | "training"
+  | "connected" | "busy" | "no-answer" | "no-carrier";
+
+const CONNECTING_PHASES: Phase[] = ["dialing", "ringing", "handshaking", "training"];
+const FAILURE_PHASES:    Phase[] = ["busy", "no-answer", "no-carrier"];
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export interface DialUpAppProps {
+  onConnected: () => void;
+}
+
+export default function DialUpApp({ onConnected }: DialUpAppProps) {
+  const [settings, setSettings] = useState<Settings>(DEFAULTS);
+  const [phase,    setPhase]    = useState<Phase>("idle");
+  const [statusMsg, setStatus]  = useState("Ready to connect.");
+
+  const cancelObjRef = useRef<{ current: boolean }>({ current: false });
+  const soundsRef    = useRef<ModemSounds | null>(null);
+
+  const isConnecting = CONNECTING_PHASES.includes(phase);
+  const isFailure    = FAILURE_PHASES.includes(phase);
+
+  useEffect(() => {
+    return () => {
+      cancelObjRef.current.current = true;
+      soundsRef.current?.stop();
+    };
+  }, []);
+
+  const handleConnect = useCallback(async () => {
+    if (isConnecting) return;
+
+    // Cancel any in-flight attempt
+    cancelObjRef.current.current = true;
+    soundsRef.current?.stop();
+    soundsRef.current = null;
+
+    // Fresh cancel signal for this attempt
+    const cancelObj = { current: false };
+    cancelObjRef.current = cancelObj;
+    const sleep = makeSleep(cancelObj);
+
+    const isp  = ISPS[settings.ispIdx];
+    const rate = calcSuccessRate(settings, isp);
+    const win  = Math.random() < rate;
+    const fail: FailMode | null = win ? null : pickFailMode(isp.digits, settings);
+
+    const volMap: Record<string, number> = {
+      off: 0.10, low: 0.40, medium: 0.65, high: 0.90,
+    };
+    const sounds = new ModemSounds(volMap[settings.speakerVol] ?? 0.40);
+    soundsRef.current = sounds;
+
+    try {
+      // ── Off-hook + dial tone ─────────────────────────────────────────────
+      setPhase("dialing");
+      setStatus(`Dialing ${isp.phone}...`);
+
+      sounds.playOffHook();
+      await sleep(80);
+      sounds.playDialTone(0.75);
+      await sleep(750);
+
+      // ── Dial the number ──────────────────────────────────────────────────
+      if (settings.dialType === "pulse") {
+        sounds.playPulseDial(isp.digits);
+      } else {
+        sounds.playDTMF(isp.digits);
+      }
+      await sleep(getDialDuration(isp.digits, settings.dialType) + 220);
+
+      // ── Busy ─────────────────────────────────────────────────────────────
+      if (fail === "busy") {
+        setPhase("busy");
+        setStatus("Line busy. Please try again.");
+        sounds.playBusy();
+        await sleep(3000);
+        return;
+      }
+
+      // ── Ringback ─────────────────────────────────────────────────────────
+      setPhase("ringing");
+      setStatus("Waiting for answer...");
+
+      const rings = fail === "no-answer"
+        ? 4 + Math.floor(Math.random() * 2)
+        : Math.floor(Math.random() * 2); // 0 or 1 rings before answer
+
+      sounds.playRingback(rings);
+
+      if (fail === "no-answer") {
+        await sleep(rings * 6000 + 800);
+        setPhase("no-answer");
+        setStatus("No answer. Check the phone number.");
+        return;
+      }
+
+      await sleep(rings * 6000 + randomDelay({ base: 400, variance: 0.5 }));
+
+      // ── ANSam carrier ────────────────────────────────────────────────────
+      setPhase("handshaking");
+      setStatus("Verifying modem protocol...");
+
+      const ansamSec = 3.1 + Math.random() * 0.5;
+      sounds.playANSam(ansamSec);
+      await sleep(Math.round(ansamSec * 1000));
+
+      // ── V.8 negotiation ──────────────────────────────────────────────────
+      const negMs = randomDelay({ base: 2000, variance: 0.35, panicChance: 0.10, panicMultiplier: 2 });
+      sounds.playNegotiation(negMs / 1000);
+      await sleep(negMs);
+
+      if (fail === "no-carrier" && Math.random() < 0.45) {
+        setPhase("no-carrier");
+        setStatus("NO CARRIER — Connection failed.");
+        sounds.playNoCarrier();
+        await sleep(900);
+        return;
+      }
+
+      // ── Training ─────────────────────────────────────────────────────────
+      setPhase("training");
+      setStatus("Negotiating connection speed...");
+
+      const trainMs = randomDelay({ base: 7000, variance: 0.35, panicChance: 0.15, panicMultiplier: 2 });
+      sounds.playTraining(trainMs / 1000);
+      await sleep(trainMs);
+
+      if (fail === "no-carrier") {
+        setPhase("no-carrier");
+        setStatus("NO CARRIER — Connection failed.");
+        sounds.playNoCarrier();
+        await sleep(900);
+        return;
+      }
+
+      // ── Connected! ───────────────────────────────────────────────────────
+      sounds.playConnected();
+      const range = SPEED_RANGES[settings.baudRate] ?? SPEED_RANGES["56K V.90"];
+      const speed = Math.floor(range[0] + Math.random() * (range[1] - range[0]));
+      setPhase("connected");
+      setStatus(`Connected at ${speed.toLocaleString()} bps!`);
+
+      await sleep(1800);
+      onConnected();
+
+    } catch {
+      // Cancelled — component unmounted or user hit Cancel
+    }
+  }, [settings, isConnecting, onConnected]);
+
+  const handleCancel = useCallback(() => {
+    cancelObjRef.current.current = true;
+    soundsRef.current?.stop();
+    soundsRef.current = null;
+    setPhase("idle");
+    setStatus("Ready to connect.");
+  }, []);
+
+  const isp = ISPS[settings.ispIdx];
+
+  const dotClass =
+    isConnecting        ? "dialup__dot--working" :
+    phase === "connected" ? "dialup__dot--ok"    :
+    isFailure           ? "dialup__dot--error"   :
+    "dialup__dot--idle";
+
+  const btnLabel = isConnecting ? "Connecting..." : isFailure ? "Try Again" : "Connect";
+
+  return (
+    <div className="dialup">
+      {/* ── Header ── */}
+      <div className="dialup__header">
+        <span className="dialup__header-icon">📞</span>
+        <span className="dialup__header-title">Dial-Up Networking</span>
+      </div>
+
+      {/* ── Provider + phone ── */}
+      <div className="dialup__section">
+        <div className="dialup__row">
+          <label className="dialup__label">Provider:</label>
+          <select
+            className="dialup__select"
+            value={settings.ispIdx}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, ispIdx: Number(e.target.value) }))}
+          >
+            {ISPS.map((isp, i) => (
+              <option key={i} value={i}>{isp.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="dialup__row">
+          <label className="dialup__label">Phone:</label>
+          <div className="dialup__phone-display">{isp.phone}</div>
+        </div>
+      </div>
+
+      {/* ── Modem settings ── */}
+      <div className="dialup__section dialup__section--box">
+        <div className="dialup__box-title">Modem Settings</div>
+
+        <div className="dialup__row">
+          <label className="dialup__label">Max Speed:</label>
+          <select
+            className="dialup__select"
+            value={settings.baudRate}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, baudRate: e.target.value }))}
+          >
+            <option>56K V.90</option>
+            <option>33.6K V.34</option>
+            <option>28.8K V.34</option>
+            <option>14.4K V.32bis</option>
+            <option>2400 V.22bis</option>
+          </select>
+        </div>
+
+        <div className="dialup__row">
+          <label className="dialup__label">Dial Type:</label>
+          <select
+            className="dialup__select"
+            value={settings.dialType}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, dialType: e.target.value as DialType }))}
+          >
+            <option value="touchtone">Touch-Tone (DTMF)</option>
+            <option value="pulse">Pulse (Rotary)</option>
+          </select>
+        </div>
+
+        <div className="dialup__row">
+          <label className="dialup__label">Flow Control:</label>
+          <select
+            className="dialup__select"
+            value={settings.flowControl}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, flowControl: e.target.value }))}
+          >
+            <option value="hardware">Hardware (RTS/CTS)</option>
+            <option value="software">Software (XON/XOFF)</option>
+            <option value="none">None</option>
+          </select>
+        </div>
+
+        <div className="dialup__row">
+          <label className="dialup__label">Init String:</label>
+          <select
+            className="dialup__select"
+            value={settings.initString}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, initString: e.target.value }))}
+          >
+            <option value="at_f">AT&amp;F  (Factory Default)</option>
+            <option value="atz">ATZ  (Reset)</option>
+            <option value="safe">AT&amp;F1  (Safe Mode)</option>
+            <option value="aggressive">AT&amp;F2  (Aggressive)</option>
+            <option value="turbo_mode">AT^TURBO  (Turbo Mode™)</option>
+          </select>
+        </div>
+
+        <div className="dialup__row">
+          <label className="dialup__label">Speaker:</label>
+          <select
+            className="dialup__select"
+            value={settings.speakerVol}
+            disabled={isConnecting}
+            onChange={(e) => setSettings((s) => ({ ...s, speakerVol: e.target.value }))}
+          >
+            <option value="off">Off</option>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+
+        <div className="dialup__checks">
+          <label className="dialup__check-label">
+            <input type="checkbox" checked={settings.errorCorrection} disabled={isConnecting}
+              onChange={(e) => setSettings((s) => ({ ...s, errorCorrection: e.target.checked }))} />
+            Error correction (V.42)
+          </label>
+          <label className="dialup__check-label">
+            <input type="checkbox" checked={settings.compression} disabled={isConnecting}
+              onChange={(e) => setSettings((s) => ({ ...s, compression: e.target.checked }))} />
+            Data compression (V.42bis)
+          </label>
+          <label className="dialup__check-label">
+            <input type="checkbox" checked={settings.turboBoost} disabled={isConnecting}
+              onChange={(e) => setSettings((s) => ({ ...s, turboBoost: e.target.checked }))} />
+            Turbo Boost Mode™
+          </label>
+          <label className="dialup__check-label">
+            <input type="checkbox" checked={settings.quantumTunneling} disabled={isConnecting}
+              onChange={(e) => setSettings((s) => ({ ...s, quantumTunneling: e.target.checked }))} />
+            Enable Quantum Tunneling
+          </label>
+          <label className="dialup__check-label">
+            <input type="checkbox" checked={settings.y2kProtection} disabled={isConnecting}
+              onChange={(e) => setSettings((s) => ({ ...s, y2kProtection: e.target.checked }))} />
+            Y2K Protection Mode
+          </label>
+        </div>
+      </div>
+
+      {/* ── Status bar ── */}
+      <div className="dialup__statusbar">
+        <span className={`dialup__dot ${dotClass}`} />
+        <span className="dialup__status-text">{statusMsg}</span>
+      </div>
+
+      {/* ── Buttons ── */}
+      <div className="dialup__footer">
+        <button
+          className="dialup__btn dialup__btn--primary"
+          disabled={isConnecting}
+          onClick={handleConnect}
+        >
+          {btnLabel}
+        </button>
+        {isConnecting && (
+          <button className="dialup__btn" onClick={handleCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/NsDoors97/ModemSounds.ts
+++ b/src/experiences/NsDoors97/ModemSounds.ts
@@ -1,0 +1,310 @@
+// Synthesizes V.90 dial-up handshake sounds using Web Audio API.
+// Based on ITU-T V.8 / V.34 / V.90 procedures and PSTN signaling standards.
+
+export type DialType = "touchtone" | "pulse";
+
+const DTMF_MAP: Record<string, [number, number]> = {
+  "1": [697, 1209], "2": [697, 1336], "3": [697, 1477],
+  "4": [770, 1209], "5": [770, 1336], "6": [770, 1477],
+  "7": [852, 1209], "8": [852, 1336], "9": [852, 1477],
+  "*": [941, 1209], "0": [941, 1336], "#": [941, 1477],
+};
+
+const DTMF_ON_SEC       = 0.100;
+const DTMF_GAP_SEC      = 0.050;
+const PULSE_ON_SEC      = 0.033; // line break (audible click)
+const PULSE_CYCLE_SEC   = 0.100; // full pulse cycle
+const PULSE_DIGIT_GAP_SEC = 0.600;
+
+/** Returns the wall-clock duration (ms) of dialing a digit string. */
+export function getDialDuration(digits: string, dialType: DialType): number {
+  if (dialType === "pulse") {
+    let total = 0;
+    for (const ch of digits) {
+      const n = ch === "0" ? 10 : parseInt(ch, 10);
+      if (!isNaN(n)) total += n * PULSE_CYCLE_SEC + PULSE_DIGIT_GAP_SEC;
+    }
+    return Math.round(total * 1000);
+  }
+  const count = digits.split("").filter((ch) => ch in DTMF_MAP).length;
+  return Math.round(count * (DTMF_ON_SEC + DTMF_GAP_SEC) * 1000);
+}
+
+export class ModemSounds {
+  private ctx: AudioContext;
+  private master: GainNode;
+
+  constructor(volume = 0.65) {
+    this.ctx = new AudioContext();
+    this.master = this.ctx.createGain();
+    this.master.gain.value = volume;
+    this.master.connect(this.ctx.destination);
+  }
+
+  private now(): number {
+    return this.ctx.currentTime;
+  }
+
+  private tone(
+    freqs: number[],
+    start: number,
+    dur: number,
+    gain = 0.25,
+    type: OscillatorType = "sine",
+  ): void {
+    const fi = 0.004;
+    const fo = 0.008;
+    for (const freq of freqs) {
+      const osc = this.ctx.createOscillator();
+      const gn  = this.ctx.createGain();
+      osc.connect(gn);
+      gn.connect(this.master);
+      osc.type = type;
+      osc.frequency.value = freq;
+      gn.gain.setValueAtTime(0, start);
+      gn.gain.linearRampToValueAtTime(gain, start + fi);
+      gn.gain.setValueAtTime(gain, start + dur - fo);
+      gn.gain.linearRampToValueAtTime(0, start + dur);
+      osc.start(start);
+      osc.stop(start + dur + 0.01);
+    }
+  }
+
+  private noise(
+    start: number,
+    dur: number,
+    gain = 0.2,
+    filterFreq?: number,
+    filterQ = 1.0,
+  ): void {
+    const ctx = this.ctx;
+    const len = Math.ceil(ctx.sampleRate * (dur + 0.06));
+    const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+
+    const src = ctx.createBufferSource();
+    src.buffer = buf;
+    const gn = ctx.createGain();
+    gn.gain.setValueAtTime(0, start);
+    gn.gain.linearRampToValueAtTime(gain, start + 0.005);
+    gn.gain.setValueAtTime(gain, start + dur - 0.012);
+    gn.gain.linearRampToValueAtTime(0, start + dur);
+
+    if (filterFreq !== undefined) {
+      const filt = ctx.createBiquadFilter();
+      filt.type = "bandpass";
+      filt.frequency.value = filterFreq;
+      filt.Q.value = filterQ;
+      src.connect(filt);
+      filt.connect(gn);
+    } else {
+      src.connect(gn);
+    }
+    gn.connect(this.master);
+    src.start(start);
+    src.stop(start + dur + 0.06);
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  playOffHook(): void {
+    this.noise(this.now() + 0.04, 0.016, 0.45);
+  }
+
+  /** Standard PSTN dial tone: 350 Hz + 440 Hz. */
+  playDialTone(dur: number): void {
+    this.tone([350, 440], this.now(), dur, 0.18);
+  }
+
+  playDTMF(digits: string): void {
+    let off = 0;
+    const t = this.now();
+    for (const ch of digits) {
+      const freqs = DTMF_MAP[ch];
+      if (freqs) {
+        this.tone(freqs, t + off, DTMF_ON_SEC, 0.22);
+        off += DTMF_ON_SEC + DTMF_GAP_SEC;
+      }
+    }
+  }
+
+  /** Rotary-style pulse dialing: series of line-break clicks per digit. */
+  playPulseDial(digits: string): void {
+    let off = 0;
+    const t = this.now();
+    for (const ch of digits) {
+      const n = ch === "0" ? 10 : parseInt(ch, 10);
+      if (isNaN(n)) continue;
+      for (let p = 0; p < n; p++) {
+        this.noise(t + off, PULSE_ON_SEC, 0.32);
+        off += PULSE_CYCLE_SEC;
+      }
+      off += PULSE_DIGIT_GAP_SEC;
+    }
+  }
+
+  /** Standard ringback: 440 Hz + 480 Hz, 2 s on / 4 s off per ring. */
+  playRingback(rings: number): void {
+    const t = this.now();
+    for (let i = 0; i < rings; i++) {
+      this.tone([440, 480], t + i * 6.0, 2.0, 0.15);
+    }
+  }
+
+  /** Busy signal: 480 Hz + 620 Hz, 0.5 s on / 0.5 s off. */
+  playBusy(cycles = 6): void {
+    const t = this.now();
+    for (let i = 0; i < cycles; i++) {
+      this.tone([480, 620], t + i * 1.0, 0.5, 0.20);
+    }
+  }
+
+  /**
+   * ANSam tone: 2100 Hz carrier with 180° phase reversals every 450 ms.
+   * Phase reversals are implemented as instantaneous gain sign flips, which
+   * produce the characteristic ANSam warble (ITU-T V.25 / V.8 §7.2.1).
+   * Sidebands at fc ± 15 Hz approximate the 15 Hz envelope modulation.
+   */
+  playANSam(dur: number): void {
+    const ctx = this.ctx;
+    const t   = this.now();
+
+    const osc = ctx.createOscillator();
+    const gn  = ctx.createGain();
+    osc.connect(gn);
+    gn.connect(this.master);
+    osc.type = "sine";
+    osc.frequency.value = 2100;
+
+    const interval = 0.45;
+    const steps    = Math.floor(dur / interval);
+    gn.gain.setValueAtTime(0, t);
+    gn.gain.linearRampToValueAtTime(0.22, t + 0.05);
+    for (let i = 1; i <= steps; i++) {
+      gn.gain.setValueAtTime(i % 2 === 0 ? 0.22 : -0.22, t + i * interval);
+    }
+    gn.gain.linearRampToValueAtTime(0, t + dur);
+    osc.start(t);
+    osc.stop(t + dur + 0.01);
+
+    this.tone([2085, 2115], t, dur, 0.035);
+  }
+
+  /**
+   * V.8 negotiation: rapid alternation of 1300 Hz (calling modem CI) and
+   * 2100 Hz (answering modem) bursts with FSK-like sub-bursts for menu data.
+   */
+  playNegotiation(dur: number): void {
+    const t   = this.now();
+    let off   = 0;
+    let step  = 0;
+
+    while (off < dur) {
+      const isCI  = step % 3 !== 2;
+      const base  = isCI ? 1300 : 2100;
+      const bLen  = 0.068 + Math.random() * 0.052;
+
+      if (Math.random() < 0.38) {
+        const h = bLen / 2;
+        this.tone([base - 80], t + off,     h, 0.18);
+        this.tone([base + 80], t + off + h, h, 0.18);
+      } else {
+        this.tone([base], t + off, bLen, 0.19);
+      }
+
+      off  += bLen + 0.008 + Math.random() * 0.02;
+      step += 1;
+      if (off >= dur) break;
+    }
+  }
+
+  /**
+   * Channel equalization training: swept bandpass-filtered noise + pilot tones
+   * + choppy AM carriers, producing the "roaring waterfall" that characterises
+   * the V.34 / V.90 QAM training sequence.
+   */
+  playTraining(dur: number): void {
+    const ctx = this.ctx;
+    const t   = this.now();
+
+    // Swept noise layer
+    const len = Math.ceil(ctx.sampleRate * (dur + 0.12));
+    const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+    const dat = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) dat[i] = Math.random() * 2 - 1;
+
+    const src  = ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = ctx.createBiquadFilter();
+    filt.type  = "bandpass";
+    filt.Q.value = 0.8;
+
+    filt.frequency.setValueAtTime(400,  t);
+    filt.frequency.linearRampToValueAtTime(2800, t + dur * 0.25);
+    filt.frequency.linearRampToValueAtTime(900,  t + dur * 0.45);
+    filt.frequency.linearRampToValueAtTime(2500, t + dur * 0.65);
+    filt.frequency.linearRampToValueAtTime(1600, t + dur * 0.85);
+    filt.frequency.linearRampToValueAtTime(2100, t + dur);
+
+    const noiseGn = ctx.createGain();
+    noiseGn.gain.setValueAtTime(0, t);
+    noiseGn.gain.linearRampToValueAtTime(0.16, t + 0.09);
+    noiseGn.gain.setValueAtTime(0.16, t + dur - 0.07);
+    noiseGn.gain.linearRampToValueAtTime(0, t + dur);
+
+    src.connect(filt);
+    filt.connect(noiseGn);
+    noiseGn.connect(this.master);
+    src.start(t);
+    src.stop(t + dur + 0.12);
+
+    // V.34 pilot tones: constant reference sinusoids spaced 600 Hz apart
+    const pilots = [600, 1200, 1800, 2400, 3000];
+    pilots.forEach((freq, idx) => {
+      const s = t + idx * 0.11;
+      const d = dur - idx * 0.11;
+      if (d > 0.15) this.tone([freq], s, d, 0.028);
+    });
+
+    // AM-textured carriers: choppy gain envelope mimics QAM symbol bursts
+    const segDur  = dur / 3;
+    const cFreqs  = [1800, 2400, 1200];
+    cFreqs.forEach((cf, idx) => {
+      const s0  = t + idx * segDur;
+      const osc = ctx.createOscillator();
+      const amGn = ctx.createGain();
+      osc.connect(amGn);
+      amGn.connect(this.master);
+      osc.type = "sine";
+      osc.frequency.value = cf;
+      const steps = Math.floor(segDur * 20);
+      for (let s = 0; s < steps; s++) {
+        amGn.gain.setValueAtTime(
+          0.022 + Math.random() * 0.052,
+          s0 + s * (segDur / steps),
+        );
+      }
+      amGn.gain.linearRampToValueAtTime(0, s0 + segDur);
+      osc.start(s0);
+      osc.stop(s0 + segDur + 0.01);
+    });
+  }
+
+  /** Brief click: the carrier locking onto the line. */
+  playConnected(): void {
+    this.noise(this.now(), 0.012, 0.38);
+  }
+
+  /** Three descending tones — classic NO CARRIER error indicator. */
+  playNoCarrier(): void {
+    const t = this.now();
+    this.tone([1400], t,        0.15, 0.28);
+    this.tone([1100], t + 0.18, 0.15, 0.28);
+    this.tone([820],  t + 0.36, 0.32, 0.28);
+  }
+
+  stop(): void {
+    try { this.ctx.close(); } catch { /* ignore */ }
+  }
+}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -21,6 +21,7 @@ import FolderApp from "./FolderApp";
 import FilesApp from "./FilesApp";
 import NotebookApp from "./NotebookApp";
 import InternetApp from "./InternetApp";
+import DialUpApp from "./DialUpApp";
 import TicTacToe from "../TicTacToe/TicTacToe";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
@@ -59,6 +60,7 @@ type DesktopIconAction =
   | "cards"
   | "about"
   | "my-doors"
+  | "dialup"
   | "internet"
   | "files"
   | "notebook";
@@ -76,7 +78,7 @@ const STATIC_ICONS: DesktopIconDef[] = [
   { id: "notebook",     title: "Notebook",     icon: "📝", action: "notebook"     },
   { id: "recycle-bin",  title: "Recycle Bin",  icon: "🗑️", action: "placeholder"  },
   { id: "about",        title: "About NS Doors 97", icon: "ℹ️", action: "about"   },
-  { id: "internet",     title: "Internet",     icon: "🌐", action: "internet"     },
+  { id: "internet",     title: "Interwebs",    icon: "🌐", action: "dialup"      },
   { id: "screensavers", title: "Screensavers", icon: "💤", action: "screensavers" },
   { id: "cards",        title: "Cards",        icon: "🃏", action: "cards"        },
 ];
@@ -109,6 +111,7 @@ type WindowContent =
   | { type: "cards-game"; game: CardsGame; settings: DeckSettings }
   | { type: "about" }
   | { type: "my-doors" }
+  | { type: "dialup" }
   | { type: "internet" }
   | { type: "files" }
   | { type: "notebook"; filePath: string; fileName: string; initialContent: string };
@@ -309,6 +312,7 @@ export default function NsDoors97() {
         case "screensavers": content = { type: "screensaver-settings" }; width = 440; break;
         case "about":        content = { type: "about" };                width = 340; break;
         case "my-doors":     content = { type: "my-doors" };             width = 440; break;
+        case "dialup":       content = { type: "dialup" };               width = 400; break;
         case "internet":     content = { type: "internet" };             width = 640; break;
         case "files":        content = { type: "files" };                width = 600; break;
         case "notebook":     content = { type: "notebook", filePath: "(new file)", fileName: "Untitled.txt", initialContent: "" }; width = 560; break;
@@ -433,6 +437,27 @@ export default function NsDoors97() {
     },
     []
   );
+
+  // Dial-up succeeded: swap the dialup window for the actual browser
+  const handleDialupConnected = useCallback(() => {
+    const offset = (windowSeq % 8) * 32;
+    windowSeq++;
+    maxZ++;
+    const z = maxZ;
+    setActiveWindowId("internet-browser");
+    setOpenWindows((prev) => [
+      ...prev.filter((w) => w.id !== "internet"),
+      {
+        id: "internet-browser",
+        title: "Noahsoft Exploder",
+        icon: "🌐",
+        content: { type: "internet" as const },
+        zIndex: z,
+        defaultPosition: { x: 80 + offset, y: 48 + offset },
+        width: 640,
+      },
+    ]);
+  }, []);
 
   // Close the Cards game and reopen the launcher
   const handleCardsGameClose = useCallback((id: string) => {
@@ -559,6 +584,9 @@ export default function NsDoors97() {
           )}
           {win.content.type === "my-doors" && (
             <FolderApp onOpenExperience={openWindow} />
+          )}
+          {win.content.type === "dialup" && (
+            <DialUpApp onConnected={handleDialupConnected} />
           )}
           {win.content.type === "internet" && (
             <InternetApp onOpenExperience={openWindow} />

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { missingFeatureMessage } from "../../utils/missingFeatureMessage";
 import { useOsDialog } from "./OsDialog";
 import "./Taskbar.css";
@@ -105,6 +106,7 @@ const START_MENU_ITEMS = [
 
 export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRestart }: TaskbarProps) {
   const { showDialog } = useOsDialog();
+  const navigate = useNavigate();
   const [startOpen, setStartOpen] = useState(false);
   const startAreaRef = useRef<HTMLDivElement>(null);
 
@@ -130,6 +132,11 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
     onRestart();
   }, [onRestart]);
 
+  const handleDiagnostics = useCallback(() => {
+    setStartOpen(false);
+    navigate("/modem-lab");
+  }, [navigate]);
+
   return (
     <div className="ns-taskbar">
       {/* ── Start button + menu ── */}
@@ -151,6 +158,11 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
                   {item.arrow && <span className="ns-start-menu__item-arrow">▶</span>}
                 </button>
               ))}
+
+              <button className="ns-start-menu__item" onClick={handleDiagnostics}>
+                <span className="ns-start-menu__item-icon">🔬</span>
+                <span className="ns-start-menu__item-label">Diagnostics...</span>
+              </button>
 
               <div className="ns-start-menu__divider" />
 

--- a/src/pages/ModemLabPage.css
+++ b/src/pages/ModemLabPage.css
@@ -1,0 +1,306 @@
+/* Noahsoft Modem Diagnostics — retro diagnostic tool aesthetic */
+
+.mlab {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, #0a1a0a 0%, #050e05 60%, #020802 100%);
+  display: flex;
+  flex-direction: column;
+  font-family: "Press Start 2P", monospace;
+  overflow: hidden;
+}
+
+/* ── Title bar ───────────────────────────────────────────────────────────── */
+
+.mlab__titlebar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 10px;
+  background: #001a00;
+  border-bottom: 2px solid #00aa00;
+  flex-shrink: 0;
+}
+
+.mlab__back {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #00cc00;
+  background: transparent;
+  border: 1px solid #00aa00;
+  padding: 4px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.mlab__back:hover {
+  background: #003300;
+}
+
+.mlab__title {
+  font-size: 8px;
+  color: #00ff00;
+  flex-shrink: 0;
+  letter-spacing: 1px;
+}
+
+.mlab__subtitle {
+  font-size: 6px;
+  color: #006600;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+/* ── Body ────────────────────────────────────────────────────────────────── */
+
+.mlab__body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────────────────── */
+
+.mlab__sidebar {
+  width: 176px;
+  background: #c0c0c0;
+  border-right: 3px solid #808080;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  overflow-y: auto;
+}
+
+.mlab__sidebar-header {
+  font-size: 6px;
+  color: #000;
+  background: #808080;
+  padding: 5px 8px;
+  border-bottom: 1px solid #555;
+  letter-spacing: 1px;
+}
+
+.mlab__phase-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #000;
+  background: #c0c0c0;
+  border: none;
+  border-bottom: 1px solid #a0a0a0;
+  padding: 8px 10px;
+  text-align: left;
+  cursor: pointer;
+  line-height: 1.5;
+}
+
+.mlab__phase-btn:hover {
+  background: #d4d0c8;
+}
+
+.mlab__phase-btn--active {
+  background: #000080;
+  color: #ffffff;
+  border-left: 3px solid #ff8800;
+}
+
+.mlab__phase-btn--active:hover {
+  background: #000099;
+}
+
+/* ── Main panel ──────────────────────────────────────────────────────────── */
+
+.mlab__main {
+  flex: 1;
+  background: #c0c0c0;
+  overflow-y: auto;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+/* ── Phase header ────────────────────────────────────────────────────────── */
+
+.mlab__phase-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.mlab__phase-name {
+  font-size: 10px;
+  color: #000080;
+}
+
+.mlab__phase-desc {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #444;
+  line-height: 1.5;
+  font-weight: normal;
+}
+
+/* ── Text input row ──────────────────────────────────────────────────────── */
+
+.mlab__text-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mlab__text-label {
+  font-size: 6px;
+  color: #000;
+  min-width: 60px;
+  flex-shrink: 0;
+}
+
+.mlab__text-input {
+  flex: 1;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 12px;
+  color: #000;
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 3px 6px;
+  min-width: 0;
+}
+
+/* ── Sliders ─────────────────────────────────────────────────────────────── */
+
+.mlab__sliders {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mlab__slider-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mlab__slider-label {
+  font-size: 6px;
+  color: #000;
+  min-width: 90px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.mlab__slider {
+  flex: 1;
+  min-width: 0;
+  height: 16px;
+  cursor: pointer;
+  accent-color: #cc4400;
+}
+
+.mlab__slider-val {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #000080;
+  min-width: 90px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.mlab__slider-unit {
+  color: #808080;
+}
+
+/* ── Divider ─────────────────────────────────────────────────────────────── */
+
+.mlab__divider {
+  height: 2px;
+  background: linear-gradient(to right, #808080, #ffffff);
+  border: none;
+  flex-shrink: 0;
+}
+
+/* ── Controls ────────────────────────────────────────────────────────────── */
+
+.mlab__controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.mlab__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 6px 14px;
+  cursor: pointer;
+  color: #000;
+  white-space: nowrap;
+}
+
+.mlab__btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.mlab__btn--play {
+  background: #d4f0d4;
+  border-color: #aaffaa #336633 #336633 #aaffaa;
+  color: #003300;
+  min-width: 100px;
+}
+
+.mlab__btn--play.mlab__btn--active {
+  background: #ffd4d4;
+  border-color: #ffaaaa #663333 #663333 #ffaaaa;
+  color: #330000;
+}
+
+.mlab__btn--play:active,
+.mlab__btn--play.mlab__btn--active:active {
+  border-color: #336633 #aaffaa #aaffaa #336633;
+}
+
+.mlab__btn--reset {
+  font-size: 6px;
+  color: #333;
+}
+
+.mlab__loop-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 6px;
+  color: #000;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.mlab__loop-label input[type="checkbox"] {
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
+  accent-color: #cc4400;
+  margin: 0;
+}
+
+.mlab__status {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #000080;
+  flex: 1;
+  min-width: 0;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #ffffff;
+  padding: 3px 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/pages/ModemLabPage.tsx
+++ b/src/pages/ModemLabPage.tsx
@@ -1,0 +1,695 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import "./ModemLabPage.css";
+
+// ── Synthesis helpers ──────────────────────────────────────────────────────
+
+function addTone(
+  ctx: AudioContext,
+  dest: AudioNode,
+  freqs: number[],
+  start: number,
+  dur: number,
+  gain: number,
+  type: OscillatorType = "sine",
+): void {
+  const fi = 0.004;
+  const fo = Math.min(0.008, dur * 0.2);
+  for (const freq of freqs) {
+    const osc = ctx.createOscillator();
+    const gn  = ctx.createGain();
+    osc.connect(gn);
+    gn.connect(dest);
+    osc.type = type;
+    osc.frequency.value = freq;
+    gn.gain.setValueAtTime(0, start);
+    gn.gain.linearRampToValueAtTime(gain, start + fi);
+    gn.gain.setValueAtTime(gain, start + dur - fo);
+    gn.gain.linearRampToValueAtTime(0, start + dur);
+    osc.start(start);
+    osc.stop(start + dur + 0.01);
+  }
+}
+
+function addNoise(
+  ctx: AudioContext,
+  dest: AudioNode,
+  start: number,
+  dur: number,
+  gain: number,
+  filterFreq?: number,
+  filterQ = 1.0,
+): void {
+  const len = Math.ceil(ctx.sampleRate * (dur + 0.06));
+  const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  const gn = ctx.createGain();
+  gn.gain.setValueAtTime(0, start);
+  gn.gain.linearRampToValueAtTime(gain, start + 0.005);
+  gn.gain.setValueAtTime(gain, start + dur - 0.01);
+  gn.gain.linearRampToValueAtTime(0, start + dur);
+
+  if (filterFreq !== undefined) {
+    const filt = ctx.createBiquadFilter();
+    filt.type = "bandpass";
+    filt.frequency.value = filterFreq;
+    filt.Q.value = filterQ;
+    src.connect(filt);
+    filt.connect(gn);
+  } else {
+    src.connect(gn);
+  }
+  gn.connect(dest);
+  src.start(start);
+  src.stop(start + dur + 0.06);
+}
+
+// ── Phase config types ─────────────────────────────────────────────────────
+
+interface SliderParam {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  defaultValue: number;
+  unit: string;
+}
+
+interface TextParam {
+  id: string;
+  label: string;
+  defaultValue: string;
+}
+
+interface PhaseConfig {
+  id: string;
+  label: string;
+  desc: string;
+  sliders: SliderParam[];
+  texts?: TextParam[];
+}
+
+// ── Phase definitions ──────────────────────────────────────────────────────
+
+const PHASES: PhaseConfig[] = [
+  {
+    id: "dial-tone",
+    label: "Dial Tone",
+    desc: "Standard PSTN dial tone: 350 + 440 Hz composite.",
+    sliders: [
+      { id: "freq1",    label: "Freq 1",   min: 200, max: 600,  step: 1,    defaultValue: 350,  unit: "Hz" },
+      { id: "freq2",    label: "Freq 2",   min: 200, max: 800,  step: 1,    defaultValue: 440,  unit: "Hz" },
+      { id: "gain",     label: "Gain",     min: 0.01, max: 1,   step: 0.01, defaultValue: 0.18, unit: "" },
+      { id: "duration", label: "Duration", min: 100, max: 5000, step: 50,   defaultValue: 750,  unit: "ms" },
+    ],
+  },
+  {
+    id: "dtmf",
+    label: "DTMF Dial",
+    desc: "Touch-tone: two ITU-T frequencies per digit.",
+    texts: [{ id: "digits", label: "Digits", defaultValue: "18008276364" }],
+    sliders: [
+      { id: "onDuration",  label: "On time", min: 50,  max: 300, step: 5,    defaultValue: 100,  unit: "ms" },
+      { id: "gapDuration", label: "Gap",     min: 10,  max: 200, step: 5,    defaultValue: 50,   unit: "ms" },
+      { id: "gain",        label: "Gain",    min: 0.01, max: 1,  step: 0.01, defaultValue: 0.22, unit: "" },
+    ],
+  },
+  {
+    id: "pulse",
+    label: "Pulse Dial",
+    desc: "Rotary-style: series of line-break clicks per digit.",
+    texts: [{ id: "digits", label: "Digits", defaultValue: "1234567" }],
+    sliders: [
+      { id: "onDuration",   label: "Click len",  min: 10,  max: 80,   step: 1,    defaultValue: 33,   unit: "ms" },
+      { id: "cycleDuration",label: "Cycle len",  min: 60,  max: 200,  step: 5,    defaultValue: 100,  unit: "ms" },
+      { id: "digitGap",     label: "Digit gap",  min: 200, max: 1500, step: 50,   defaultValue: 600,  unit: "ms" },
+      { id: "gain",         label: "Gain",       min: 0.01, max: 1,   step: 0.01, defaultValue: 0.32, unit: "" },
+    ],
+  },
+  {
+    id: "ringback",
+    label: "Ringback",
+    desc: "Audible ring signal: 440 + 480 Hz, 2s on / 4s off.",
+    sliders: [
+      { id: "freq1",        label: "Freq 1",   min: 200, max: 700,  step: 1,    defaultValue: 440,  unit: "Hz" },
+      { id: "freq2",        label: "Freq 2",   min: 300, max: 800,  step: 1,    defaultValue: 480,  unit: "Hz" },
+      { id: "ringDuration", label: "Ring on",  min: 500, max: 4000, step: 100,  defaultValue: 2000, unit: "ms" },
+      { id: "pauseDuration",label: "Ring off", min: 500, max: 8000, step: 100,  defaultValue: 4000, unit: "ms" },
+      { id: "rings",        label: "Count",    min: 1,   max: 5,    step: 1,    defaultValue: 2,    unit: "" },
+      { id: "gain",         label: "Gain",     min: 0.01, max: 1,   step: 0.01, defaultValue: 0.15, unit: "" },
+    ],
+  },
+  {
+    id: "busy",
+    label: "Busy Signal",
+    desc: "Line engaged: 480 + 620 Hz, 0.5s on / 0.5s off.",
+    sliders: [
+      { id: "freq1",      label: "Freq 1",   min: 200, max: 800,  step: 1,    defaultValue: 480,  unit: "Hz" },
+      { id: "freq2",      label: "Freq 2",   min: 300, max: 1000, step: 1,    defaultValue: 620,  unit: "Hz" },
+      { id: "onDuration", label: "On / Off", min: 100, max: 1000, step: 50,   defaultValue: 500,  unit: "ms" },
+      { id: "cycles",     label: "Cycles",   min: 2,   max: 10,   step: 1,    defaultValue: 4,    unit: "" },
+      { id: "gain",       label: "Gain",     min: 0.01, max: 1,   step: 0.01, defaultValue: 0.20, unit: "" },
+    ],
+  },
+  {
+    id: "ansam",
+    label: "ANSam Carrier",
+    desc: "Answering modem: 2100 Hz with 180° phase reversals every 450 ms (ITU-T V.25).",
+    sliders: [
+      { id: "carrierFreq",       label: "Carrier",       min: 1800, max: 2400, step: 1,    defaultValue: 2100,  unit: "Hz" },
+      { id: "reversalInterval",  label: "Reversal Δt",   min: 100,  max: 1000, step: 10,   defaultValue: 450,   unit: "ms" },
+      { id: "sidebandOffset",    label: "Sideband ±",    min: 1,    max: 50,   step: 1,    defaultValue: 15,    unit: "Hz" },
+      { id: "mainGain",          label: "Main gain",     min: 0.01, max: 1,    step: 0.01, defaultValue: 0.22,  unit: "" },
+      { id: "sidebandGain",      label: "Sideband gain", min: 0,    max: 0.3,  step: 0.005,defaultValue: 0.035, unit: "" },
+      { id: "duration",          label: "Duration",      min: 500,  max: 8000, step: 100,  defaultValue: 3300,  unit: "ms" },
+    ],
+  },
+  {
+    id: "negotiation",
+    label: "V.8 Negotiation",
+    desc: "CI/CM/JM exchange: 1300 Hz CI bursts, then 75-baud V.21 FSK (980/1180 Hz).",
+    sliders: [
+      { id: "ciFreq",   label: "CI freq",   min: 800,  max: 2000, step: 10,   defaultValue: 1300, unit: "Hz" },
+      { id: "ansFreq",  label: "Ans freq",  min: 1500, max: 2500, step: 10,   defaultValue: 2100, unit: "Hz" },
+      { id: "fskMark",  label: "FSK mark",  min: 600,  max: 1400, step: 10,   defaultValue: 980,  unit: "Hz" },
+      { id: "fskSpace", label: "FSK space", min: 800,  max: 1800, step: 10,   defaultValue: 1180, unit: "Hz" },
+      { id: "burstLen", label: "CI burst",  min: 20,   max: 400,  step: 10,   defaultValue: 100,  unit: "ms" },
+      { id: "burstGap", label: "Burst gap", min: 5,    max: 100,  step: 5,    defaultValue: 15,   unit: "ms" },
+      { id: "gain",     label: "Gain",      min: 0.01, max: 1,    step: 0.01, defaultValue: 0.19, unit: "" },
+      { id: "duration", label: "Duration",  min: 500,  max: 8000, step: 100,  defaultValue: 2000, unit: "ms" },
+    ],
+  },
+  {
+    id: "training",
+    label: "Training Noise",
+    desc: "Channel equalisation: swept bandpass noise + V.34 pilot tones + AM carriers.",
+    sliders: [
+      { id: "noiseGain",  label: "Noise level", min: 0,   max: 1,    step: 0.01,  defaultValue: 0.16,  unit: "" },
+      { id: "filterQ",    label: "Filter Q",    min: 0.1, max: 10,   step: 0.1,   defaultValue: 0.8,   unit: "" },
+      { id: "sweepStart", label: "Sweep start", min: 100, max: 2000, step: 50,    defaultValue: 400,   unit: "Hz" },
+      { id: "sweepPeak",  label: "Sweep peak",  min: 1000,max: 4000, step: 100,   defaultValue: 2800,  unit: "Hz" },
+      { id: "sweepMid",   label: "Sweep mid",   min: 200, max: 3000, step: 100,   defaultValue: 900,   unit: "Hz" },
+      { id: "sweepPeak2", label: "Sweep peak 2",min: 1000,max: 4000, step: 100,   defaultValue: 2500,  unit: "Hz" },
+      { id: "sweepEnd",   label: "Sweep end",   min: 500, max: 3500, step: 100,   defaultValue: 1600,  unit: "Hz" },
+      { id: "pilotGain",  label: "Pilot gain",  min: 0,   max: 0.3,  step: 0.005, defaultValue: 0.028, unit: "" },
+      { id: "amGain",     label: "AM gain",     min: 0,   max: 0.3,  step: 0.005, defaultValue: 0.036, unit: "" },
+      { id: "duration",   label: "Duration",    min: 1000,max: 15000,step: 500,   defaultValue: 7000,  unit: "ms" },
+    ],
+  },
+  {
+    id: "connected",
+    label: "Connected Click",
+    desc: "Carrier lock: brief noise burst as modems switch to data mode.",
+    sliders: [
+      { id: "gain",     label: "Gain",     min: 0.01, max: 1,   step: 0.01, defaultValue: 0.38, unit: "" },
+      { id: "duration", label: "Duration", min: 5,    max: 100, step: 1,    defaultValue: 12,   unit: "ms" },
+    ],
+  },
+  {
+    id: "no-carrier",
+    label: "NO CARRIER",
+    desc: "Connection failed: three descending error tones.",
+    sliders: [
+      { id: "freq1", label: "Tone 1", min: 500,  max: 3000, step: 10,   defaultValue: 1400, unit: "Hz" },
+      { id: "freq2", label: "Tone 2", min: 400,  max: 2500, step: 10,   defaultValue: 1100, unit: "Hz" },
+      { id: "freq3", label: "Tone 3", min: 300,  max: 2000, step: 10,   defaultValue: 820,  unit: "Hz" },
+      { id: "dur1",  label: "Dur 1",  min: 50,   max: 500,  step: 10,   defaultValue: 150,  unit: "ms" },
+      { id: "dur2",  label: "Dur 2",  min: 50,   max: 500,  step: 10,   defaultValue: 150,  unit: "ms" },
+      { id: "dur3",  label: "Dur 3",  min: 100,  max: 1000, step: 10,   defaultValue: 320,  unit: "ms" },
+      { id: "gain",  label: "Gain",   min: 0.01, max: 1,    step: 0.01, defaultValue: 0.28, unit: "" },
+    ],
+  },
+];
+
+// ── Play functions (return duration in seconds) ───────────────────────────
+
+type PlayFn = (
+  ctx: AudioContext,
+  dest: AudioNode,
+  p: Record<string, number>,
+  t: Record<string, string>,
+) => number;
+
+const DTMF_MAP: Record<string, [number, number]> = {
+  "1": [697, 1209], "2": [697, 1336], "3": [697, 1477],
+  "4": [770, 1209], "5": [770, 1336], "6": [770, 1477],
+  "7": [852, 1209], "8": [852, 1336], "9": [852, 1477],
+  "*": [941, 1209], "0": [941, 1336], "#": [941, 1477],
+};
+
+const PLAY_FNS: Record<string, PlayFn> = {
+
+  "dial-tone": (ctx, dest, p) => {
+    const dur = p.duration / 1000;
+    addTone(ctx, dest, [p.freq1, p.freq2], ctx.currentTime, dur, p.gain);
+    return dur;
+  },
+
+  "dtmf": (ctx, dest, p, t) => {
+    const digits = t.digits || "0";
+    const onSec  = p.onDuration / 1000;
+    const gapSec = p.gapDuration / 1000;
+    let off = 0;
+    const start = ctx.currentTime;
+    for (const ch of digits) {
+      const freqs = DTMF_MAP[ch];
+      if (freqs) {
+        addTone(ctx, dest, freqs, start + off, onSec, p.gain);
+        off += onSec + gapSec;
+      }
+    }
+    return off + 0.15;
+  },
+
+  "pulse": (ctx, dest, p, t) => {
+    const digits   = t.digits || "0";
+    const onSec    = p.onDuration / 1000;
+    const cycleSec = p.cycleDuration / 1000;
+    const gapSec   = p.digitGap / 1000;
+    let off = 0;
+    const start = ctx.currentTime;
+    for (const ch of digits) {
+      const n = ch === "0" ? 10 : parseInt(ch, 10);
+      if (isNaN(n)) continue;
+      for (let i = 0; i < n; i++) {
+        addNoise(ctx, dest, start + off, onSec, p.gain);
+        off += cycleSec;
+      }
+      off += gapSec;
+    }
+    return off + 0.15;
+  },
+
+  "ringback": (ctx, dest, p) => {
+    const ringDur  = p.ringDuration / 1000;
+    const pauseDur = p.pauseDuration / 1000;
+    const rings    = Math.round(p.rings);
+    const start    = ctx.currentTime;
+    for (let i = 0; i < rings; i++) {
+      addTone(ctx, dest, [p.freq1, p.freq2], start + i * (ringDur + pauseDur), ringDur, p.gain);
+    }
+    return rings * (ringDur + pauseDur);
+  },
+
+  "busy": (ctx, dest, p) => {
+    const onSec  = p.onDuration / 1000;
+    const cycles = Math.round(p.cycles);
+    const start  = ctx.currentTime;
+    for (let i = 0; i < cycles; i++) {
+      addTone(ctx, dest, [p.freq1, p.freq2], start + i * onSec * 2, onSec, p.gain);
+    }
+    return cycles * onSec * 2 + 0.1;
+  },
+
+  // ANSam: 2100 Hz carrier with instantaneous 180° phase reversals every
+  // reversalInterval ms. Sidebands at fc ± sidebandOffset add AM character.
+  "ansam": (ctx, dest, p) => {
+    const dur      = p.duration / 1000;
+    const interval = p.reversalInterval / 1000;
+    const start    = ctx.currentTime;
+
+    const osc = ctx.createOscillator();
+    const gn  = ctx.createGain();
+    osc.connect(gn);
+    gn.connect(dest);
+    osc.type = "sine";
+    osc.frequency.value = p.carrierFreq;
+
+    const steps = Math.floor(dur / interval);
+    gn.gain.setValueAtTime(0, start);
+    gn.gain.linearRampToValueAtTime(p.mainGain, start + 0.02);
+    for (let i = 1; i <= steps; i++) {
+      const rt   = start + i * interval;
+      const sign = i % 2 === 0 ? p.mainGain : -p.mainGain;
+      // Very brief dip through zero makes the reversal cleaner
+      gn.gain.linearRampToValueAtTime(sign * 0.04, rt - 0.003);
+      gn.gain.linearRampToValueAtTime(sign, rt + 0.003);
+    }
+    gn.gain.linearRampToValueAtTime(0, start + dur);
+    osc.start(start);
+    osc.stop(start + dur + 0.01);
+
+    if (p.sidebandGain > 0) {
+      addTone(ctx, dest,
+        [p.carrierFreq - p.sidebandOffset, p.carrierFreq + p.sidebandOffset],
+        start, dur, p.sidebandGain);
+    }
+    return dur;
+  },
+
+  // V.8 Negotiation:
+  //   Phase 1 (~40%): CI tone (ciFreq) alternates with answering-modem response (ansFreq)
+  //   Phase 2 (~60%): V.21 FSK at 75 baud — alternating mark/space (fskMark / fskSpace)
+  //                   This is the "rapid warbling" that is the most distinctive V.8 sound.
+  "negotiation": (ctx, dest, p) => {
+    const dur     = p.duration / 1000;
+    const start   = ctx.currentTime;
+    const bLen    = p.burstLen / 1000;
+    const bGap    = p.burstGap / 1000;
+
+    // Phase 1: CI / answer burst exchange
+    const phase1End = dur * 0.40;
+    let off = 0;
+    while (off + bLen < phase1End) {
+      addTone(ctx, dest, [p.ciFreq],  start + off,            bLen,        p.gain);
+      off += bLen + bGap;
+      if (off + bLen * 0.6 < phase1End) {
+        addTone(ctx, dest, [p.ansFreq], start + off, bLen * 0.6,  p.gain * 0.85);
+        off += bLen * 0.6 + bGap * 0.5;
+      }
+    }
+
+    // Phase 2: V.21 75-baud FSK  (1 / 75 ≈ 13.3 ms per symbol)
+    const symbolSec = 1 / 75;
+    let off2 = phase1End;
+    while (off2 + symbolSec < dur) {
+      const freq = Math.random() < 0.5 ? p.fskMark : p.fskSpace;
+      addTone(ctx, dest, [freq], start + off2, symbolSec, p.gain * 0.9);
+      off2 += symbolSec;
+    }
+
+    return dur;
+  },
+
+  // Training: swept bandpass noise + pilot tones + choppy AM carriers.
+  // The user can tune sweep waypoints, noise gain, filter Q, and AM levels.
+  "training": (ctx, dest, p) => {
+    const dur   = p.duration / 1000;
+    const start = ctx.currentTime;
+
+    // Swept noise layer
+    const len = Math.ceil(ctx.sampleRate * (dur + 0.12));
+    const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+    const dat = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) dat[i] = Math.random() * 2 - 1;
+
+    const src  = ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = ctx.createBiquadFilter();
+    filt.type  = "bandpass";
+    filt.Q.value = p.filterQ;
+    filt.frequency.setValueAtTime(p.sweepStart, start);
+    filt.frequency.linearRampToValueAtTime(p.sweepPeak,  start + dur * 0.25);
+    filt.frequency.linearRampToValueAtTime(p.sweepMid,   start + dur * 0.45);
+    filt.frequency.linearRampToValueAtTime(p.sweepPeak2, start + dur * 0.65);
+    filt.frequency.linearRampToValueAtTime(p.sweepEnd,   start + dur);
+
+    const noiseGn = ctx.createGain();
+    noiseGn.gain.setValueAtTime(0, start);
+    noiseGn.gain.linearRampToValueAtTime(p.noiseGain, start + 0.09);
+    noiseGn.gain.setValueAtTime(p.noiseGain, start + dur - 0.07);
+    noiseGn.gain.linearRampToValueAtTime(0, start + dur);
+
+    src.connect(filt);
+    filt.connect(noiseGn);
+    noiseGn.connect(dest);
+    src.start(start);
+    src.stop(start + dur + 0.12);
+
+    // V.34 pilot tones (constant reference sinusoids every 600 Hz)
+    [600, 1200, 1800, 2400, 3000].forEach((freq, idx) => {
+      const s = start + idx * 0.10;
+      const d = dur - idx * 0.10;
+      if (d > 0.2) addTone(ctx, dest, [freq], s, d, p.pilotGain);
+    });
+
+    // AM-textured carrier segments
+    const segDur = dur / 3;
+    [1800, 2400, 1200].forEach((cf, idx) => {
+      const s0  = start + idx * segDur;
+      const osc = ctx.createOscillator();
+      const amGn = ctx.createGain();
+      osc.connect(amGn);
+      amGn.connect(dest);
+      osc.type = "sine";
+      osc.frequency.value = cf;
+      const steps = Math.max(1, Math.floor(segDur * 30));
+      for (let s = 0; s < steps; s++) {
+        amGn.gain.setValueAtTime(
+          p.amGain * (0.3 + Math.random() * 1.4),
+          s0 + s * (segDur / steps),
+        );
+      }
+      amGn.gain.linearRampToValueAtTime(0, s0 + segDur);
+      osc.start(s0);
+      osc.stop(s0 + segDur + 0.01);
+    });
+
+    return dur;
+  },
+
+  "connected": (ctx, dest, p) => {
+    const dur = p.duration / 1000;
+    addNoise(ctx, dest, ctx.currentTime, dur, p.gain);
+    return dur + 0.1;
+  },
+
+  "no-carrier": (ctx, dest, p) => {
+    const start = ctx.currentTime;
+    const d1 = p.dur1 / 1000;
+    const d2 = p.dur2 / 1000;
+    const d3 = p.dur3 / 1000;
+    addTone(ctx, dest, [p.freq1], start,                d1, p.gain);
+    addTone(ctx, dest, [p.freq2], start + d1 + 0.03,   d2, p.gain);
+    addTone(ctx, dest, [p.freq3], start + d1 + d2 + 0.06, d3, p.gain);
+    return d1 + d2 + d3 + 0.2;
+  },
+};
+
+// ── Default state builders ─────────────────────────────────────────────────
+
+function buildDefaultSliders(): Record<string, Record<string, number>> {
+  const out: Record<string, Record<string, number>> = {};
+  for (const phase of PHASES) {
+    out[phase.id] = {};
+    for (const s of phase.sliders) out[phase.id][s.id] = s.defaultValue;
+  }
+  return out;
+}
+
+function buildDefaultTexts(): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {};
+  for (const phase of PHASES) {
+    if (phase.texts) {
+      out[phase.id] = {};
+      for (const t of phase.texts) out[phase.id][t.id] = t.defaultValue;
+    }
+  }
+  return out;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function ModemLabPage() {
+  const navigate = useNavigate();
+
+  const [phaseIdx, setPhaseIdx] = useState(5); // default to ANSam
+  const [allSliders, setAllSliders] = useState(buildDefaultSliders);
+  const [allTexts,   setAllTexts]   = useState(buildDefaultTexts);
+  const [playing,    setPlaying]    = useState(false);
+  const [looping,    setLooping]    = useState(false);
+  const [statusMsg,  setStatusMsg]  = useState("Ready.");
+
+  const ctxRef   = useRef<AudioContext | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loopRef  = useRef(false);
+
+  // Keep loopRef in sync
+  useEffect(() => { loopRef.current = looping; }, [looping]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      try { ctxRef.current?.close(); } catch { /* ignore */ }
+    };
+  }, []);
+
+  const stopAudio = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    try { ctxRef.current?.close(); } catch { /* ignore */ }
+    ctxRef.current = null;
+    setPlaying(false);
+    setStatusMsg("Stopped.");
+  }, []);
+
+  const doPlay = useCallback((
+    phase: PhaseConfig,
+    sliders: Record<string, number>,
+    texts: Record<string, string>,
+  ) => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    try { ctxRef.current?.close(); } catch { /* ignore */ }
+
+    const ctx = new AudioContext();
+    const master = ctx.createGain();
+    master.gain.value = 0.85;
+    master.connect(ctx.destination);
+    ctxRef.current = ctx;
+
+    const fn = PLAY_FNS[phase.id];
+    if (!fn) { setStatusMsg("No play function for this phase."); return; }
+
+    const duration = fn(ctx, master, sliders, texts);
+    setPlaying(true);
+    setStatusMsg(`Playing: ${phase.label}  (${duration.toFixed(1)} s)`);
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      if (loopRef.current) {
+        doPlay(phase, sliders, texts);
+      } else {
+        setPlaying(false);
+        setStatusMsg("Done.");
+      }
+    }, Math.round(duration * 1000) + 200);
+  }, []);
+
+  const handlePlay = useCallback(() => {
+    const phase = PHASES[phaseIdx];
+    doPlay(
+      phase,
+      allSliders[phase.id] ?? {},
+      allTexts[phase.id] ?? {},
+    );
+  }, [phaseIdx, allSliders, allTexts, doPlay]);
+
+  const handleSelectPhase = useCallback((idx: number) => {
+    stopAudio();
+    setPhaseIdx(idx);
+    setStatusMsg("Ready.");
+  }, [stopAudio]);
+
+  const handleReset = useCallback(() => {
+    const phase = PHASES[phaseIdx];
+    const defaults: Record<string, number> = {};
+    for (const s of phase.sliders) defaults[s.id] = s.defaultValue;
+    setAllSliders((prev) => ({ ...prev, [phase.id]: defaults }));
+
+    if (phase.texts) {
+      const defTexts: Record<string, string> = {};
+      for (const t of phase.texts) defTexts[t.id] = t.defaultValue;
+      setAllTexts((prev) => ({ ...prev, [phase.id]: defTexts }));
+    }
+  }, [phaseIdx]);
+
+  const phase   = PHASES[phaseIdx];
+  const sliders = allSliders[phase.id] ?? {};
+  const texts   = allTexts[phase.id] ?? {};
+
+  return (
+    <div className="mlab">
+      {/* ── Title bar ── */}
+      <div className="mlab__titlebar">
+        <button className="mlab__back" onClick={() => { stopAudio(); navigate("/"); }}>
+          ← NS Doors 97
+        </button>
+        <span className="mlab__title">🔬 NOAHSOFT MODEM DIAGNOSTICS v1.0</span>
+        <span className="mlab__subtitle">Sound Lab — Internal Use Only</span>
+      </div>
+
+      <div className="mlab__body">
+        {/* ── Phase list ── */}
+        <div className="mlab__sidebar">
+          <div className="mlab__sidebar-header">SOUND PHASES</div>
+          {PHASES.map((ph, i) => (
+            <button
+              key={ph.id}
+              className={`mlab__phase-btn${i === phaseIdx ? " mlab__phase-btn--active" : ""}`}
+              onClick={() => handleSelectPhase(i)}
+            >
+              {ph.label}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Main panel ── */}
+        <div className="mlab__main">
+          <div className="mlab__phase-header">
+            <span className="mlab__phase-name">{phase.label}</span>
+            <span className="mlab__phase-desc">{phase.desc}</span>
+          </div>
+
+          {/* Text inputs */}
+          {phase.texts && phase.texts.map((t) => (
+            <div key={t.id} className="mlab__text-row">
+              <label className="mlab__text-label">{t.label}</label>
+              <input
+                className="mlab__text-input"
+                type="text"
+                value={texts[t.id] ?? t.defaultValue}
+                onChange={(e) =>
+                  setAllTexts((prev) => ({
+                    ...prev,
+                    [phase.id]: { ...(prev[phase.id] ?? {}), [t.id]: e.target.value },
+                  }))
+                }
+              />
+            </div>
+          ))}
+
+          {/* Sliders */}
+          <div className="mlab__sliders">
+            {phase.sliders.map((s) => {
+              const val = sliders[s.id] ?? s.defaultValue;
+              return (
+                <div key={s.id} className="mlab__slider-row">
+                  <label className="mlab__slider-label">{s.label}</label>
+                  <input
+                    className="mlab__slider"
+                    type="range"
+                    min={s.min}
+                    max={s.max}
+                    step={s.step}
+                    value={val}
+                    onChange={(e) =>
+                      setAllSliders((prev) => ({
+                        ...prev,
+                        [phase.id]: { ...(prev[phase.id] ?? {}), [s.id]: Number(e.target.value) },
+                      }))
+                    }
+                  />
+                  <span className="mlab__slider-val">
+                    {typeof val === "number" && s.step < 1
+                      ? val.toFixed(3)
+                      : Math.round(val)}
+                    {s.unit && <span className="mlab__slider-unit"> {s.unit}</span>}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mlab__divider" />
+
+          {/* Controls */}
+          <div className="mlab__controls">
+            <button
+              className={`mlab__btn mlab__btn--play${playing ? " mlab__btn--active" : ""}`}
+              onClick={playing ? stopAudio : handlePlay}
+            >
+              {playing ? "■ STOP" : "▶ PLAY"}
+            </button>
+            <label className="mlab__loop-label">
+              <input
+                type="checkbox"
+                checked={looping}
+                onChange={(e) => setLooping(e.target.checked)}
+              />
+              Loop
+            </label>
+            <button className="mlab__btn mlab__btn--reset" onClick={handleReset}>
+              Reset
+            </button>
+            <div className="mlab__status">{statusMsg}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Clicking the renamed "Interwebs" desktop icon now opens a Win95-style Dial-Up
Networking dialog instead of launching the browser directly. The user configures
ISP, baud rate, dial type, flow control, init string, speaker volume, and five
toggle settings (including Turbo Boost™ and Quantum Tunneling), then hits
Connect to hear a fully synthesized V.90 handshake sequence.

ModemSounds.ts generates all audio via Web Audio API — no recordings:
- PSTN dial tone (350+440 Hz)
- DTMF touch-tone or rotary pulse dialing (correct frequencies per ITU-T)
- Ringback (440+480 Hz, 2 s on / 4 s off)
- Busy signal (480+620 Hz)
- ANSam carrier (2100 Hz with 180° phase reversals every 450 ms + 15 Hz AM)
- V.8 negotiation ping-pong (1300/2100 Hz bursts + FSK-like sub-bursts)
- Training waterfall (swept bandpass noise + V.34 pilot tones + AM carriers)
- NO CARRIER error tones (three descending)

Success rate defaults to ~85% with AOL + 56K V.90 defaults. Funny ISP phone
numbers (867-5309, The Lost Numbers, Pi, 1-NCC-1701-D, etc.) and bad settings
reduce success or guarantee failure in distinctive ways. Timing uses the same
randomDelay / makeSleep utilities as the boot screen.

On success the dialog closes and opens the existing browser (Noahsoft Exploder).

https://claude.ai/code/session_01HsLJAb3Mox344jBPh5Cy33