### PR TITLE
Overhaul Typing Racer → Type 'Em Up shmup typing game

### DIFF
--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -51,9 +51,9 @@ export const experiences: Experience[] = [
   },
   {
     id: "typing-racer",
-    title: "Typing Racer",
-    description: "Type the phrase as fast as you can. WPM and accuracy tracked.",
-    category: "educational",
+    title: "Type 'Em Up",
+    description: "Words fall from above — type them to blast them before they reach your ship!",
+    category: "game",
     path: "/typing-racer",
   },
   {

--- a/src/experiences/TypingRacer/TypingRacer.css
+++ b/src/experiences/TypingRacer/TypingRacer.css
@@ -1,137 +1,269 @@
 /* ═══════════════════════════════════════════════════════════════════════════
-   Typing Racer — Noahsoft Win95 Redesign
-   Win95 chrome throughout; Courier New for the phrase (legibility);
-   Press Start 2P for all HUD / status labels.
+   Type 'Em Up — shmup typing game
+   Win95 chrome for menu / game-over screens; canvas renders the game itself.
    ═══════════════════════════════════════════════════════════════════════════ */
 
-.typing-racer {
+/* ── Outer container ─────────────────────────────────────────────────────── */
+
+.teu {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Win95 window chrome ─────────────────────────────────────────────────── */
+
+.teu__window {
+  width: min(440px, 96vw);
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  box-shadow: 4px 4px 0 #000000;
+}
+
+.teu__titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  background: linear-gradient(to right, #7b3dbe, #cc4400);
+  user-select: none;
+}
+
+.teu__titlebar--dead {
+  background: linear-gradient(to right, #660000, #cc0000);
+}
+
+.teu__titlebar-text {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  color: #ffffff;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.5);
+  letter-spacing: 0.05em;
+}
+
+.teu__titlebar-dots {
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 3px;
+}
+
+/* ── Window body ─────────────────────────────────────────────────────────── */
+
+.teu__body {
+  background: #c0c0c0;
+  padding: 20px 24px 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 14px 16px 18px;
-  gap: 12px;
-  background: #c0c0c0;
-  width: min(560px, 94vw);
+  gap: 14px;
 }
 
-/* ── Stats bar — Win95 sunken status strip ─────────────────────────────── */
+/* ── Logo / heading ──────────────────────────────────────────────────────── */
 
-.typing-racer__stats {
-  display: flex;
-  gap: 16px;
-  width: 100%;
-  padding: 4px 8px;
-  background: #d4d0c8;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
+.teu__logo {
+  font-family: "Press Start 2P", monospace;
+  font-size: 18px;
+  color: #cc4400;
+  text-shadow: 2px 2px 0 #663300, 4px 4px 0 rgba(0, 0, 0, 0.3);
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.teu__logo--dead {
+  color: #cc0000;
+  text-shadow: 2px 2px 0 #660000, 4px 4px 0 rgba(0, 0, 0, 0.3);
+}
+
+.teu__tagline {
   font-family: "Press Start 2P", monospace;
   font-size: 7px;
-  color: #000;
-  box-sizing: border-box;
-  font-variant-numeric: tabular-nums;
-  min-height: 22px;
-  align-items: center;
+  color: #666;
+  text-transform: lowercase;
+  letter-spacing: 0.1em;
 }
 
-.typing-racer__timer {
-  color: #cc4400;
-  margin-left: auto;
-}
+/* ── High score ──────────────────────────────────────────────────────────── */
 
-/* ── Phrase display — Win95 inset panel ───────────────────────────────── */
-
-.typing-racer__phrase {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 10px 12px;
+.teu__high-score {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #5b2d8e;
   background: #d4d0c8;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
-  font-family: "Courier New", Courier, monospace;
-  font-size: 1.15rem;
+  padding: 5px 12px;
+  letter-spacing: 0.06em;
+}
+
+/* ── New record flash ────────────────────────────────────────────────────── */
+
+.teu__new-record {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  color: #ffcc00;
+  text-shadow: 1px 1px 0 #664400;
+  animation: teu-flash 0.6s step-end infinite;
+  letter-spacing: 0.06em;
+}
+
+@keyframes teu-flash {
+  0%,  100% { opacity: 1; }
+  50%        { opacity: 0; }
+}
+
+/* ── Section label ───────────────────────────────────────────────────────── */
+
+.teu__section-label {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #444;
+  letter-spacing: 0.1em;
+  align-self: flex-start;
+}
+
+/* ── Difficulty buttons ──────────────────────────────────────────────────── */
+
+.teu__diff-row {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.teu__diff-btn {
+  flex: 1;
+  padding: 8px 4px;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  color: #333;
+  letter-spacing: 0.05em;
+}
+
+.teu__diff-btn:hover {
+  background: #d4d0c8;
+}
+
+.teu__diff-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  transform: translateY(1px);
+}
+
+/* Easy = green tint, Medium = amber, Hard = red */
+.teu__diff-btn--active:nth-child(1) {
+  background: #cceecc;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #226622;
+}
+.teu__diff-btn--active:nth-child(2) {
+  background: #ffeebb;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #664400;
+}
+.teu__diff-btn--active:nth-child(3) {
+  background: #ffcccc;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #880000;
+}
+
+/* ── Launch / action buttons ─────────────────────────────────────────────── */
+
+.teu__launch-btn {
+  padding: 10px 28px;
+  background: #ff6b00;
+  color: #ffffff;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  cursor: pointer;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
+  letter-spacing: 0.06em;
+}
+
+.teu__launch-btn:hover {
+  background: #ff7a1a;
+}
+
+.teu__launch-btn:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #cc4400;
+  transform: translateY(1px);
+}
+
+.teu__launch-btn--secondary {
+  background: #c0c0c0;
+  color: #333;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  text-shadow: none;
+}
+
+.teu__launch-btn--secondary:hover {
+  background: #d4d0c8;
+}
+
+.teu__launch-btn--secondary:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #b0b0b0;
+}
+
+/* ── Tips / instructions ─────────────────────────────────────────────────── */
+
+.teu__tips {
+  width: 100%;
+  padding: 8px 10px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.teu__tips p {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #444;
+  margin: 0 0 6px;
   line-height: 1.8;
-  text-align: left;
-  user-select: none;
-  letter-spacing: 0.02em;
-  word-break: break-word;
 }
 
-.typing-racer__char {
-  color: #888;
+.teu__tips p:last-child {
+  margin-bottom: 0;
 }
 
-.typing-racer__char--correct {
-  color: #228833;
+.teu__tips-esc {
+  color: #888 !important;
 }
 
-.typing-racer__char--wrong {
-  color: #cc0000;
-  background: rgba(204, 0, 0, 0.12);
-}
+/* ── Stats grid (game over) ──────────────────────────────────────────────── */
 
-.typing-racer__char--cursor {
-  color: #000;
-  border-bottom: 2px solid #cc4400;
-}
-
-/* ── Input — Win95 text field ────────────────────────────────────────── */
-
-.typing-racer__input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 5px 8px;
-  font-family: "Courier New", Courier, monospace;
-  font-size: 1rem;
-  background: #ffffff;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
-  color: #000;
-  outline: none;
-  caret-color: #cc4400;
-}
-
-.typing-racer__input:focus {
-  border-color: #000000 #c0c0c0 #c0c0c0 #000000;
-}
-
-/* ── Result screen ──────────────────────────────────────────────────── */
-
-.typing-racer__result {
+.teu__stats-grid {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  width: 100%;
-}
-
-.typing-racer__result-stats {
-  display: flex;
-  gap: 0;
   width: 100%;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   background: #d4d0c8;
 }
 
-.typing-racer__result-stats > div {
+.teu__stat {
   flex: 1;
   text-align: center;
-  padding: 10px 8px;
+  padding: 12px 8px;
   border-right: 1px solid #808080;
 }
 
-.typing-racer__result-stats > div:last-child {
+.teu__stat:last-child {
   border-right: none;
 }
 
-.typing-racer__result-value {
+.teu__stat-val {
   font-family: "Press Start 2P", monospace;
   font-size: 14px;
   color: #cc4400;
   font-variant-numeric: tabular-nums;
 }
 
-.typing-racer__result-label {
+.teu__stat-key {
   font-family: "Press Start 2P", monospace;
   font-size: 6px;
   color: #555;
@@ -140,26 +272,19 @@
   margin-top: 6px;
 }
 
-/* Win95 orange primary button */
-.typing-racer__reset {
-  padding: 7px 24px;
-  background: #ff6b00;
-  color: #fff;
+/* ── Action row ──────────────────────────────────────────────────────────── */
+
+.teu__action-row {
+  display: flex;
+  gap: 12px;
+}
+
+/* ── Canvas (playing phase) ──────────────────────────────────────────────── */
+
+.teu__canvas {
+  display: block;
   border: 2px solid;
-  border-color: #ffcc88 #664400 #664400 #ffcc88;
-  font-family: "Press Start 2P", monospace;
-  font-size: 8px;
-  cursor: pointer;
-  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
-  letter-spacing: 0.04em;
-}
-
-.typing-racer__reset:hover {
-  background: #ff7a1a;
-}
-
-.typing-racer__reset:active {
-  border-color: #664400 #ffcc88 #ffcc88 #664400;
-  background: #cc4400;
-  transform: translateY(1px);
+  border-color: #ffffff #808080 #808080 #ffffff;
+  box-shadow: 4px 4px 0 #000000;
+  image-rendering: pixelated;
 }

--- a/src/experiences/TypingRacer/TypingRacer.css
+++ b/src/experiences/TypingRacer/TypingRacer.css
@@ -279,12 +279,85 @@
   gap: 12px;
 }
 
-/* ── Canvas (playing phase) ──────────────────────────────────────────────── */
+/* ── Canvas + type strip wrapper (playing phase) ─────────────────────────── */
+
+.teu__game-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(560px, 96vw);
+}
 
 .teu__canvas {
   display: block;
+  width: 100%;
+  height: auto;
   border: 2px solid;
   border-color: #ffffff #808080 #808080 #ffffff;
+  border-bottom: none; /* strip shares the bottom edge */
   box-shadow: 4px 4px 0 #000000;
   image-rendering: pixelated;
+}
+
+/* ── Type strip ──────────────────────────────────────────────────────────── */
+
+/* Visible bar below the canvas. Tapping it focuses the hidden input, which
+   brings up the mobile keyboard and resumes the game. */
+.teu__type-strip {
+  height: 38px;
+  background: #080820;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  border-top: 1px solid #222244;
+  box-shadow: 4px 4px 0 #000000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  box-sizing: border-box;
+}
+
+.teu__type-strip--paused {
+  background: #0d0d30;
+  border-color: #ffcc00 #886600 #886600 #ffcc00;
+  animation: teu-strip-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes teu-strip-pulse {
+  0%,  100% { background: #0d0d30; }
+  50%        { background: #1a1a00; }
+}
+
+.teu__strip-label {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  color: #ffcc00;
+  letter-spacing: 0.12em;
+}
+
+/* Blinking block cursor shown when the game is active */
+.teu__strip-cursor {
+  display: inline-block;
+  width: 10px;
+  height: 16px;
+  background: #44bb66;
+  animation: teu-blink 0.8s step-end infinite;
+}
+
+@keyframes teu-blink {
+  0%,  100% { opacity: 1; }
+  50%        { opacity: 0; }
+}
+
+/* ── Hidden input (always in DOM for iOS focus support) ──────────────────── */
+
+.teu__mobile-input {
+  position: fixed;
+  left: -9999px;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/experiences/TypingRacer/TypingRacer.css
+++ b/src/experiences/TypingRacer/TypingRacer.css
@@ -361,3 +361,32 @@
   opacity: 0;
   pointer-events: none;
 }
+
+/* ── Mobile: pin canvas to the top of the visual viewport ───────────────── */
+/*
+ * When the virtual keyboard opens, the browser scrolls/reflows to keep the
+ * focused element visible. With the canvas centered in the page that pushes
+ * it off-screen.  Fixing the game wrapper to top:0 makes it immune to that
+ * scroll — the keyboard slides up from below and the canvas stays put.
+ *
+ * `dvh` (dynamic viewport height) shrinks as the keyboard rises, so the
+ * max-height constraint automatically scales the canvas down to fit.
+ * max-width keeps the 560:480 aspect ratio when height is the limiting edge.
+ */
+@media (pointer: coarse) {
+  .teu__game-wrapper {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(560px, 100vw);
+    /* sit below the back-button and help-overlay which use z-index: 10 */
+    z-index: 5;
+  }
+
+  .teu__canvas {
+    max-height: calc(100dvh - 42px);
+    /* maintain 560∶480 aspect ratio when max-height is the binding constraint */
+    max-width: calc((100dvh - 42px) * 560 / 480);
+  }
+}

--- a/src/experiences/TypingRacer/TypingRacer.tsx
+++ b/src/experiences/TypingRacer/TypingRacer.tsx
@@ -315,13 +315,140 @@ export default function TypingRacer() {
     const s = localStorage.getItem("typeemup-highscore");
     return s ? parseInt(s, 10) : 0;
   });
+  // gamePaused drives the "tap to play" strip; gamePausedRef is readable inside
+  // the RAF loop without a stale-closure issue.
+  const [gamePaused, setGamePaused] = useState(true);
 
-  const canvasRef    = useRef<HTMLCanvasElement>(null);
-  const gameRef      = useRef<GameState | null>(null);
-  const rafRef       = useRef<number>(0);
-  const highScoreRef = useRef(highScore);
+  const canvasRef       = useRef<HTMLCanvasElement>(null);
+  const gameRef         = useRef<GameState | null>(null);
+  const rafRef          = useRef<number>(0);
+  const highScoreRef    = useRef(highScore);
+  const gamePausedRef   = useRef(true);
+  // The input is always in the DOM so iOS focus() works in a user-gesture handler.
+  const inputRef        = useRef<HTMLInputElement>(null);
+  // Prevents double-processing on desktop when both onKeyDown and onChange fire.
+  const keyHandledRef   = useRef(false);
 
   useEffect(() => { highScoreRef.current = highScore; }, [highScore]);
+
+  // ── Pause / resume helpers ─────────────────────────────────────────────────
+
+  const pauseGame = useCallback(() => {
+    gamePausedRef.current = true;
+    setGamePaused(true);
+  }, []);
+
+  const resumeGame = useCallback(() => {
+    if (!gameRef.current) return;
+    // Reset the frame timer so the first dt after a pause isn't huge.
+    gameRef.current.lastFrameTime = performance.now();
+    gamePausedRef.current = false;
+    setGamePaused(false);
+  }, []);
+
+  // ── Core char processor (shared by desktop onKeyDown and mobile onChange) ──
+
+  const processChar = useCallback((ch: string) => {
+    const state = gameRef.current;
+    if (!state) return;
+
+    if (state.targetId !== null) {
+      const target = state.words.find(w => w.id === state.targetId);
+      if (!target) { state.targetId = null; return; }
+
+      if (ch === target.text[target.typed]) {
+        target.typed++;
+        state.charsTyped++;
+
+        state.bullets.push({
+          id: state.nextId++,
+          x: target.x,
+          fromY: SHIP_Y - 34,
+          toY: target.y,
+          progress: 0,
+        });
+
+        if (target.typed === target.text.length) {
+          state.wordsDestroyed++;
+          state.score += target.text.length * 10 + Math.floor(target.speed);
+          burstParticles(state, target.x, target.y, 14);
+          state.words    = state.words.filter(w => w.id !== target.id);
+          state.targetId = null;
+        }
+      } else {
+        target.penalty += DIFF[state.difficulty].penalty;
+      }
+    } else {
+      const candidates = state.words.filter(w => w.text[0] === ch && w.typed === 0);
+      if (candidates.length === 0) return;
+
+      const target = candidates.reduce((a, b) => (a.y > b.y ? a : b));
+      state.targetId  = target.id;
+      target.typed    = 1;
+      state.charsTyped++;
+
+      state.bullets.push({
+        id: state.nextId++,
+        x: target.x,
+        fromY: SHIP_Y - 34,
+        toY: target.y,
+        progress: 0,
+      });
+
+      if (target.text.length === 1) {
+        state.wordsDestroyed++;
+        state.score += 10 + Math.floor(target.speed);
+        burstParticles(state, target.x, target.y, 10);
+        state.words    = state.words.filter(w => w.id !== target.id);
+        state.targetId = null;
+      }
+    }
+  }, []);
+
+  // ── Input event handlers ───────────────────────────────────────────────────
+
+  // Desktop: onKeyDown fires with a real key value. We preventDefault so the
+  // character never reaches the input value (no onChange needed for desktop).
+  const handleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    if (e.key === "Escape") {
+      cancelAnimationFrame(rafRef.current);
+      setPhase("menu");
+      return;
+    }
+
+    if (e.key.length === 1) {
+      e.preventDefault();
+      keyHandledRef.current = true;
+      processChar(e.key.toLowerCase());
+    }
+  }, [processChar]);
+
+  // Mobile: onKeyDown gives "Unidentified", so the character ends up in the
+  // input value and onChange fires. We drain the value and clear the field.
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (keyHandledRef.current) {
+      // Desktop path already processed this keystroke.
+      keyHandledRef.current = false;
+      e.target.value = "";
+      return;
+    }
+    // Mobile path: one or more characters arrived via the IME / virtual keyboard.
+    const val = e.target.value;
+    for (const ch of val) {
+      processChar(ch.toLowerCase());
+    }
+    e.target.value = "";
+  }, [processChar]);
+
+  const handleInputFocus = useCallback(() => {
+    resumeGame();
+  }, [resumeGame]);
+
+  const handleInputBlur = useCallback(() => {
+    pauseGame();
+  }, [pauseGame]);
 
   // ── Game loop ──────────────────────────────────────────────────────────────
 
@@ -333,91 +460,91 @@ export default function TypingRacer() {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const dt = Math.min((timestamp - state.lastFrameTime) / 1000, 0.05);
-    state.lastFrameTime = timestamp;
+    // ── Update (skipped while paused) ────────────────────────────────────────
+    if (!gamePausedRef.current) {
+      const dt = Math.min((timestamp - state.lastFrameTime) / 1000, 0.05);
+      state.lastFrameTime = timestamp;
 
-    // WPM sample every second
-    if (timestamp - state.lastWpmUpdate > 1000) {
-      state.wpm = calcWpm(state.charsTyped, state.startTime);
-      state.wpmHistory.push({ wpm: state.wpm });
-      if (state.wpmHistory.length > 45) state.wpmHistory.shift();
-      state.lastWpmUpdate = timestamp;
-    }
-
-    // Spawn words
-    const cfg = DIFF[state.difficulty];
-    if (timestamp - state.lastSpawnTime > cfg.spawnMs && state.words.length < cfg.maxWords) {
-      spawnWord(state);
-      state.lastSpawnTime = timestamp;
-    }
-
-    // Move words & detect hits
-    const hitIds: number[] = [];
-    for (const w of state.words) {
-      w.y += (w.speed + w.penalty) * dt;
-      w.penalty = Math.max(0, w.penalty - w.penalty * 3 * dt);
-      if (w.y >= SHIP_Y - 10) hitIds.push(w.id);
-    }
-
-    // Process hits
-    let died = false;
-    for (const id of hitIds) {
-      state.words = state.words.filter(w => w.id !== id);
-      if (state.targetId === id) state.targetId = null;
-      state.lives--;
-      state.shipFlash = 1;
-      if (state.lives <= 0) { died = true; break; }
-    }
-
-    if (died) {
-      cancelAnimationFrame(rafRef.current);
-      const finalWpm = calcWpm(state.charsTyped, state.startTime);
-      const isNewRecord = state.score > highScoreRef.current;
-      setFinalStats({ score: state.score, wpm: finalWpm, wordsDestroyed: state.wordsDestroyed, isNewRecord });
-      if (isNewRecord) {
-        localStorage.setItem("typeemup-highscore", String(state.score));
-        setHighScore(state.score);
+      // WPM sample every second
+      if (timestamp - state.lastWpmUpdate > 1000) {
+        state.wpm = calcWpm(state.charsTyped, state.startTime);
+        state.wpmHistory.push({ wpm: state.wpm });
+        if (state.wpmHistory.length > 45) state.wpmHistory.shift();
+        state.lastWpmUpdate = timestamp;
       }
-      setPhase("gameover");
-      return;
+
+      // Spawn words
+      const cfg = DIFF[state.difficulty];
+      if (timestamp - state.lastSpawnTime > cfg.spawnMs && state.words.length < cfg.maxWords) {
+        spawnWord(state);
+        state.lastSpawnTime = timestamp;
+      }
+
+      // Move words & detect hits
+      const hitIds: number[] = [];
+      for (const w of state.words) {
+        w.y += (w.speed + w.penalty) * dt;
+        w.penalty = Math.max(0, w.penalty - w.penalty * 3 * dt);
+        if (w.y >= SHIP_Y - 10) hitIds.push(w.id);
+      }
+
+      // Process hits
+      let died = false;
+      for (const id of hitIds) {
+        state.words = state.words.filter(w => w.id !== id);
+        if (state.targetId === id) state.targetId = null;
+        state.lives--;
+        state.shipFlash = 1;
+        if (state.lives <= 0) { died = true; break; }
+      }
+
+      if (died) {
+        cancelAnimationFrame(rafRef.current);
+        const finalWpm = calcWpm(state.charsTyped, state.startTime);
+        const isNewRecord = state.score > highScoreRef.current;
+        setFinalStats({ score: state.score, wpm: finalWpm, wordsDestroyed: state.wordsDestroyed, isNewRecord });
+        if (isNewRecord) {
+          localStorage.setItem("typeemup-highscore", String(state.score));
+          setHighScore(state.score);
+        }
+        gameRef.current = null;
+        setPhase("gameover");
+        return;
+      }
+
+      // Decay ship flash
+      if (state.shipFlash > 0) state.shipFlash = Math.max(0, state.shipFlash - dt * 3);
+
+      // Advance bullets
+      for (const b of state.bullets) b.progress += dt * 5;
+      state.bullets = state.bullets.filter(b => b.progress < 1);
+
+      // Advance particles
+      for (const p of state.particles) {
+        p.x  += p.vx * dt;
+        p.y  += p.vy * dt;
+        p.vy += 120 * dt;
+        p.life -= dt * 2;
+      }
+      state.particles = state.particles.filter(p => p.life > 0);
     }
 
-    // Decay ship flash
-    if (state.shipFlash > 0) state.shipFlash = Math.max(0, state.shipFlash - dt * 3);
+    // ── Render (always, even while paused) ───────────────────────────────────
 
-    // Advance bullets
-    for (const b of state.bullets) b.progress += dt * 5;
-    state.bullets = state.bullets.filter(b => b.progress < 1);
-
-    // Advance particles
-    for (const p of state.particles) {
-      p.x  += p.vx * dt;
-      p.y  += p.vy * dt;
-      p.vy += 120 * dt; // gravity
-      p.life -= dt * 2;
-    }
-    state.particles = state.particles.filter(p => p.life > 0);
-
-    // ── Render ───────────────────────────────────────────────────────────────
-
-    // Background
     ctx.fillStyle = "#06061a";
     ctx.fillRect(0, 0, CW, CH);
 
-    // Stars
     for (const s of state.stars) {
       ctx.fillStyle = `rgba(255,255,255,${s.b})`;
       ctx.fillRect(s.x, s.y, s.r, s.r);
     }
 
-    // Danger zone glow at bottom
     const dangerGrad = ctx.createLinearGradient(0, SHIP_Y - 50, 0, SHIP_Y + 30);
     dangerGrad.addColorStop(0, "rgba(180,0,0,0)");
     dangerGrad.addColorStop(1, "rgba(180,0,0,0.12)");
     ctx.fillStyle = dangerGrad;
     ctx.fillRect(0, SHIP_Y - 50, CW, 80);
 
-    // Bullets
     ctx.shadowColor = "#ff6600";
     ctx.shadowBlur  = 10;
     ctx.fillStyle   = "#ff8833";
@@ -427,7 +554,6 @@ export default function TypingRacer() {
     }
     ctx.shadowBlur = 0;
 
-    // Falling words
     ctx.textBaseline = "middle";
     for (const word of state.words) {
       const isTarget = word.id === state.targetId;
@@ -454,14 +580,12 @@ export default function TypingRacer() {
         ctx.fillText(word.text[i], charX, word.y);
       }
 
-      // Underline the first char of untargeted words as a "press me" hint
       if (!isTarget && word.typed === 0) {
         ctx.fillStyle = "#44bb66";
         ctx.fillRect(word.x - half, word.y + 10, CHAR_W, 1);
       }
     }
 
-    // Particles
     for (const p of state.particles) {
       ctx.globalAlpha = p.life;
       ctx.fillStyle   = p.color;
@@ -469,88 +593,10 @@ export default function TypingRacer() {
     }
     ctx.globalAlpha = 1;
 
-    // Ship (drawn above particles)
     drawShip(ctx, state.shipFlash);
-
-    // HUD last — always on top
     drawHud(ctx, state.lives, state.score, state.wpm, state.wpmHistory, state.difficulty);
 
     rafRef.current = requestAnimationFrame(gameLoop);
-  }, []);
-
-  // ── Key handler ────────────────────────────────────────────────────────────
-
-  const handleKey = useCallback((e: KeyboardEvent) => {
-    if (e.metaKey || e.ctrlKey || e.altKey) return;
-
-    const state = gameRef.current;
-    if (!state) return;
-
-    if (e.key === "Escape") {
-      cancelAnimationFrame(rafRef.current);
-      setPhase("menu");
-      return;
-    }
-
-    if (e.key.length !== 1) return;
-    const ch = e.key.toLowerCase();
-
-    if (state.targetId !== null) {
-      const target = state.words.find(w => w.id === state.targetId);
-      if (!target) { state.targetId = null; return; }
-
-      if (ch === target.text[target.typed]) {
-        // Correct letter
-        target.typed++;
-        state.charsTyped++;
-
-        state.bullets.push({
-          id: state.nextId++,
-          x: target.x,
-          fromY: SHIP_Y - 34,
-          toY: target.y,
-          progress: 0,
-        });
-
-        if (target.typed === target.text.length) {
-          // Word destroyed
-          state.wordsDestroyed++;
-          state.score += target.text.length * 10 + Math.floor(target.speed);
-          burstParticles(state, target.x, target.y, 14);
-          state.words     = state.words.filter(w => w.id !== target.id);
-          state.targetId  = null;
-        }
-      } else {
-        // Wrong letter → extra fall speed
-        target.penalty += DIFF[state.difficulty].penalty;
-      }
-    } else {
-      // No active target — acquire the lowest word starting with this char
-      const candidates = state.words.filter(w => w.text[0] === ch && w.typed === 0);
-      if (candidates.length === 0) return;
-
-      const target = candidates.reduce((a, b) => (a.y > b.y ? a : b));
-      state.targetId  = target.id;
-      target.typed    = 1;
-      state.charsTyped++;
-
-      state.bullets.push({
-        id: state.nextId++,
-        x: target.x,
-        fromY: SHIP_Y - 34,
-        toY: target.y,
-        progress: 0,
-      });
-
-      // Handle single-char words
-      if (target.text.length === 1) {
-        state.wordsDestroyed++;
-        state.score += 10 + Math.floor(target.speed);
-        burstParticles(state, target.x, target.y, 10);
-        state.words    = state.words.filter(w => w.id !== target.id);
-        state.targetId = null;
-      }
-    }
   }, []);
 
   // ── Start game ─────────────────────────────────────────────────────────────
@@ -578,7 +624,7 @@ export default function TypingRacer() {
       charsTyped: 0,
       wordsDestroyed: 0,
       startTime: Date.now(),
-      lastSpawnTime: now - DIFF[diff].spawnMs, // trigger first spawn immediately
+      lastSpawnTime: now - DIFF[diff].spawnMs,
       wpm: 0,
       wpmHistory: [],
       lastWpmUpdate: 0,
@@ -588,25 +634,59 @@ export default function TypingRacer() {
       shipFlash: 0,
     };
 
+    // Start paused; the RAF loop renders a static first frame.
+    // Game logic begins when the input receives focus.
+    gamePausedRef.current = true;
+    setGamePaused(true);
     setPhase("playing");
     rafRef.current = requestAnimationFrame(gameLoop);
   }, [gameLoop]);
 
-  // ── Effects ────────────────────────────────────────────────────────────────
+  // ── Global Escape listener (works even when input isn't focused) ───────────
 
   useEffect(() => {
     if (phase !== "playing") return;
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [phase, handleKey]);
+    function onEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        cancelAnimationFrame(rafRef.current);
+        setPhase("menu");
+      }
+    }
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [phase]);
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────────
 
   useEffect(() => () => { cancelAnimationFrame(rafRef.current); }, []);
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
+  // The <input> is always in the DOM (visibility:hidden when not playing) so
+  // that focus() called synchronously inside a button click works on iOS.
+  const inputEl = (
+    <input
+      ref={inputRef}
+      className="teu__mobile-input"
+      type="text"
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="none"
+      spellCheck={false}
+      inputMode="text"
+      tabIndex={phase === "playing" ? 0 : -1}
+      aria-label="Type here to play"
+      onFocus={handleInputFocus}
+      onBlur={handleInputBlur}
+      onKeyDown={handleInputKeyDown}
+      onChange={handleInputChange}
+    />
+  );
+
   if (phase === "menu") {
     return (
       <div className="teu">
+        {inputEl}
         <div className="teu__window">
           <div className="teu__titlebar">
             <span className="teu__titlebar-text">Type &#39;Em Up</span>
@@ -633,7 +713,15 @@ export default function TypingRacer() {
               ))}
             </div>
 
-            <button className="teu__launch-btn" onClick={() => startGame(difficulty)}>
+            <button
+              className="teu__launch-btn"
+              onClick={() => {
+                startGame(difficulty);
+                // Synchronous focus in the user-gesture handler — required for
+                // iOS to show the virtual keyboard without an extra tap.
+                inputRef.current?.focus();
+              }}
+            >
               LAUNCH
             </button>
 
@@ -641,7 +729,7 @@ export default function TypingRacer() {
               <p>Words fall from above &mdash; type them to shoot!</p>
               <p>Mistyping makes words fall faster.</p>
               <p>Don&#39;t let words reach your ship!</p>
-              <p className="teu__tips-esc">ESC pauses &amp; returns to menu.</p>
+              <p className="teu__tips-esc">ESC returns to menu.</p>
             </div>
           </div>
         </div>
@@ -652,6 +740,7 @@ export default function TypingRacer() {
   if (phase === "gameover") {
     return (
       <div className="teu">
+        {inputEl}
         <div className="teu__window">
           <div className="teu__titlebar teu__titlebar--dead">
             <span className="teu__titlebar-text">GAME OVER</span>
@@ -684,7 +773,13 @@ export default function TypingRacer() {
             )}
 
             <div className="teu__action-row">
-              <button className="teu__launch-btn" onClick={() => startGame(difficulty)}>
+              <button
+                className="teu__launch-btn"
+                onClick={() => {
+                  startGame(difficulty);
+                  inputRef.current?.focus();
+                }}
+              >
                 RETRY
               </button>
               <button
@@ -700,15 +795,31 @@ export default function TypingRacer() {
     );
   }
 
-  // Playing phase — canvas only
+  // Playing phase
   return (
     <div className="teu">
-      <canvas
-        ref={canvasRef}
-        width={CW}
-        height={CH}
-        className="teu__canvas"
-      />
+      {inputEl}
+      <div className="teu__game-wrapper">
+        <canvas
+          ref={canvasRef}
+          width={CW}
+          height={CH}
+          className="teu__canvas"
+        />
+        {/* Tap strip — always visible below the canvas during play.
+            Shows a "tap here" prompt when paused, a blinking cursor when active. */}
+        <div
+          className={`teu__type-strip${gamePaused ? " teu__type-strip--paused" : ""}`}
+          onClick={() => inputRef.current?.focus()}
+          role="button"
+          aria-label="Tap to play"
+        >
+          {gamePaused
+            ? <span className="teu__strip-label">&#9654; TAP TO PLAY</span>
+            : <span className="teu__strip-cursor" aria-hidden="true" />
+          }
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/experiences/TypingRacer/TypingRacer.tsx
+++ b/src/experiences/TypingRacer/TypingRacer.tsx
@@ -1,138 +1,714 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import "./TypingRacer.css";
 
-const PHRASES = [
-  "The quick brown fox jumps over the lazy dog.",
-  "Pack my box with five dozen liquor jugs.",
-  "How vexingly quick daft zebras jump!",
-  "The five boxing wizards jump quickly.",
-  "Sphinx of black quartz, judge my vow.",
-  "Two driven jocks help fax my big quiz.",
-  "Five quacking zephyrs jolt my wax bed.",
-  "Jackdaws love my big sphinx of quartz.",
-  "Blowzy red vixens fight for a quick jump.",
-  "The jay, pig, fox, zebra, and my wolves quack!",
-  "Bright vixens jump dozy fowl quack.",
-  "Woven silk pyjamas exchanged for blue quartz.",
-];
+// ─── Types ───────────────────────────────────────────────────────────────────
 
-function pickPhrase(): string {
-  return PHRASES[Math.floor(Math.random() * PHRASES.length)];
+type Difficulty = "easy" | "medium" | "hard";
+type Phase = "menu" | "playing" | "gameover";
+
+interface FallingWord {
+  id: number;
+  text: string;
+  x: number;
+  y: number;
+  speed: number;
+  penalty: number;
+  typed: number;
 }
 
-export default function TypingRacer() {
-  const [phrase, setPhrase] = useState(pickPhrase);
-  const [typed, setTyped] = useState("");
-  const [startTime, setStartTime] = useState<number | null>(null);
-  const [finishTime, setFinishTime] = useState<number | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+interface Bullet {
+  id: number;
+  x: number;
+  fromY: number;
+  toY: number;
+  progress: number;
+}
 
-  useEffect(() => {
-    inputRef.current?.focus();
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  color: string;
+}
+
+interface WpmSample {
+  wpm: number;
+}
+
+interface GameState {
+  words: FallingWord[];
+  bullets: Bullet[];
+  particles: Particle[];
+  stars: Array<{ x: number; y: number; r: number; b: number }>;
+  targetId: number | null;
+  lives: number;
+  score: number;
+  charsTyped: number;
+  wordsDestroyed: number;
+  startTime: number;
+  lastSpawnTime: number;
+  wpm: number;
+  wpmHistory: WpmSample[];
+  lastWpmUpdate: number;
+  nextId: number;
+  difficulty: Difficulty;
+  lastFrameTime: number;
+  shipFlash: number;
+}
+
+interface FinalStats {
+  score: number;
+  wpm: number;
+  wordsDestroyed: number;
+  isNewRecord: boolean;
+}
+
+// ─── Word lists ──────────────────────────────────────────────────────────────
+
+const WORDS: Record<Difficulty, string[]> = {
+  easy: [
+    "cat","dog","fox","bat","ant","bee","fly","owl","rat","elk",
+    "run","hop","zip","zap","pop","top","map","cap","cup","box",
+    "big","bit","hit","sit","fit","tip","dip","rip","sip","lip",
+    "ham","jam","ram","yam","can","ban","fan","man","pan","ran",
+    "red","bed","fed","led","wed","net","set","let","met","jet",
+    "hot","lot","pot","dot","got","bug","mug","rug","tug","dug",
+    "lag","rag","sag","tag","wag","bag","arm","arc","ash","ace",
+    "age","air","ale","aim","axe","bow","cog","cub","dam","den",
+    "dew","dye","eel","egg","elm","era","eve","ewe","eye","fad",
+    "foe","fog","fur","gag","gap","gem","gin","gnu","hag","hay",
+  ],
+  medium: [
+    "brick","clock","dream","flame","ghost","joker","knife","laser",
+    "magic","night","orbit","pixel","queen","robot","storm","tiger",
+    "alpha","blaze","champ","delta","elite","frost","globe","hydra",
+    "blast","cyber","disco","ember","forge","grind","haste","ionic",
+    "jumbo","karma","light","metal","ninja","ozone","prowl","quirk",
+    "racer","shift","solar","turbo","vivid","craze","drive","epoch",
+    "flick","graze","helix","irony","jelly","knack","lemon","mango",
+    "nerve","oxide","piano","quill","raven","scout","thump","ultra",
+    "valor","woven","xerox","yield","zilch","amber","blunt","crisp",
+    "decoy","elder","flare","glyph","haven","inbox","joust","karma",
+  ],
+  hard: [
+    "algorithm","bandwidth","compiler","database","endpoint",
+    "firewall","graphics","hardware","internet","keyboard",
+    "megabyte","overflow","password","quantize","register",
+    "software","terminal","username","variable","wireless",
+    "bootstrap","codeblock","download","encrypted","framework",
+    "gigahertz","hyperlink","interface","kilobyte","localhost",
+    "megahertz","namespace","objective","processor","quicksort",
+    "recursive","shellcode","timestamp","undefined","vectorize",
+    "webmaster","xdebugger","yottabyte","zeropoint","archetype",
+    "benchmark","cacheline","debugmode","eventloop","firstbyte",
+  ],
+};
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CW = 560;
+const CH = 480;
+const HUD_H = 60;
+const SHIP_Y = CH - 80; // 400
+const MAX_LIVES = 3;
+const CHAR_W = 8.5;
+
+const DIFF: Record<Difficulty, {
+  speedMin: number;
+  speedMax: number;
+  spawnMs: number;
+  maxWords: number;
+  penalty: number;
+}> = {
+  easy:   { speedMin: 28,  speedMax: 50,  spawnMs: 3500, maxWords: 3, penalty: 45  },
+  medium: { speedMin: 50,  speedMax: 82,  spawnMs: 2400, maxWords: 4, penalty: 70  },
+  hard:   { speedMin: 82,  speedMax: 120, spawnMs: 1700, maxWords: 5, penalty: 100 },
+};
+
+const PARTICLE_COLORS = ["#ff6600", "#ffcc00", "#ff3300", "#ffffff", "#ff8833"];
+
+// ─── Module-level helpers ─────────────────────────────────────────────────────
+
+function calcWpm(chars: number, startTime: number): number {
+  const mins = (Date.now() - startTime) / 60000;
+  if (mins < 0.01) return 0;
+  return Math.round((chars / 5) / mins);
+}
+
+function spawnWord(state: GameState): void {
+  const cfg = DIFF[state.difficulty];
+  const list = WORDS[state.difficulty];
+  const existing = new Set<string>(state.words.map(w => w.text));
+
+  let text = list[Math.floor(Math.random() * list.length)];
+  for (let i = 0; i < 10 && existing.has(text); i++) {
+    text = list[Math.floor(Math.random() * list.length)];
+  }
+
+  const half = (text.length * CHAR_W) / 2;
+  const margin = half + 20;
+  const x = margin + Math.random() * (CW - margin * 2);
+  const speed = cfg.speedMin + Math.random() * (cfg.speedMax - cfg.speedMin);
+
+  state.words.push({
+    id: state.nextId++,
+    text,
+    x,
+    y: HUD_H - 10,
+    speed,
+    penalty: 0,
+    typed: 0,
+  });
+}
+
+function burstParticles(state: GameState, x: number, y: number, count: number): void {
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2;
+    const spd = 50 + Math.random() * 100;
+    state.particles.push({
+      x,
+      y,
+      vx: Math.cos(angle) * spd,
+      vy: Math.sin(angle) * spd,
+      life: 1,
+      color: PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)],
+    });
+  }
+}
+
+function drawShip(ctx: CanvasRenderingContext2D, flash: number): void {
+  const cx = CW / 2;
+  const cy = SHIP_Y;
+
+  ctx.save();
+
+  // Thruster flame (randomized height for animation effect)
+  const flameH = 8 + Math.random() * 10;
+  ctx.fillStyle = "rgba(255,140,0,0.85)";
+  ctx.beginPath();
+  ctx.moveTo(cx - 5, cy + 18);
+  ctx.lineTo(cx, cy + 18 + flameH);
+  ctx.lineTo(cx + 5, cy + 18);
+  ctx.closePath();
+  ctx.fill();
+
+  // Color shift on hit
+  const r = flash > 0 ? Math.min(255, Math.floor(180 + 75 * flash)) : 180;
+  const g = flash > 0 ? Math.floor(100 * (1 - flash)) : 100;
+  const b = flash > 0 ? Math.floor(60 * (1 - flash))  : 60;
+
+  // Wings
+  const wr = Math.floor(r * 0.55);
+  const wg = Math.floor(g * 0.55);
+  const wb = Math.floor(b * 0.55);
+  ctx.fillStyle = `rgb(${wr},${wg},${wb})`;
+  ctx.beginPath();
+  ctx.moveTo(cx - 10, cy + 6);
+  ctx.lineTo(cx - 30, cy + 22);
+  ctx.lineTo(cx - 6,  cy + 18);
+  ctx.closePath();
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(cx + 10, cy + 6);
+  ctx.lineTo(cx + 30, cy + 22);
+  ctx.lineTo(cx + 6,  cy + 18);
+  ctx.closePath();
+  ctx.fill();
+
+  // Body
+  ctx.fillStyle = `rgb(${r},${g},${b})`;
+  ctx.beginPath();
+  ctx.moveTo(cx,      cy - 26);
+  ctx.lineTo(cx + 12, cy + 8);
+  ctx.lineTo(cx + 8,  cy + 18);
+  ctx.lineTo(cx - 8,  cy + 18);
+  ctx.lineTo(cx - 12, cy + 8);
+  ctx.closePath();
+  ctx.fill();
+
+  // Cockpit
+  ctx.fillStyle = "#44aaff";
+  ctx.beginPath();
+  ctx.ellipse(cx, cy - 10, 4, 7, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Cannon
+  ctx.fillStyle = "#ff6600";
+  ctx.fillRect(cx - 2, cy - 34, 4, 12);
+
+  ctx.restore();
+}
+
+function drawHud(
+  ctx: CanvasRenderingContext2D,
+  lives: number,
+  score: number,
+  wpm: number,
+  wpmHistory: WpmSample[],
+  difficulty: Difficulty,
+): void {
+  // Background panel
+  ctx.fillStyle = "#080820";
+  ctx.fillRect(0, 0, CW, HUD_H);
+  ctx.fillStyle = "#1a1a44";
+  ctx.fillRect(0, HUD_H, CW, 1);
+
+  ctx.textBaseline = "middle";
+
+  // Lives
+  ctx.font = '9px "Press Start 2P", monospace';
+  ctx.fillStyle = "#ff4444";
+  const hearts = "♥".repeat(lives) + "♡".repeat(MAX_LIVES - lives);
+  ctx.fillText(hearts, 10, 18);
+
+  // Difficulty badge
+  const diffColors: Record<Difficulty, string> = { easy: "#44cc44", medium: "#ffaa00", hard: "#ff4444" };
+  ctx.fillStyle = diffColors[difficulty];
+  ctx.font = '6px "Press Start 2P", monospace';
+  ctx.fillText(difficulty.toUpperCase(), 10, 34);
+
+  // Score (centered)
+  ctx.fillStyle = "#ffcc00";
+  ctx.font = '9px "Press Start 2P", monospace';
+  const scoreStr = String(score);
+  const scoreW = ctx.measureText(scoreStr).width;
+  ctx.fillText(scoreStr, CW / 2 - scoreW / 2, 18);
+
+  // WPM label
+  ctx.fillStyle = "#44ccff";
+  ctx.font = '7px "Press Start 2P", monospace';
+  ctx.textAlign = "right";
+  ctx.fillText(`${wpm} WPM`, CW - 10, 18);
+  ctx.textAlign = "left";
+
+  // WPM mini line graph (top-right corner, below WPM label)
+  if (wpmHistory.length > 1) {
+    const gx = CW - 88;
+    const gy = 30;
+    const gw = 78;
+    const gh = 22;
+    const maxVal = Math.max(80, ...wpmHistory.map(s => s.wpm));
+
+    ctx.strokeStyle = "rgba(68,204,255,0.45)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    wpmHistory.forEach((s, i) => {
+      const px = gx + (i / (wpmHistory.length - 1)) * gw;
+      const py = gy + gh - (s.wpm / maxVal) * gh;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    });
+    ctx.stroke();
+    ctx.lineWidth = 1;
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function TypingRacer() {
+  const [phase, setPhase]           = useState<Phase>("menu");
+  const [difficulty, setDifficulty] = useState<Difficulty>("medium");
+  const [finalStats, setFinalStats] = useState<FinalStats | null>(null);
+  const [highScore, setHighScore]   = useState<number>(() => {
+    const s = localStorage.getItem("typeemup-highscore");
+    return s ? parseInt(s, 10) : 0;
+  });
+
+  const canvasRef    = useRef<HTMLCanvasElement>(null);
+  const gameRef      = useRef<GameState | null>(null);
+  const rafRef       = useRef<number>(0);
+  const highScoreRef = useRef(highScore);
+
+  useEffect(() => { highScoreRef.current = highScore; }, [highScore]);
+
+  // ── Game loop ──────────────────────────────────────────────────────────────
+
+  const gameLoop = useCallback((timestamp: number) => {
+    const state  = gameRef.current;
+    const canvas = canvasRef.current;
+    if (!state || !canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dt = Math.min((timestamp - state.lastFrameTime) / 1000, 0.05);
+    state.lastFrameTime = timestamp;
+
+    // WPM sample every second
+    if (timestamp - state.lastWpmUpdate > 1000) {
+      state.wpm = calcWpm(state.charsTyped, state.startTime);
+      state.wpmHistory.push({ wpm: state.wpm });
+      if (state.wpmHistory.length > 45) state.wpmHistory.shift();
+      state.lastWpmUpdate = timestamp;
+    }
+
+    // Spawn words
+    const cfg = DIFF[state.difficulty];
+    if (timestamp - state.lastSpawnTime > cfg.spawnMs && state.words.length < cfg.maxWords) {
+      spawnWord(state);
+      state.lastSpawnTime = timestamp;
+    }
+
+    // Move words & detect hits
+    const hitIds: number[] = [];
+    for (const w of state.words) {
+      w.y += (w.speed + w.penalty) * dt;
+      w.penalty = Math.max(0, w.penalty - w.penalty * 3 * dt);
+      if (w.y >= SHIP_Y - 10) hitIds.push(w.id);
+    }
+
+    // Process hits
+    let died = false;
+    for (const id of hitIds) {
+      state.words = state.words.filter(w => w.id !== id);
+      if (state.targetId === id) state.targetId = null;
+      state.lives--;
+      state.shipFlash = 1;
+      if (state.lives <= 0) { died = true; break; }
+    }
+
+    if (died) {
+      cancelAnimationFrame(rafRef.current);
+      const finalWpm = calcWpm(state.charsTyped, state.startTime);
+      const isNewRecord = state.score > highScoreRef.current;
+      setFinalStats({ score: state.score, wpm: finalWpm, wordsDestroyed: state.wordsDestroyed, isNewRecord });
+      if (isNewRecord) {
+        localStorage.setItem("typeemup-highscore", String(state.score));
+        setHighScore(state.score);
+      }
+      setPhase("gameover");
+      return;
+    }
+
+    // Decay ship flash
+    if (state.shipFlash > 0) state.shipFlash = Math.max(0, state.shipFlash - dt * 3);
+
+    // Advance bullets
+    for (const b of state.bullets) b.progress += dt * 5;
+    state.bullets = state.bullets.filter(b => b.progress < 1);
+
+    // Advance particles
+    for (const p of state.particles) {
+      p.x  += p.vx * dt;
+      p.y  += p.vy * dt;
+      p.vy += 120 * dt; // gravity
+      p.life -= dt * 2;
+    }
+    state.particles = state.particles.filter(p => p.life > 0);
+
+    // ── Render ───────────────────────────────────────────────────────────────
+
+    // Background
+    ctx.fillStyle = "#06061a";
+    ctx.fillRect(0, 0, CW, CH);
+
+    // Stars
+    for (const s of state.stars) {
+      ctx.fillStyle = `rgba(255,255,255,${s.b})`;
+      ctx.fillRect(s.x, s.y, s.r, s.r);
+    }
+
+    // Danger zone glow at bottom
+    const dangerGrad = ctx.createLinearGradient(0, SHIP_Y - 50, 0, SHIP_Y + 30);
+    dangerGrad.addColorStop(0, "rgba(180,0,0,0)");
+    dangerGrad.addColorStop(1, "rgba(180,0,0,0.12)");
+    ctx.fillStyle = dangerGrad;
+    ctx.fillRect(0, SHIP_Y - 50, CW, 80);
+
+    // Bullets
+    ctx.shadowColor = "#ff6600";
+    ctx.shadowBlur  = 10;
+    ctx.fillStyle   = "#ff8833";
+    for (const b of state.bullets) {
+      const by = b.fromY + (b.toY - b.fromY) * b.progress;
+      ctx.fillRect(b.x - 2, by - 6, 4, 12);
+    }
+    ctx.shadowBlur = 0;
+
+    // Falling words
+    ctx.textBaseline = "middle";
+    for (const word of state.words) {
+      const isTarget = word.id === state.targetId;
+      const half     = (word.text.length * CHAR_W) / 2;
+      const startX   = word.x - half;
+
+      for (let i = 0; i < word.text.length; i++) {
+        const charX = startX + i * CHAR_W;
+
+        if (i < word.typed) {
+          ctx.fillStyle = "#33bb55";
+          ctx.font = '14px "Courier New", monospace';
+        } else if (isTarget && i === word.typed) {
+          ctx.fillStyle = "#ffdd00";
+          ctx.font = 'bold 14px "Courier New", monospace';
+        } else if (isTarget) {
+          ctx.fillStyle = "#ff8833";
+          ctx.font = '14px "Courier New", monospace';
+        } else {
+          ctx.fillStyle = "#44bb66";
+          ctx.font = '14px "Courier New", monospace';
+        }
+
+        ctx.fillText(word.text[i], charX, word.y);
+      }
+
+      // Underline the first char of untargeted words as a "press me" hint
+      if (!isTarget && word.typed === 0) {
+        ctx.fillStyle = "#44bb66";
+        ctx.fillRect(word.x - half, word.y + 10, CHAR_W, 1);
+      }
+    }
+
+    // Particles
+    for (const p of state.particles) {
+      ctx.globalAlpha = p.life;
+      ctx.fillStyle   = p.color;
+      ctx.fillRect(p.x - 2, p.y - 2, 4, 4);
+    }
+    ctx.globalAlpha = 1;
+
+    // Ship (drawn above particles)
+    drawShip(ctx, state.shipFlash);
+
+    // HUD last — always on top
+    drawHud(ctx, state.lives, state.score, state.wpm, state.wpmHistory, state.difficulty);
+
+    rafRef.current = requestAnimationFrame(gameLoop);
   }, []);
 
-  const elapsed =
-    finishTime && startTime
-      ? (finishTime - startTime) / 1000
-      : startTime
-      ? (Date.now() - startTime) / 1000
-      : 0;
+  // ── Key handler ────────────────────────────────────────────────────────────
 
-  const wpm =
-    startTime && typed.length > 0
-      ? Math.round((typed.length / 5) / Math.max(elapsed / 60, 0.001))
-      : 0;
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
 
-  const correctChars = typed.split("").filter((c, i) => c === phrase[i]).length;
-  const accuracy =
-    typed.length > 0 ? Math.round((correctChars / typed.length) * 100) : 100;
+    const state = gameRef.current;
+    if (!state) return;
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-    if (value.length > phrase.length) return;
-
-    if (!startTime && value.length > 0) {
-      setStartTime(Date.now());
+    if (e.key === "Escape") {
+      cancelAnimationFrame(rafRef.current);
+      setPhase("menu");
+      return;
     }
 
-    setTyped(value);
+    if (e.key.length !== 1) return;
+    const ch = e.key.toLowerCase();
 
-    if (value === phrase) {
-      setFinishTime(Date.now());
+    if (state.targetId !== null) {
+      const target = state.words.find(w => w.id === state.targetId);
+      if (!target) { state.targetId = null; return; }
+
+      if (ch === target.text[target.typed]) {
+        // Correct letter
+        target.typed++;
+        state.charsTyped++;
+
+        state.bullets.push({
+          id: state.nextId++,
+          x: target.x,
+          fromY: SHIP_Y - 34,
+          toY: target.y,
+          progress: 0,
+        });
+
+        if (target.typed === target.text.length) {
+          // Word destroyed
+          state.wordsDestroyed++;
+          state.score += target.text.length * 10 + Math.floor(target.speed);
+          burstParticles(state, target.x, target.y, 14);
+          state.words     = state.words.filter(w => w.id !== target.id);
+          state.targetId  = null;
+        }
+      } else {
+        // Wrong letter → extra fall speed
+        target.penalty += DIFF[state.difficulty].penalty;
+      }
+    } else {
+      // No active target — acquire the lowest word starting with this char
+      const candidates = state.words.filter(w => w.text[0] === ch && w.typed === 0);
+      if (candidates.length === 0) return;
+
+      const target = candidates.reduce((a, b) => (a.y > b.y ? a : b));
+      state.targetId  = target.id;
+      target.typed    = 1;
+      state.charsTyped++;
+
+      state.bullets.push({
+        id: state.nextId++,
+        x: target.x,
+        fromY: SHIP_Y - 34,
+        toY: target.y,
+        progress: 0,
+      });
+
+      // Handle single-char words
+      if (target.text.length === 1) {
+        state.wordsDestroyed++;
+        state.score += 10 + Math.floor(target.speed);
+        burstParticles(state, target.x, target.y, 10);
+        state.words    = state.words.filter(w => w.id !== target.id);
+        state.targetId = null;
+      }
     }
-  }
+  }, []);
 
-  function reset() {
-    setPhrase(pickPhrase());
-    setTyped("");
-    setStartTime(null);
-    setFinishTime(null);
-    setTimeout(() => inputRef.current?.focus(), 50);
-  }
+  // ── Start game ─────────────────────────────────────────────────────────────
 
-  return (
-    <div className="typing-racer">
-      <div className="typing-racer__stats">
-        <span>{wpm} WPM</span>
-        <span>{accuracy}% accuracy</span>
-        {startTime && !finishTime && (
-          <span className="typing-racer__timer">{elapsed.toFixed(1)}s</span>
-        )}
-      </div>
+  const startGame = useCallback((diff: Difficulty) => {
+    cancelAnimationFrame(rafRef.current);
 
-      <div className="typing-racer__phrase" aria-hidden="true">
-        {phrase.split("").map((char, i) => {
-          let cls = "typing-racer__char";
-          if (i < typed.length) {
-            cls +=
-              typed[i] === char
-                ? " typing-racer__char--correct"
-                : " typing-racer__char--wrong";
-          } else if (i === typed.length) {
-            cls += " typing-racer__char--cursor";
-          }
-          return (
-            <span key={i} className={cls}>
-              {char}
-            </span>
-          );
-        })}
-      </div>
+    const stars = Array.from({ length: 70 }, () => ({
+      x: Math.random() * CW,
+      y: Math.random() * CH,
+      r: Math.random() < 0.2 ? 2 : 1,
+      b: 0.15 + Math.random() * 0.5,
+    }));
 
-      {finishTime ? (
-        <div className="typing-racer__result">
-          <div className="typing-racer__result-stats">
-            <div>
-              <div className="typing-racer__result-value">{wpm}</div>
-              <div className="typing-racer__result-label">WPM</div>
+    const now = performance.now();
+
+    gameRef.current = {
+      words: [],
+      bullets: [],
+      particles: [],
+      stars,
+      targetId: null,
+      lives: MAX_LIVES,
+      score: 0,
+      charsTyped: 0,
+      wordsDestroyed: 0,
+      startTime: Date.now(),
+      lastSpawnTime: now - DIFF[diff].spawnMs, // trigger first spawn immediately
+      wpm: 0,
+      wpmHistory: [],
+      lastWpmUpdate: 0,
+      nextId: 1,
+      difficulty: diff,
+      lastFrameTime: now,
+      shipFlash: 0,
+    };
+
+    setPhase("playing");
+    rafRef.current = requestAnimationFrame(gameLoop);
+  }, [gameLoop]);
+
+  // ── Effects ────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (phase !== "playing") return;
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [phase, handleKey]);
+
+  useEffect(() => () => { cancelAnimationFrame(rafRef.current); }, []);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  if (phase === "menu") {
+    return (
+      <div className="teu">
+        <div className="teu__window">
+          <div className="teu__titlebar">
+            <span className="teu__titlebar-text">Type &#39;Em Up</span>
+            <span className="teu__titlebar-dots">●●●</span>
+          </div>
+          <div className="teu__body">
+            <div className="teu__logo">TYPE &#39;EM UP</div>
+            <div className="teu__tagline">a typing shmup</div>
+
+            {highScore > 0 && (
+              <div className="teu__high-score">HI SCORE: {highScore}</div>
+            )}
+
+            <div className="teu__section-label">DIFFICULTY</div>
+            <div className="teu__diff-row">
+              {(["easy", "medium", "hard"] as Difficulty[]).map(d => (
+                <button
+                  key={d}
+                  className={`teu__diff-btn${difficulty === d ? " teu__diff-btn--active" : ""}`}
+                  onClick={() => setDifficulty(d)}
+                >
+                  {d.toUpperCase()}
+                </button>
+              ))}
             </div>
-            <div>
-              <div className="typing-racer__result-value">{accuracy}%</div>
-              <div className="typing-racer__result-label">accuracy</div>
-            </div>
-            <div>
-              <div className="typing-racer__result-value">
-                {((finishTime - startTime!) / 1000).toFixed(2)}s
-              </div>
-              <div className="typing-racer__result-label">time</div>
+
+            <button className="teu__launch-btn" onClick={() => startGame(difficulty)}>
+              LAUNCH
+            </button>
+
+            <div className="teu__tips">
+              <p>Words fall from above &mdash; type them to shoot!</p>
+              <p>Mistyping makes words fall faster.</p>
+              <p>Don&#39;t let words reach your ship!</p>
+              <p className="teu__tips-esc">ESC pauses &amp; returns to menu.</p>
             </div>
           </div>
-          <button className="typing-racer__reset" onClick={reset}>
-            Try again
-          </button>
         </div>
-      ) : (
-        <input
-          ref={inputRef}
-          className="typing-racer__input"
-          value={typed}
-          onChange={handleChange}
-          spellCheck={false}
-          autoComplete="off"
-          autoCapitalize="none"
-          placeholder="Start typing…"
-        />
-      )}
+      </div>
+    );
+  }
+
+  if (phase === "gameover") {
+    return (
+      <div className="teu">
+        <div className="teu__window">
+          <div className="teu__titlebar teu__titlebar--dead">
+            <span className="teu__titlebar-text">GAME OVER</span>
+            <span className="teu__titlebar-dots">●●●</span>
+          </div>
+          <div className="teu__body">
+            <div className="teu__logo teu__logo--dead">GAME OVER</div>
+
+            {finalStats?.isNewRecord && (
+              <div className="teu__new-record">&#9733; NEW RECORD &#9733;</div>
+            )}
+
+            <div className="teu__stats-grid">
+              <div className="teu__stat">
+                <div className="teu__stat-val">{finalStats?.score ?? 0}</div>
+                <div className="teu__stat-key">SCORE</div>
+              </div>
+              <div className="teu__stat">
+                <div className="teu__stat-val">{finalStats?.wpm ?? 0}</div>
+                <div className="teu__stat-key">WPM</div>
+              </div>
+              <div className="teu__stat">
+                <div className="teu__stat-val">{finalStats?.wordsDestroyed ?? 0}</div>
+                <div className="teu__stat-key">WORDS</div>
+              </div>
+            </div>
+
+            {highScore > 0 && !finalStats?.isNewRecord && (
+              <div className="teu__high-score">HI SCORE: {highScore}</div>
+            )}
+
+            <div className="teu__action-row">
+              <button className="teu__launch-btn" onClick={() => startGame(difficulty)}>
+                RETRY
+              </button>
+              <button
+                className="teu__launch-btn teu__launch-btn--secondary"
+                onClick={() => setPhase("menu")}
+              >
+                MENU
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Playing phase — canvas only
+  return (
+    <div className="teu">
+      <canvas
+        ref={canvasRef}
+        width={CW}
+        height={CH}
+        className="teu__canvas"
+      />
     </div>
   );
 }

--- a/src/pages/TypingRacerPage.tsx
+++ b/src/pages/TypingRacerPage.tsx
@@ -17,11 +17,13 @@ export default function TypingRacerPage() {
         </Button>
       </div>
 
-      <HelpOverlay title="Typing Racer">
+      <HelpOverlay title="Type 'Em Up">
         <ul>
-          <li>Type the phrase as fast as you can</li>
-          <li>Green = correct · Red = wrong</li>
-          <li>WPM and accuracy shown on completion</li>
+          <li>Type the first letter to target the lowest matching word</li>
+          <li>Keep typing to shoot it down before it reaches your ship</li>
+          <li>Wrong letters make words fall faster</li>
+          <li>You have 3 lives — don't let words hit your ship!</li>
+          <li><strong>ESC</strong> — return to menu</li>
           <li><strong>Press ?</strong> to toggle these instructions</li>
         </ul>
       </HelpOverlay>


### PR DESCRIPTION
Replaces the static single-phrase timer with a fully animated
canvas-based shoot-em-up: words fall from above, players type
to shoot them down, mistyping adds fall-speed penalty, and
touching the ship costs a life (3 lives total).

- Canvas game loop with starfield, ship with thruster flame,
  orange laser bullets, and particle explosions on word destroy
- Three difficulty tiers (Easy / Medium / Hard) with tuned word
  lists, fall speeds, spawn rates, and mistype penalties
- Live WPM tracking with mini line-graph drawn in the HUD
- Persistent high score via localStorage
- First-letter auto-targeting: type any starting letter to lock
  onto the lowest matching word; ESC returns to menu mid-game
- Win95-styled menu and game-over screens with result stats
- Updated experiences.ts entry (category: game, new description)

https://claude.ai/code/session_01YaN4JLDuvh4VC2Ci8uuyM9