### PR TITLE
Add NS Art — retro MS Paint-style drawing app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import BombFinderPage from "./pages/BombFinderPage";
 import NsDoors97Page from "./pages/NsDoors97Page";
 import NsToSPage from "./pages/NsToSPage";
 import DuckHuntPage from "./pages/DuckHuntPage";
+import NsArtPage from "./pages/NsArtPage";
 
 export default function App() {
   return (
@@ -35,6 +36,7 @@ export default function App() {
         <Route path="/doors97" element={<NsDoors97Page />} />
         <Route path="/ns-tos" element={<NsToSPage />} />
         <Route path="/duck-hunt" element={<DuckHuntPage />} />
+        <Route path="/art" element={<NsArtPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -105,4 +105,11 @@ export const experiences: Experience[] = [
     category: "toy",
     path: "/ns-tos",
   },
+  {
+    id: "ns-art",
+    title: "NS Art",
+    description: "A retro paint program. Draw, spray, fill, and export your masterpiece as a PNG.",
+    category: "toy",
+    path: "/art",
+  },
 ];

--- a/src/experiences/NsArt/NsArt.css
+++ b/src/experiences/NsArt/NsArt.css
@@ -351,3 +351,89 @@
   margin-left: auto;
   white-space: nowrap;
 }
+
+/* ── Hidden native color picker ──────────────────────────────────────────── */
+
+.ns-art__hidden-picker {
+  display: none;
+}
+
+/* ── Confirm / alert dialog overlay ─────────────────────────────────────── */
+
+.ns-art__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.ns-art__dialog {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  min-width: 240px;
+  max-width: 340px;
+  box-shadow: 4px 4px 0 #000;
+}
+
+.ns-art__dialog-titlebar {
+  background: linear-gradient(to right, #7b3dbe, #cc4400);
+  color: #fff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  user-select: none;
+}
+
+.ns-art__dialog-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.ns-art__dialog-body {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #000;
+  padding: 16px 12px 12px;
+  line-height: 1.7;
+}
+
+.ns-art__dialog-btns {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 4px 10px 10px;
+}
+
+.ns-art__dialog-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 5px 10px;
+  cursor: pointer;
+  color: #000;
+  white-space: nowrap;
+  min-width: 64px;
+}
+
+.ns-art__dialog-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.ns-art__dialog-btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+
+.ns-art__dialog-btn--primary:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+}

--- a/src/experiences/NsArt/NsArt.css
+++ b/src/experiences/NsArt/NsArt.css
@@ -245,6 +245,7 @@
   display: block;
   cursor: crosshair;
   image-rendering: pixelated;
+  touch-action: none; /* prevent browser scroll/zoom so touch draws */
 }
 
 /* ── Bottom bar ──────────────────────────────────────────────────────────── */

--- a/src/experiences/NsArt/NsArt.css
+++ b/src/experiences/NsArt/NsArt.css
@@ -1,0 +1,352 @@
+/* ── NS Art — MS Paint clone ─────────────────────────────────────────────── */
+
+.ns-art {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 520px;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+}
+
+/* ── Action bar ──────────────────────────────────────────────────────────── */
+
+.ns-art__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: #c0c0c0;
+  border-bottom: 1px solid #808080;
+  flex-shrink: 0;
+}
+
+.ns-art__action-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 3px 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #000;
+}
+
+.ns-art__action-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.ns-art__action-sep {
+  width: 1px;
+  height: 16px;
+  background: #808080;
+  margin: 0 2px;
+}
+
+/* Canvas size picker */
+.ns-art__size-picker {
+  position: relative;
+}
+
+.ns-art__size-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  display: flex;
+  flex-direction: column;
+  min-width: 90px;
+}
+
+.ns-art__size-item {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  border: none;
+  padding: 5px 8px;
+  text-align: left;
+  cursor: pointer;
+  color: #000;
+  white-space: nowrap;
+}
+
+.ns-art__size-item:hover {
+  background: #000080;
+  color: #fff;
+}
+
+.ns-art__size-item--active {
+  font-weight: bold;
+}
+
+/* ── Workspace ───────────────────────────────────────────────────────────── */
+
+.ns-art__workspace {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ── Toolbox ─────────────────────────────────────────────────────────────── */
+
+.ns-art__toolbox {
+  width: 52px;
+  flex-shrink: 0;
+  background: #c0c0c0;
+  border-right: 2px solid #808080;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  overflow-y: auto;
+}
+
+.ns-art__tool-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+}
+
+.ns-art__tool {
+  width: 20px;
+  height: 20px;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: #000;
+  line-height: 1;
+}
+
+.ns-art__tool:active,
+.ns-art__tool--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+.ns-art__toolbox-sep {
+  width: 38px;
+  height: 2px;
+  background: #808080;
+  margin: 3px 0;
+}
+
+/* Brush size dots */
+.ns-art__size-dots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.ns-art__size-dot-btn {
+  width: 38px;
+  height: 18px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.ns-art__size-dot-btn:active,
+.ns-art__size-dot-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+.ns-art__dot {
+  display: block;
+  border-radius: 50%;
+  background: #000;
+  flex-shrink: 0;
+}
+
+/* Fill mode buttons */
+.ns-art__fill-modes {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+}
+
+.ns-art__fill-btn {
+  width: 38px;
+  height: 18px;
+  font-family: Arial, sans-serif;
+  font-size: 13px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: #000;
+}
+
+.ns-art__fill-btn:active,
+.ns-art__fill-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+/* Zoom label */
+.ns-art__zoom-label {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: #000080;
+  text-align: center;
+  padding: 2px 0;
+}
+
+/* ── Canvas area ─────────────────────────────────────────────────────────── */
+
+.ns-art__canvas-area {
+  flex: 1;
+  overflow: auto;
+  background: #808080;
+  padding: 8px;
+  min-width: 0;
+}
+
+.ns-art__canvas-wrap {
+  display: inline-block;
+  /* checkerboard to show transparency */
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+  background-color: #fff;
+}
+
+.ns-art__canvas {
+  display: block;
+  cursor: crosshair;
+  image-rendering: pixelated;
+}
+
+/* ── Bottom bar ──────────────────────────────────────────────────────────── */
+
+.ns-art__bottom {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  background: #c0c0c0;
+  border-top: 2px solid #808080;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+/* Active color swatch display */
+.ns-art__swatch-box {
+  position: relative;
+  width: 34px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.ns-art__swatch {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.ns-art__swatch--secondary {
+  bottom: 0;
+  right: 0;
+}
+
+.ns-art__swatch--primary {
+  top: 0;
+  left: 0;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.ns-art__swatch[data-transparent] {
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+  background-color: #fff;
+}
+
+/* Color palette */
+.ns-art__palette {
+  display: grid;
+  grid-template-columns: repeat(14, 18px);
+  grid-template-rows: repeat(2, 18px);
+  gap: 1px;
+  flex-shrink: 0;
+}
+
+.ns-art__pal-swatch {
+  width: 18px;
+  height: 18px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  cursor: pointer;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.ns-art__pal-swatch:hover {
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.ns-art__pal-swatch--pri {
+  border-color: #ffffff #000 #000 #ffffff;
+  box-shadow: inset 0 0 0 1px #000;
+}
+
+.ns-art__pal-swatch--sec {
+  border-color: #000 #ffffff #ffffff #000;
+}
+
+/* Transparent swatch — checkerboard */
+.ns-art__pal-swatch--transparent {
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 6px 6px;
+  background-position: 0 0, 0 3px, 3px -3px, -3px 0;
+  background-color: #fff;
+}
+
+/* Status bar */
+.ns-art__status {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #000;
+  margin-left: auto;
+  white-space: nowrap;
+}

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -1,12 +1,29 @@
-import { useRef, useState, useEffect, useCallback, useLayoutEffect } from "react";
+import {
+  useRef, useState, useEffect, useCallback,
+  useLayoutEffect, forwardRef, useImperativeHandle,
+} from "react";
 import "./NsArt.css";
+
+// ── Types ──────────────────────────────────────────────────────────────────
 
 type Tool = "pencil" | "brush" | "spray" | "eraser" | "fill" | "line" | "rect" | "oval" | "zoom";
 type FillMode = "outline" | "filled" | "both";
-
 interface CanvasSize { w: number; h: number }
 
-const PALETTE: string[] = [
+interface DialogButton { label: string; onClick: () => void; primary?: boolean }
+interface ConfirmState { title: string; message: string; buttons: DialogButton[] }
+
+export interface NsArtHandle {
+  requestClose: (proceed: () => void) => void;
+}
+
+export interface NsArtProps {
+  onBackupSaved?: () => void;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const DEFAULT_PALETTE: string[] = [
   // Row 1 — dark / brand
   "#000000", "#7f7f7f", "#800000", "#cc4400",
   "#ff6b00", "#808000", "#005500", "#006060",
@@ -30,40 +47,38 @@ const BRUSH_SIZES = [2, 5, 10] as const;
 type BrushSize = typeof BRUSH_SIZES[number];
 
 const TOOLS: { id: Tool; label: string; title: string }[] = [
-  { id: "pencil", label: "✏",  title: "Pencil (1px)"              },
-  { id: "brush",  label: "⬤",  title: "Brush"                     },
-  { id: "spray",  label: "∷",  title: "Spray Can"                 },
-  { id: "eraser", label: "◻",  title: "Eraser"                    },
-  { id: "fill",   label: "▤",  title: "Fill"                      },
-  { id: "line",   label: "╱",  title: "Line"                      },
-  { id: "rect",   label: "▭",  title: "Rectangle"                 },
-  { id: "oval",   label: "⬭",  title: "Oval"                      },
-  { id: "zoom",   label: "⊕",  title: "Zoom (right-click/2-tap zooms out)" },
+  { id: "pencil", label: "✏️", title: "Pencil (1px)"                  },
+  { id: "brush",  label: "🖌️", title: "Brush"                         },
+  { id: "spray",  label: "🫧",  title: "Spray Can"                     },
+  { id: "eraser", label: "🧼",  title: "Eraser"                        },
+  { id: "fill",   label: "🪣",  title: "Fill"                          },
+  { id: "line",   label: "╱",  title: "Line"                          },
+  { id: "rect",   label: "▭",  title: "Rectangle"                     },
+  { id: "oval",   label: "⬭",  title: "Oval"                          },
+  { id: "zoom",   label: "🔍",  title: "Zoom — click cycles 1×→2×→4×→1×; right-click reverses" },
 ];
 
-// ── Utilities (module-level) ───────────────────────────────────────────────
+const LS_KEY = "ns-art-backup";
+
+// ── Canvas utilities ───────────────────────────────────────────────────────
 
 function floodFill(ctx: CanvasRenderingContext2D, sx: number, sy: number, fillColor: string) {
   const canvas = ctx.canvas;
   const w = canvas.width, h = canvas.height;
   if (sx < 0 || sy < 0 || sx >= w || sy >= h) return;
-
   const imageData = ctx.getImageData(0, 0, w, h);
   const d = imageData.data;
-  const byteIdx = (x: number, y: number) => (y * w + x) * 4;
-  const si = byteIdx(sx, sy);
+  const si = (sy * w + sx) * 4;
   const tR = d[si], tG = d[si+1], tB = d[si+2], tA = d[si+3];
-
   let fR: number, fG: number, fB: number, fA: number;
   if (fillColor === "transparent") {
     [fR, fG, fB, fA] = [0, 0, 0, 0];
   } else {
     const m = /^#(..)(..)(..)$/.exec(fillColor);
     if (!m) return;
-    [fR, fG, fB, fA] = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255];
+    [fR, fG, fB, fA] = [parseInt(m[1],16), parseInt(m[2],16), parseInt(m[3],16), 255];
   }
   if (tR === fR && tG === fG && tB === fB && tA === fA) return;
-
   const visited = new Uint8Array(w * h);
   const stack: number[] = [si];
   while (stack.length > 0) {
@@ -114,29 +129,41 @@ function strokeLine(
 function strokeRect(
   ctx: CanvasRenderingContext2D,
   x0: number, y0: number, x1: number, y1: number,
-  color: string, size: number, mode: FillMode,
+  outlineColor: string, fillColor: string,
+  size: number, mode: FillMode,
 ) {
-  applyColor(ctx, color, size);
-  const x = Math.min(x0, x1), y = Math.min(y0, y1);
-  const w = Math.abs(x1 - x0), h = Math.abs(y1 - y0);
-  if (mode === "filled" || mode === "both") ctx.fillRect(x, y, w, h);
-  if (mode === "outline" || mode === "both") ctx.strokeRect(x, y, w, h);
+  const x = Math.min(x0,x1), y = Math.min(y0,y1);
+  const w = Math.abs(x1-x0), h = Math.abs(y1-y0);
+  if ((mode === "filled" || mode === "both") && w > 0 && h > 0) {
+    applyColor(ctx, fillColor, size);
+    ctx.fillRect(x, y, w, h);
+  }
+  if (mode === "outline" || mode === "both") {
+    applyColor(ctx, outlineColor, size);
+    ctx.strokeRect(x, y, w, h);
+  }
   resetCtx(ctx);
 }
 
 function strokeOval(
   ctx: CanvasRenderingContext2D,
   x0: number, y0: number, x1: number, y1: number,
-  color: string, size: number, mode: FillMode,
+  outlineColor: string, fillColor: string,
+  size: number, mode: FillMode,
 ) {
-  applyColor(ctx, color, size);
-  const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
-  const rx = Math.max(1, Math.abs(x1 - x0) / 2);
-  const ry = Math.max(1, Math.abs(y1 - y0) / 2);
+  const cx = (x0+x1)/2, cy = (y0+y1)/2;
+  const rx = Math.max(1, Math.abs(x1-x0)/2);
+  const ry = Math.max(1, Math.abs(y1-y0)/2);
   ctx.beginPath();
-  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
-  if (mode === "filled" || mode === "both") ctx.fill();
-  if (mode === "outline" || mode === "both") ctx.stroke();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI*2);
+  if ((mode === "filled" || mode === "both")) {
+    applyColor(ctx, fillColor, size);
+    ctx.fill();
+  }
+  if (mode === "outline" || mode === "both") {
+    applyColor(ctx, outlineColor, size);
+    ctx.stroke();
+  }
   resetCtx(ctx);
 }
 
@@ -146,19 +173,26 @@ function doSpray(canvas: HTMLCanvasElement, x: number, y: number, color: string,
   const radius = size * 5, density = size * 4;
   for (let i = 0; i < density; i++) {
     const angle = Math.random() * Math.PI * 2;
-    const r = Math.random() * radius;
-    ctx.fillRect(Math.round(x + Math.cos(angle) * r), Math.round(y + Math.sin(angle) * r), 1, 1);
+    const r     = Math.random() * radius;
+    ctx.fillRect(Math.round(x + Math.cos(angle)*r), Math.round(y + Math.sin(angle)*r), 1, 1);
   }
   resetCtx(ctx);
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
 
-export default function NsArt() {
-  const canvasRef    = useRef<HTMLCanvasElement>(null);
+const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
+  { onBackupSaved }: NsArtProps,
+  ref,
+) {
+  const canvasRef     = useRef<HTMLCanvasElement>(null);
   const canvasAreaRef = useRef<HTMLDivElement>(null);
+  const primaryPickerRef   = useRef<HTMLInputElement>(null);
+  const secondaryPickerRef = useRef<HTMLInputElement>(null);
+  const swatchPickerRef    = useRef<HTMLInputElement>(null);
 
   const [tool,           setTool]          = useState<Tool>("pencil");
+  const [palette,        setPalette]       = useState<string[]>(() => [...DEFAULT_PALETTE]);
   const [primaryColor,   setPrimaryColor]  = useState("#000000");
   const [secondaryColor, setSecondaryColor]= useState("#ffffff");
   const [brushSize,      setBrushSize]     = useState<BrushSize>(2);
@@ -167,17 +201,55 @@ export default function NsArt() {
   const [canvasSize,     setCanvasSize]    = useState<CanvasSize>({ w: 640, h: 480 });
   const [showSizeMenu,   setShowSizeMenu]  = useState(false);
   const [status,         setStatus]        = useState("Ready");
+  const [confirmState,   setConfirmState]  = useState<ConfirmState | null>(null);
+  const [editingSwatchIdx, setEditingSwatchIdx] = useState<number | null>(null);
 
-  const isDrawingRef   = useRef(false);
-  const startRef       = useRef({ x: 0, y: 0 });
-  const lastRef        = useRef({ x: 0, y: 0 });
-  const snapshotRef    = useRef<ImageData | null>(null);
-  const undoRef        = useRef<ImageData[]>([]);
-  const sprayRef       = useRef<ReturnType<typeof setInterval> | null>(null);
-  const activeColorRef = useRef("#000000");
-  const activeSizeRef  = useRef<number>(1);
+  const isDrawingRef        = useRef(false);
+  const startRef            = useRef({ x: 0, y: 0 });
+  const lastRef             = useRef({ x: 0, y: 0 });
+  const snapshotRef         = useRef<ImageData | null>(null);
+  const undoRef             = useRef<ImageData[]>([]);
+  const sprayRef            = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeColorRef      = useRef("#000000");
+  const activeFillColorRef  = useRef("#ffffff");
+  const activeSizeRef       = useRef<number>(1);
+  const isDirtyRef          = useRef(false);
+  const saveTimerRef        = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onBackupSavedRef    = useRef(onBackupSaved);
+  useEffect(() => { onBackupSavedRef.current = onBackupSaved; }, [onBackupSaved]);
 
-  // Pick the largest canvas preset that fits the available area on first render
+  // ── Expose imperative handle for close confirmation ──────────────────
+
+  const exportPng = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = "ns-art.png";
+    a.click();
+    isDirtyRef.current = false;
+  }, []);
+
+  useImperativeHandle(ref, () => ({
+    requestClose: (proceed) => {
+      if (isDirtyRef.current) {
+        setConfirmState({
+          title: "NS Art",
+          message: "Your artwork has unsaved changes.",
+          buttons: [
+            { label: "Save PNG", primary: true, onClick: () => { exportPng(); proceed(); setConfirmState(null); } },
+            { label: "Close without saving",   onClick: () => { proceed();    setConfirmState(null); } },
+            { label: "Cancel",                 onClick: () => setConfirmState(null) },
+          ],
+        });
+      } else {
+        proceed();
+      }
+    },
+  }), [exportPng]);
+
+  // ── Auto-size canvas to fit available space on mount ─────────────────
+
   useLayoutEffect(() => {
     const el = canvasAreaRef.current;
     if (!el) return;
@@ -190,7 +262,8 @@ export default function NsArt() {
     setCanvasSize(best);
   }, []);
 
-  // White-fill when canvas size changes (changing canvas dimensions also clears it)
+  // ── Initialise canvas to white when size changes ─────────────────────
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -198,13 +271,33 @@ export default function NsArt() {
     ctx.fillStyle = "#ffffff";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     undoRef.current = [];
+    isDirtyRef.current = false;
   }, [canvasSize]);
+
+  // ── Load backup from localStorage after first canvas init ────────────
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const backup = localStorage.getItem(LS_KEY);
+      if (!backup || !canvasRef.current) return;
+      const img = new Image();
+      img.onload = () => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        canvas.getContext("2d")!.drawImage(img, 0, 0, canvas.width, canvas.height);
+        isDirtyRef.current = false;
+      };
+      img.src = backup;
+    }, 80);
+    return () => clearTimeout(t);
+  }, []); // once on mount
+
+  // ── Undo stack ────────────────────────────────────────────────────────
 
   const pushUndo = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx  = canvas.getContext("2d")!;
-    const snap = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const snap  = canvas.getContext("2d")!.getImageData(0, 0, canvas.width, canvas.height);
     const stack = undoRef.current;
     undoRef.current = stack.length >= 5 ? [...stack.slice(1), snap] : [...stack, snap];
   }, []);
@@ -212,30 +305,59 @@ export default function NsArt() {
   const undo = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas || undoRef.current.length === 0) return;
-    const ctx  = canvas.getContext("2d")!;
     const prev = undoRef.current[undoRef.current.length - 1];
     undoRef.current = undoRef.current.slice(0, -1);
-    ctx.putImageData(prev, 0, 0);
+    canvas.getContext("2d")!.putImageData(prev, 0, 0);
+    isDirtyRef.current = true;
   }, []);
+
+  // ── Auto-save to localStorage (debounced 2 s) ─────────────────────────
+
+  const scheduleAutoSave = useCallback(() => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      try {
+        localStorage.setItem(LS_KEY, canvas.toDataURL("image/png"));
+        onBackupSavedRef.current?.();
+      } catch { /* storage full */ }
+    }, 2000);
+  }, []);
+
+  // ── New canvas ────────────────────────────────────────────────────────
 
   const newCanvas = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    pushUndo();
-    const ctx = canvas.getContext("2d")!;
-    ctx.globalCompositeOperation = "source-over";
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    if (isDirtyRef.current) {
+      setConfirmState({
+        title: "NS Art — New",
+        message: "Clear the canvas? This cannot be undone.",
+        buttons: [
+          { label: "Clear", primary: true, onClick: () => {
+            const canvas = canvasRef.current;
+            if (!canvas) return;
+            pushUndo();
+            const ctx = canvas.getContext("2d")!;
+            ctx.globalCompositeOperation = "source-over";
+            ctx.fillStyle = "#ffffff";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            isDirtyRef.current = false;
+            setConfirmState(null);
+          }},
+          { label: "Cancel", onClick: () => setConfirmState(null) },
+        ],
+      });
+    } else {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d")!;
+      ctx.globalCompositeOperation = "source-over";
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
   }, [pushUndo]);
 
-  const exportPng = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const a = document.createElement("a");
-    a.href = canvas.toDataURL("image/png");
-    a.download = "ns-art.png";
-    a.click();
-  }, []);
+  // ── Keyboard shortcuts ────────────────────────────────────────────────
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -245,33 +367,75 @@ export default function NsArt() {
     return () => document.removeEventListener("keydown", onKey);
   }, [undo]);
 
-  // ── Shared drawing helpers ─────────────────────────────────────────────
+  // ── beforeunload guard when dirty (standalone) ────────────────────────
+
+  useEffect(() => {
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      if (isDirtyRef.current) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+
+  // ── Palette swatch editing ────────────────────────────────────────────
+
+  function openSwatchEditor(idx: number) {
+    setEditingSwatchIdx(idx);
+    const input = swatchPickerRef.current;
+    if (!input) return;
+    input.value = palette[idx];
+    input.click();
+  }
+
+  function onSwatchColorChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (editingSwatchIdx === null) return;
+    const newColor = e.target.value;
+    const oldColor = palette[editingSwatchIdx];
+    setPalette(prev => prev.map((c, i) => i === editingSwatchIdx ? newColor : c));
+    if (primaryColor   === oldColor) setPrimaryColor(newColor);
+    if (secondaryColor === oldColor) setSecondaryColor(newColor);
+  }
+
+  // ── Shared drawing core ───────────────────────────────────────────────
 
   const startDrawing = useCallback((x: number, y: number, isSecondary: boolean) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx   = canvas.getContext("2d")!;
-    const color = isSecondary ? secondaryColor : primaryColor;
 
     if (tool === "zoom") {
-      setZoom(z => isSecondary ? Math.max(1, z / 2) : Math.min(4, z * 2));
-      return;
-    }
-    if (tool === "fill") {
-      pushUndo();
-      floodFill(ctx, x, y, color);
+      // Cycle 1→2→4→1 forward, reverse for secondary
+      if (isSecondary) {
+        setZoom(z => z === 1 ? 4 : z / 2);
+      } else {
+        setZoom(z => z === 4 ? 1 : z * 2);
+      }
       return;
     }
 
-    isDrawingRef.current   = true;
-    startRef.current       = { x, y };
-    lastRef.current        = { x, y };
-    activeColorRef.current = color;
-    activeSizeRef.current  = tool === "pencil" ? 1 : brushSize;
+    const strokeColor = isSecondary ? secondaryColor : primaryColor;
+
+    if (tool === "fill") {
+      pushUndo();
+      floodFill(ctx, x, y, strokeColor);
+      isDirtyRef.current = true;
+      scheduleAutoSave();
+      return;
+    }
+
+    isDrawingRef.current       = true;
+    startRef.current           = { x, y };
+    lastRef.current            = { x, y };
+    activeColorRef.current     = strokeColor;
+    activeFillColorRef.current = secondaryColor;
+    activeSizeRef.current      = tool === "pencil" ? 1 : brushSize;
 
     if (tool === "pencil" || tool === "brush" || tool === "eraser") {
       pushUndo();
-      const ec = tool === "eraser" ? "transparent" : color;
+      const ec = tool === "eraser" ? "transparent" : strokeColor;
       const es = tool === "pencil" ? 1 : brushSize;
       applyColor(ctx, ec, es);
       ctx.beginPath();
@@ -280,25 +444,27 @@ export default function NsArt() {
       resetCtx(ctx);
     } else if (tool === "spray") {
       pushUndo();
-      doSpray(canvas, x, y, color, brushSize);
-      const cc = color, cs = brushSize;
+      doSpray(canvas, x, y, strokeColor, brushSize);
+      const cc = strokeColor, cs = brushSize;
       sprayRef.current = setInterval(() => {
         if (!isDrawingRef.current || !canvasRef.current) return;
         doSpray(canvasRef.current, lastRef.current.x, lastRef.current.y, cc, cs);
       }, 50);
     } else {
+      // line / rect / oval — save snapshot for preview
       pushUndo();
       snapshotRef.current = ctx.getImageData(0, 0, canvas.width, canvas.height);
     }
-  }, [tool, primaryColor, secondaryColor, brushSize, pushUndo]);
+  }, [tool, primaryColor, secondaryColor, brushSize, pushUndo, scheduleAutoSave]);
 
   const continueDrawing = useCallback((x: number, y: number) => {
     if (!isDrawingRef.current) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx   = canvas.getContext("2d")!;
-    const color = activeColorRef.current;
-    const size  = activeSizeRef.current;
+    const ctx      = canvas.getContext("2d")!;
+    const color    = activeColorRef.current;
+    const fillCol  = activeFillColorRef.current;
+    const size     = activeSizeRef.current;
 
     if (tool === "pencil" || tool === "brush") {
       strokeLine(ctx, lastRef.current.x, lastRef.current.y, x, y, color, size);
@@ -310,8 +476,8 @@ export default function NsArt() {
       ctx.putImageData(snapshotRef.current, 0, 0);
       const { x: sx, y: sy } = startRef.current;
       if (tool === "line")      strokeLine(ctx, sx, sy, x, y, color, size);
-      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, size, fillMode);
-      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, size, fillMode);
+      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, fillCol, size, fillMode);
+      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, fillCol, size, fillMode);
     }
     lastRef.current = { x, y };
   }, [tool, brushSize, fillMode]);
@@ -323,32 +489,42 @@ export default function NsArt() {
 
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx   = canvas.getContext("2d")!;
-    const color = activeColorRef.current;
-    const size  = activeSizeRef.current;
+    const ctx     = canvas.getContext("2d")!;
+    const color   = activeColorRef.current;
+    const fillCol = activeFillColorRef.current;
+    const size    = activeSizeRef.current;
 
     if (snapshotRef.current) {
       ctx.putImageData(snapshotRef.current, 0, 0);
       const { x: sx, y: sy } = startRef.current;
       if (tool === "line")      strokeLine(ctx, sx, sy, x, y, color, size);
-      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, size, fillMode);
-      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, size, fillMode);
+      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, fillCol, size, fillMode);
+      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, fillCol, size, fillMode);
       snapshotRef.current = null;
     }
-  }, [tool, fillMode]);
 
-  // ── Mouse handlers ─────────────────────────────────────────────────────
+    isDirtyRef.current = true;
+    scheduleAutoSave();
+  }, [tool, fillMode, scheduleAutoSave]);
+
+  // ── Mouse handlers ────────────────────────────────────────────────────
 
   const onMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     e.preventDefault();
-    const { x, y } = { x: Math.floor((e.clientX - canvasRef.current!.getBoundingClientRect().left) / zoom),
-                       y: Math.floor((e.clientY - canvasRef.current!.getBoundingClientRect().top)  / zoom) };
-    startDrawing(x, y, e.button === 2);
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    startDrawing(
+      Math.floor((e.clientX - rect.left) / zoom),
+      Math.floor((e.clientY - rect.top)  / zoom),
+      e.button === 2,
+    );
   }, [startDrawing, zoom]);
 
   const onMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!canvasRef.current) return;
-    const rect = canvasRef.current.getBoundingClientRect();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
     const x = Math.floor((e.clientX - rect.left) / zoom);
     const y = Math.floor((e.clientY - rect.top)  / zoom);
     setStatus(`${x}, ${y}`);
@@ -356,8 +532,9 @@ export default function NsArt() {
   }, [continueDrawing, zoom]);
 
   const onMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!canvasRef.current) return;
-    const rect = canvasRef.current.getBoundingClientRect();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
     endDrawing(
       Math.floor((e.clientX - rect.left) / zoom),
       Math.floor((e.clientY - rect.top)  / zoom),
@@ -369,12 +546,12 @@ export default function NsArt() {
     onMouseUp(e);
   }, [onMouseUp]);
 
-  // ── Touch handlers ─────────────────────────────────────────────────────
+  // ── Touch handlers ────────────────────────────────────────────────────
 
   const onTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     if (e.touches.length === 0 || !canvasRef.current) return;
     const rect = canvasRef.current.getBoundingClientRect();
-    const t = e.touches[0];
+    const t    = e.touches[0];
     startDrawing(
       Math.floor((t.clientX - rect.left) / zoom),
       Math.floor((t.clientY - rect.top)  / zoom),
@@ -385,7 +562,7 @@ export default function NsArt() {
   const onTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     if (e.touches.length === 0 || !canvasRef.current) return;
     const rect = canvasRef.current.getBoundingClientRect();
-    const t = e.touches[0];
+    const t    = e.touches[0];
     const x = Math.floor((t.clientX - rect.left) / zoom);
     const y = Math.floor((t.clientY - rect.top)  / zoom);
     setStatus(`${x}, ${y}`);
@@ -395,7 +572,7 @@ export default function NsArt() {
   const onTouchEnd = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     if (!canvasRef.current) return;
     const rect = canvasRef.current.getBoundingClientRect();
-    const t = e.changedTouches[0];
+    const t    = e.changedTouches[0];
     endDrawing(
       Math.floor((t.clientX - rect.left) / zoom),
       Math.floor((t.clientY - rect.top)  / zoom),
@@ -403,7 +580,7 @@ export default function NsArt() {
     setStatus("Ready");
   }, [endDrawing, zoom]);
 
-  // ── Size picker ────────────────────────────────────────────────────────
+  // ── Canvas size picker ────────────────────────────────────────────────
 
   const handleSizeSelect = useCallback((preset: CanvasSize) => {
     setCanvasSize(preset);
@@ -413,13 +590,40 @@ export default function NsArt() {
 
   const showFillMode = tool === "rect" || tool === "oval";
 
+  // ── Render ────────────────────────────────────────────────────────────
+
   return (
     <div className="ns-art">
+
+      {/* ── Confirm dialog overlay ── */}
+      {confirmState && (
+        <div className="ns-art__overlay">
+          <div className="ns-art__dialog">
+            <div className="ns-art__dialog-titlebar">
+              <span className="ns-art__dialog-icon">⚠️</span>
+              <span>{confirmState.title}</span>
+            </div>
+            <div className="ns-art__dialog-body">{confirmState.message}</div>
+            <div className="ns-art__dialog-btns">
+              {confirmState.buttons.map(btn => (
+                <button
+                  key={btn.label}
+                  className={`ns-art__dialog-btn${btn.primary ? " ns-art__dialog-btn--primary" : ""}`}
+                  onClick={btn.onClick}
+                >
+                  {btn.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* ── Action bar ── */}
       <div className="ns-art__actions">
-        <button className="ns-art__action-btn" onClick={newCanvas} title="New (clears canvas)">New</button>
-        <button className="ns-art__action-btn" onClick={exportPng} title="Export as PNG">Export PNG</button>
-        <button className="ns-art__action-btn" onClick={undo}      title="Undo (Ctrl+Z)">Undo</button>
+        <button className="ns-art__action-btn" onClick={newCanvas}  title="New">New</button>
+        <button className="ns-art__action-btn" onClick={exportPng}  title="Export as PNG">Export PNG</button>
+        <button className="ns-art__action-btn" onClick={undo}       title="Undo (Ctrl+Z)">Undo</button>
         <div className="ns-art__action-sep" />
         <div className="ns-art__size-picker">
           <button
@@ -434,7 +638,7 @@ export default function NsArt() {
               {CANVAS_PRESETS.map(p => (
                 <button
                   key={`${p.w}x${p.h}`}
-                  className={`ns-art__size-item${canvasSize.w === p.w && canvasSize.h === p.h ? " ns-art__size-item--active" : ""}`}
+                  className={`ns-art__size-item${canvasSize.w===p.w && canvasSize.h===p.h ? " ns-art__size-item--active" : ""}`}
                   onClick={() => handleSizeSelect(p)}
                 >
                   {p.w}×{p.h}
@@ -447,6 +651,7 @@ export default function NsArt() {
 
       {/* ── Workspace ── */}
       <div className="ns-art__workspace">
+
         {/* Tool palette */}
         <div className="ns-art__toolbox">
           <div className="ns-art__tool-grid">
@@ -485,7 +690,7 @@ export default function NsArt() {
                   <button
                     key={m}
                     className={`ns-art__fill-btn${fillMode === m ? " ns-art__fill-btn--active" : ""}`}
-                    title={m}
+                    title={`${m} — outline=primary, fill=secondary`}
                     onClick={() => setFillMode(m)}
                   >
                     {m === "outline" ? "□" : m === "filled" ? "■" : "▣"}
@@ -528,39 +733,68 @@ export default function NsArt() {
         </div>
       </div>
 
-      {/* ── Bottom: color swatches + palette + status ── */}
+      {/* ── Bottom: color pickers + palette + status ── */}
       <div className="ns-art__bottom">
+
+        {/* Primary / secondary swatches — click to open color picker */}
         <div className="ns-art__swatch-box">
           <div
             className="ns-art__swatch ns-art__swatch--secondary"
             style={secondaryColor !== "transparent" ? { background: secondaryColor } : undefined}
             data-transparent={secondaryColor === "transparent" || undefined}
-            title="Secondary color (right-click palette)"
+            title="Secondary color — fills shapes, right-click palette to change"
+            onClick={() => secondaryPickerRef.current?.click()}
           />
           <div
             className="ns-art__swatch ns-art__swatch--primary"
             style={primaryColor !== "transparent" ? { background: primaryColor } : undefined}
             data-transparent={primaryColor === "transparent" || undefined}
-            title="Primary color (left-click palette)"
+            title="Primary color — outlines & freehand, left-click palette to change"
+            onClick={() => primaryPickerRef.current?.click()}
+          />
+          {/* Hidden native color inputs */}
+          <input
+            ref={primaryPickerRef}
+            type="color"
+            className="ns-art__hidden-picker"
+            value={primaryColor !== "transparent" ? primaryColor : "#000000"}
+            onChange={e => setPrimaryColor(e.target.value)}
+          />
+          <input
+            ref={secondaryPickerRef}
+            type="color"
+            className="ns-art__hidden-picker"
+            value={secondaryColor !== "transparent" ? secondaryColor : "#ffffff"}
+            onChange={e => setSecondaryColor(e.target.value)}
           />
         </div>
 
+        {/* Palette — left-click=primary, right-click=secondary, double-click=edit slot */}
         <div className="ns-art__palette">
-          {PALETTE.map((color, i) => (
+          {palette.map((color, i) => (
             <button
               key={i}
               className={`ns-art__pal-swatch${color === primaryColor ? " ns-art__pal-swatch--pri" : ""}${color === secondaryColor ? " ns-art__pal-swatch--sec" : ""}`}
               style={{ background: color }}
-              title={color}
+              title={`${color}  (double-click to edit)`}
               onClick={() => setPrimaryColor(color)}
               onContextMenu={e => { e.preventDefault(); setSecondaryColor(color); }}
+              onDoubleClick={() => openSwatchEditor(i)}
             />
           ))}
+          {/* Transparent swatch */}
           <button
             className={`ns-art__pal-swatch ns-art__pal-swatch--transparent${primaryColor === "transparent" ? " ns-art__pal-swatch--pri" : ""}${secondaryColor === "transparent" ? " ns-art__pal-swatch--sec" : ""}`}
-            title="Transparent / Eraser"
+            title="Transparent / erases to alpha"
             onClick={() => setPrimaryColor("transparent")}
             onContextMenu={e => { e.preventDefault(); setSecondaryColor("transparent"); }}
+          />
+          {/* Hidden input for swatch editing */}
+          <input
+            ref={swatchPickerRef}
+            type="color"
+            className="ns-art__hidden-picker"
+            onChange={onSwatchColorChange}
           />
         </div>
 
@@ -568,4 +802,6 @@ export default function NsArt() {
       </div>
     </div>
   );
-}
+});
+
+export default NsArt;

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState, useEffect, useCallback, useLayoutEffect } from "react";
 import "./NsArt.css";
 
 type Tool = "pencil" | "brush" | "spray" | "eraser" | "fill" | "line" | "rect" | "oval" | "zoom";
@@ -30,36 +30,29 @@ const BRUSH_SIZES = [2, 5, 10] as const;
 type BrushSize = typeof BRUSH_SIZES[number];
 
 const TOOLS: { id: Tool; label: string; title: string }[] = [
-  { id: "pencil", label: "✏",  title: "Pencil (1px)"     },
-  { id: "brush",  label: "⬤",  title: "Brush"            },
-  { id: "spray",  label: "∷",  title: "Spray Can"        },
-  { id: "eraser", label: "◻",  title: "Eraser"           },
-  { id: "fill",   label: "▤",  title: "Fill"             },
-  { id: "line",   label: "╱",  title: "Line"             },
-  { id: "rect",   label: "▭",  title: "Rectangle"        },
-  { id: "oval",   label: "⬭",  title: "Oval"             },
-  { id: "zoom",   label: "⊕",  title: "Zoom (right-click zooms out)" },
+  { id: "pencil", label: "✏",  title: "Pencil (1px)"              },
+  { id: "brush",  label: "⬤",  title: "Brush"                     },
+  { id: "spray",  label: "∷",  title: "Spray Can"                 },
+  { id: "eraser", label: "◻",  title: "Eraser"                    },
+  { id: "fill",   label: "▤",  title: "Fill"                      },
+  { id: "line",   label: "╱",  title: "Line"                      },
+  { id: "rect",   label: "▭",  title: "Rectangle"                 },
+  { id: "oval",   label: "⬭",  title: "Oval"                      },
+  { id: "zoom",   label: "⊕",  title: "Zoom (right-click/2-tap zooms out)" },
 ];
 
-// ── Utilities ──────────────────────────────────────────────────────────────
+// ── Utilities (module-level) ───────────────────────────────────────────────
 
-function floodFill(
-  ctx: CanvasRenderingContext2D,
-  sx: number,
-  sy: number,
-  fillColor: string,
-) {
+function floodFill(ctx: CanvasRenderingContext2D, sx: number, sy: number, fillColor: string) {
   const canvas = ctx.canvas;
-  const w = canvas.width;
-  const h = canvas.height;
+  const w = canvas.width, h = canvas.height;
   if (sx < 0 || sy < 0 || sx >= w || sy >= h) return;
 
   const imageData = ctx.getImageData(0, 0, w, h);
   const d = imageData.data;
   const byteIdx = (x: number, y: number) => (y * w + x) * 4;
-
   const si = byteIdx(sx, sy);
-  const tR = d[si], tG = d[si + 1], tB = d[si + 2], tA = d[si + 3];
+  const tR = d[si], tG = d[si+1], tB = d[si+2], tA = d[si+3];
 
   let fR: number, fG: number, fB: number, fA: number;
   if (fillColor === "transparent") {
@@ -69,12 +62,10 @@ function floodFill(
     if (!m) return;
     [fR, fG, fB, fA] = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255];
   }
-
   if (tR === fR && tG === fG && tB === fB && tA === fA) return;
 
   const visited = new Uint8Array(w * h);
   const stack: number[] = [si];
-
   while (stack.length > 0) {
     const i = stack.pop()!;
     const pi = i >> 2;
@@ -82,14 +73,12 @@ function floodFill(
     if (d[i] !== tR || d[i+1] !== tG || d[i+2] !== tB || d[i+3] !== tA) continue;
     visited[pi] = 1;
     d[i] = fR; d[i+1] = fG; d[i+2] = fB; d[i+3] = fA;
-    const x = pi % w;
-    const y = Math.floor(pi / w);
+    const x = pi % w, y = Math.floor(pi / w);
     if (x > 0)     stack.push(i - 4);
     if (x < w - 1) stack.push(i + 4);
     if (y > 0)     stack.push(i - w * 4);
     if (y < h - 1) stack.push(i + w * 4);
   }
-
   ctx.putImageData(imageData, 0, 0);
 }
 
@@ -103,9 +92,9 @@ function applyColor(ctx: CanvasRenderingContext2D, color: string, size: number) 
     ctx.strokeStyle = color;
     ctx.fillStyle   = color;
   }
-  ctx.lineWidth  = size;
-  ctx.lineCap    = "round";
-  ctx.lineJoin   = "round";
+  ctx.lineWidth = size;
+  ctx.lineCap   = "round";
+  ctx.lineJoin  = "round";
 }
 
 function resetCtx(ctx: CanvasRenderingContext2D) {
@@ -114,26 +103,18 @@ function resetCtx(ctx: CanvasRenderingContext2D) {
 
 function strokeLine(
   ctx: CanvasRenderingContext2D,
-  x0: number, y0: number,
-  x1: number, y1: number,
-  color: string,
-  size: number,
+  x0: number, y0: number, x1: number, y1: number,
+  color: string, size: number,
 ) {
   applyColor(ctx, color, size);
-  ctx.beginPath();
-  ctx.moveTo(x0, y0);
-  ctx.lineTo(x1, y1);
-  ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke();
   resetCtx(ctx);
 }
 
 function strokeRect(
   ctx: CanvasRenderingContext2D,
-  x0: number, y0: number,
-  x1: number, y1: number,
-  color: string,
-  size: number,
-  mode: FillMode,
+  x0: number, y0: number, x1: number, y1: number,
+  color: string, size: number, mode: FillMode,
 ) {
   applyColor(ctx, color, size);
   const x = Math.min(x0, x1), y = Math.min(y0, y1);
@@ -145,11 +126,8 @@ function strokeRect(
 
 function strokeOval(
   ctx: CanvasRenderingContext2D,
-  x0: number, y0: number,
-  x1: number, y1: number,
-  color: string,
-  size: number,
-  mode: FillMode,
+  x0: number, y0: number, x1: number, y1: number,
+  color: string, size: number, mode: FillMode,
 ) {
   applyColor(ctx, color, size);
   const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
@@ -162,31 +140,57 @@ function strokeOval(
   resetCtx(ctx);
 }
 
+function doSpray(canvas: HTMLCanvasElement, x: number, y: number, color: string, size: number) {
+  const ctx = canvas.getContext("2d")!;
+  applyColor(ctx, color, 1);
+  const radius = size * 5, density = size * 4;
+  for (let i = 0; i < density; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const r = Math.random() * radius;
+    ctx.fillRect(Math.round(x + Math.cos(angle) * r), Math.round(y + Math.sin(angle) * r), 1, 1);
+  }
+  resetCtx(ctx);
+}
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 export default function NsArt() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef    = useRef<HTMLCanvasElement>(null);
+  const canvasAreaRef = useRef<HTMLDivElement>(null);
 
-  const [tool,            setTool]           = useState<Tool>("pencil");
-  const [primaryColor,    setPrimaryColor]   = useState("#000000");
-  const [secondaryColor,  setSecondaryColor] = useState("#ffffff");
-  const [brushSize,       setBrushSize]      = useState<BrushSize>(2);
-  const [fillMode,        setFillMode]       = useState<FillMode>("outline");
-  const [zoom,            setZoom]           = useState(1);
-  const [canvasSize,      setCanvasSize]     = useState<CanvasSize>({ w: 640, h: 480 });
-  const [showSizeMenu,    setShowSizeMenu]   = useState(false);
-  const [status,          setStatus]         = useState("Ready");
+  const [tool,           setTool]          = useState<Tool>("pencil");
+  const [primaryColor,   setPrimaryColor]  = useState("#000000");
+  const [secondaryColor, setSecondaryColor]= useState("#ffffff");
+  const [brushSize,      setBrushSize]     = useState<BrushSize>(2);
+  const [fillMode,       setFillMode]      = useState<FillMode>("outline");
+  const [zoom,           setZoom]          = useState(1);
+  const [canvasSize,     setCanvasSize]    = useState<CanvasSize>({ w: 640, h: 480 });
+  const [showSizeMenu,   setShowSizeMenu]  = useState(false);
+  const [status,         setStatus]        = useState("Ready");
 
-  const isDrawingRef        = useRef(false);
-  const startRef            = useRef({ x: 0, y: 0 });
-  const lastRef             = useRef({ x: 0, y: 0 });
-  const snapshotRef         = useRef<ImageData | null>(null);
-  const undoRef             = useRef<ImageData[]>([]);
-  const sprayRef            = useRef<ReturnType<typeof setInterval> | null>(null);
-  const activeColorRef      = useRef("#000000");
-  const activeSizeRef       = useRef<number>(1);
+  const isDrawingRef   = useRef(false);
+  const startRef       = useRef({ x: 0, y: 0 });
+  const lastRef        = useRef({ x: 0, y: 0 });
+  const snapshotRef    = useRef<ImageData | null>(null);
+  const undoRef        = useRef<ImageData[]>([]);
+  const sprayRef       = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeColorRef = useRef("#000000");
+  const activeSizeRef  = useRef<number>(1);
 
-  // White-fill whenever canvas size changes (creates new canvas element)
+  // Pick the largest canvas preset that fits the available area on first render
+  useLayoutEffect(() => {
+    const el = canvasAreaRef.current;
+    if (!el) return;
+    const availW = el.clientWidth  - 16;
+    const availH = el.clientHeight - 16;
+    let best = CANVAS_PRESETS[0];
+    for (const p of CANVAS_PRESETS) {
+      if (p.w <= availW && p.h <= availH) best = p;
+    }
+    setCanvasSize(best);
+  }, []);
+
+  // White-fill when canvas size changes (changing canvas dimensions also clears it)
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -199,7 +203,7 @@ export default function NsArt() {
   const pushUndo = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d")!;
+    const ctx  = canvas.getContext("2d")!;
     const snap = ctx.getImageData(0, 0, canvas.width, canvas.height);
     const stack = undoRef.current;
     undoRef.current = stack.length >= 5 ? [...stack.slice(1), snap] : [...stack, snap];
@@ -208,7 +212,7 @@ export default function NsArt() {
   const undo = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas || undoRef.current.length === 0) return;
-    const ctx = canvas.getContext("2d")!;
+    const ctx  = canvas.getContext("2d")!;
     const prev = undoRef.current[undoRef.current.length - 1];
     undoRef.current = undoRef.current.slice(0, -1);
     ctx.putImageData(prev, 0, 0);
@@ -235,164 +239,171 @@ export default function NsArt() {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === "z") {
-        e.preventDefault();
-        undo();
-      }
+      if ((e.ctrlKey || e.metaKey) && e.key === "z") { e.preventDefault(); undo(); }
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [undo]);
 
-  function sprayAt(x: number, y: number, color: string, size: number) {
+  // ── Shared drawing helpers ─────────────────────────────────────────────
+
+  const startDrawing = useCallback((x: number, y: number, isSecondary: boolean) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d")!;
-    applyColor(ctx, color, 1);
-    const radius  = size * 5;
-    const density = size * 4;
-    for (let i = 0; i < density; i++) {
-      const angle = Math.random() * Math.PI * 2;
-      const r     = Math.random() * radius;
-      ctx.fillRect(
-        Math.round(x + Math.cos(angle) * r),
-        Math.round(y + Math.sin(angle) * r),
-        1, 1,
-      );
+    const ctx   = canvas.getContext("2d")!;
+    const color = isSecondary ? secondaryColor : primaryColor;
+
+    if (tool === "zoom") {
+      setZoom(z => isSecondary ? Math.max(1, z / 2) : Math.min(4, z * 2));
+      return;
     }
-    resetCtx(ctx);
-  }
+    if (tool === "fill") {
+      pushUndo();
+      floodFill(ctx, x, y, color);
+      return;
+    }
 
-  const onMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const ctx  = canvas.getContext("2d")!;
-      const pos  = { x: Math.floor((e.clientX - canvas.getBoundingClientRect().left) / zoom),
-                     y: Math.floor((e.clientY - canvas.getBoundingClientRect().top)  / zoom) };
-      const color = e.button === 2 ? secondaryColor : primaryColor;
+    isDrawingRef.current   = true;
+    startRef.current       = { x, y };
+    lastRef.current        = { x, y };
+    activeColorRef.current = color;
+    activeSizeRef.current  = tool === "pencil" ? 1 : brushSize;
 
-      if (tool === "zoom") {
-        setZoom(z => e.button === 2 ? Math.max(1, z / 2) : Math.min(4, z * 2));
-        return;
-      }
+    if (tool === "pencil" || tool === "brush" || tool === "eraser") {
+      pushUndo();
+      const ec = tool === "eraser" ? "transparent" : color;
+      const es = tool === "pencil" ? 1 : brushSize;
+      applyColor(ctx, ec, es);
+      ctx.beginPath();
+      ctx.arc(x, y, es / 2, 0, Math.PI * 2);
+      ctx.fill();
+      resetCtx(ctx);
+    } else if (tool === "spray") {
+      pushUndo();
+      doSpray(canvas, x, y, color, brushSize);
+      const cc = color, cs = brushSize;
+      sprayRef.current = setInterval(() => {
+        if (!isDrawingRef.current || !canvasRef.current) return;
+        doSpray(canvasRef.current, lastRef.current.x, lastRef.current.y, cc, cs);
+      }, 50);
+    } else {
+      pushUndo();
+      snapshotRef.current = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    }
+  }, [tool, primaryColor, secondaryColor, brushSize, pushUndo]);
 
-      if (tool === "fill") {
-        pushUndo();
-        floodFill(ctx, pos.x, pos.y, color);
-        return;
-      }
+  const continueDrawing = useCallback((x: number, y: number) => {
+    if (!isDrawingRef.current) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx   = canvas.getContext("2d")!;
+    const color = activeColorRef.current;
+    const size  = activeSizeRef.current;
 
-      isDrawingRef.current   = true;
-      startRef.current       = pos;
-      lastRef.current        = pos;
-      activeColorRef.current = color;
-      activeSizeRef.current  = tool === "pencil" ? 1 : brushSize;
+    if (tool === "pencil" || tool === "brush") {
+      strokeLine(ctx, lastRef.current.x, lastRef.current.y, x, y, color, size);
+    } else if (tool === "eraser") {
+      strokeLine(ctx, lastRef.current.x, lastRef.current.y, x, y, "transparent", brushSize);
+    } else if (tool === "spray") {
+      doSpray(canvas, x, y, color, brushSize);
+    } else if (snapshotRef.current) {
+      ctx.putImageData(snapshotRef.current, 0, 0);
+      const { x: sx, y: sy } = startRef.current;
+      if (tool === "line")      strokeLine(ctx, sx, sy, x, y, color, size);
+      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, size, fillMode);
+      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, size, fillMode);
+    }
+    lastRef.current = { x, y };
+  }, [tool, brushSize, fillMode]);
 
-      if (tool === "pencil" || tool === "brush" || tool === "eraser") {
-        pushUndo();
-        const effectiveColor = tool === "eraser" ? "transparent" : color;
-        const effectiveSize  = tool === "pencil" ? 1 : brushSize;
-        // Draw initial dot
-        applyColor(ctx, effectiveColor, effectiveSize);
-        ctx.beginPath();
-        ctx.arc(pos.x, pos.y, effectiveSize / 2, 0, Math.PI * 2);
-        ctx.fill();
-        resetCtx(ctx);
-      } else if (tool === "spray") {
-        pushUndo();
-        sprayAt(pos.x, pos.y, color, brushSize);
-        const capturedColor = color;
-        const capturedSize  = brushSize;
-        sprayRef.current = setInterval(() => {
-          if (!isDrawingRef.current) return;
-          sprayAt(lastRef.current.x, lastRef.current.y, capturedColor, capturedSize);
-        }, 50);
-      } else {
-        // line / rect / oval — save snapshot for live preview
-        pushUndo();
-        snapshotRef.current = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      }
-    },
-    [tool, primaryColor, secondaryColor, brushSize, pushUndo, zoom],
-  );
+  const endDrawing = useCallback((x: number, y: number) => {
+    if (!isDrawingRef.current) return;
+    isDrawingRef.current = false;
+    if (sprayRef.current) { clearInterval(sprayRef.current); sprayRef.current = null; }
 
-  const onMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      const pos  = {
-        x: Math.floor((e.clientX - rect.left) / zoom),
-        y: Math.floor((e.clientY - rect.top)  / zoom),
-      };
-      setStatus(`${pos.x}, ${pos.y}`);
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx   = canvas.getContext("2d")!;
+    const color = activeColorRef.current;
+    const size  = activeSizeRef.current;
 
-      if (!isDrawingRef.current) return;
-      const ctx   = canvas.getContext("2d")!;
-      const color = activeColorRef.current;
-      const size  = activeSizeRef.current;
+    if (snapshotRef.current) {
+      ctx.putImageData(snapshotRef.current, 0, 0);
+      const { x: sx, y: sy } = startRef.current;
+      if (tool === "line")      strokeLine(ctx, sx, sy, x, y, color, size);
+      else if (tool === "rect") strokeRect(ctx, sx, sy, x, y, color, size, fillMode);
+      else if (tool === "oval") strokeOval(ctx, sx, sy, x, y, color, size, fillMode);
+      snapshotRef.current = null;
+    }
+  }, [tool, fillMode]);
 
-      if (tool === "pencil" || tool === "brush") {
-        strokeLine(ctx, lastRef.current.x, lastRef.current.y, pos.x, pos.y, color, size);
-      } else if (tool === "eraser") {
-        strokeLine(ctx, lastRef.current.x, lastRef.current.y, pos.x, pos.y, "transparent", brushSize);
-      } else if (tool === "spray") {
-        sprayAt(pos.x, pos.y, color, brushSize);
-      } else if (snapshotRef.current) {
-        ctx.putImageData(snapshotRef.current, 0, 0);
-        const { x: sx, y: sy } = startRef.current;
-        if (tool === "line") strokeLine(ctx, sx, sy, pos.x, pos.y, color, size);
-        else if (tool === "rect") strokeRect(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
-        else if (tool === "oval") strokeOval(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
-      }
+  // ── Mouse handlers ─────────────────────────────────────────────────────
 
-      lastRef.current = pos;
-    },
-    [tool, brushSize, fillMode, zoom],
-  );
+  const onMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    const { x, y } = { x: Math.floor((e.clientX - canvasRef.current!.getBoundingClientRect().left) / zoom),
+                       y: Math.floor((e.clientY - canvasRef.current!.getBoundingClientRect().top)  / zoom) };
+    startDrawing(x, y, e.button === 2);
+  }, [startDrawing, zoom]);
 
-  const onMouseUp = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!isDrawingRef.current) return;
-      isDrawingRef.current = false;
+  const onMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) / zoom);
+    const y = Math.floor((e.clientY - rect.top)  / zoom);
+    setStatus(`${x}, ${y}`);
+    continueDrawing(x, y);
+  }, [continueDrawing, zoom]);
 
-      if (sprayRef.current) {
-        clearInterval(sprayRef.current);
-        sprayRef.current = null;
-      }
+  const onMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    endDrawing(
+      Math.floor((e.clientX - rect.left) / zoom),
+      Math.floor((e.clientY - rect.top)  / zoom),
+    );
+  }, [endDrawing, zoom]);
 
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const ctx   = canvas.getContext("2d")!;
-      const rect  = canvas.getBoundingClientRect();
-      const pos   = {
-        x: Math.floor((e.clientX - rect.left) / zoom),
-        y: Math.floor((e.clientY - rect.top)  / zoom),
-      };
-      const color = activeColorRef.current;
-      const size  = activeSizeRef.current;
+  const onMouseLeave = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    setStatus("Ready");
+    onMouseUp(e);
+  }, [onMouseUp]);
 
-      if (snapshotRef.current) {
-        ctx.putImageData(snapshotRef.current, 0, 0);
-        const { x: sx, y: sy } = startRef.current;
-        if (tool === "line")      strokeLine(ctx, sx, sy, pos.x, pos.y, color, size);
-        else if (tool === "rect") strokeRect(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
-        else if (tool === "oval") strokeOval(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
-        snapshotRef.current = null;
-      }
-    },
-    [tool, fillMode, zoom],
-  );
+  // ── Touch handlers ─────────────────────────────────────────────────────
 
-  const onMouseLeave = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      setStatus("Ready");
-      if (isDrawingRef.current) onMouseUp(e);
-    },
-    [onMouseUp],
-  );
+  const onTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (e.touches.length === 0 || !canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const t = e.touches[0];
+    startDrawing(
+      Math.floor((t.clientX - rect.left) / zoom),
+      Math.floor((t.clientY - rect.top)  / zoom),
+      false,
+    );
+  }, [startDrawing, zoom]);
+
+  const onTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (e.touches.length === 0 || !canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const t = e.touches[0];
+    const x = Math.floor((t.clientX - rect.left) / zoom);
+    const y = Math.floor((t.clientY - rect.top)  / zoom);
+    setStatus(`${x}, ${y}`);
+    continueDrawing(x, y);
+  }, [continueDrawing, zoom]);
+
+  const onTouchEnd = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const t = e.changedTouches[0];
+    endDrawing(
+      Math.floor((t.clientX - rect.left) / zoom),
+      Math.floor((t.clientY - rect.top)  / zoom),
+    );
+    setStatus("Ready");
+  }, [endDrawing, zoom]);
+
+  // ── Size picker ────────────────────────────────────────────────────────
 
   const handleSizeSelect = useCallback((preset: CanvasSize) => {
     setCanvasSize(preset);
@@ -406,9 +417,9 @@ export default function NsArt() {
     <div className="ns-art">
       {/* ── Action bar ── */}
       <div className="ns-art__actions">
-        <button className="ns-art__action-btn" onClick={newCanvas}  title="New (clears canvas)">New</button>
-        <button className="ns-art__action-btn" onClick={exportPng}  title="Export as PNG">Export PNG</button>
-        <button className="ns-art__action-btn" onClick={undo}       title="Undo (Ctrl+Z)">Undo</button>
+        <button className="ns-art__action-btn" onClick={newCanvas} title="New (clears canvas)">New</button>
+        <button className="ns-art__action-btn" onClick={exportPng} title="Export as PNG">Export PNG</button>
+        <button className="ns-art__action-btn" onClick={undo}      title="Undo (Ctrl+Z)">Undo</button>
         <div className="ns-art__action-sep" />
         <div className="ns-art__size-picker">
           <button
@@ -453,7 +464,6 @@ export default function NsArt() {
 
           <div className="ns-art__toolbox-sep" />
 
-          {/* Brush sizes */}
           <div className="ns-art__size-dots">
             {BRUSH_SIZES.map(s => (
               <button
@@ -467,7 +477,6 @@ export default function NsArt() {
             ))}
           </div>
 
-          {/* Fill mode (shapes only) */}
           {showFillMode && (
             <>
               <div className="ns-art__toolbox-sep" />
@@ -486,7 +495,6 @@ export default function NsArt() {
             </>
           )}
 
-          {/* Zoom indicator */}
           {zoom > 1 && (
             <>
               <div className="ns-art__toolbox-sep" />
@@ -496,7 +504,7 @@ export default function NsArt() {
         </div>
 
         {/* Canvas scroll area */}
-        <div className="ns-art__canvas-area">
+        <div className="ns-art__canvas-area" ref={canvasAreaRef}>
           <div
             className="ns-art__canvas-wrap"
             style={{ width: canvasSize.w * zoom, height: canvasSize.h * zoom }}
@@ -511,6 +519,9 @@ export default function NsArt() {
               onMouseMove={onMouseMove}
               onMouseUp={onMouseUp}
               onMouseLeave={onMouseLeave}
+              onTouchStart={onTouchStart}
+              onTouchMove={onTouchMove}
+              onTouchEnd={onTouchEnd}
               onContextMenu={e => e.preventDefault()}
             />
           </div>
@@ -519,7 +530,6 @@ export default function NsArt() {
 
       {/* ── Bottom: color swatches + palette + status ── */}
       <div className="ns-art__bottom">
-        {/* Active color display */}
         <div className="ns-art__swatch-box">
           <div
             className="ns-art__swatch ns-art__swatch--secondary"
@@ -535,7 +545,6 @@ export default function NsArt() {
           />
         </div>
 
-        {/* Palette */}
         <div className="ns-art__palette">
           {PALETTE.map((color, i) => (
             <button
@@ -547,7 +556,6 @@ export default function NsArt() {
               onContextMenu={e => { e.preventDefault(); setSecondaryColor(color); }}
             />
           ))}
-          {/* Transparent swatch */}
           <button
             className={`ns-art__pal-swatch ns-art__pal-swatch--transparent${primaryColor === "transparent" ? " ns-art__pal-swatch--pri" : ""}${secondaryColor === "transparent" ? " ns-art__pal-swatch--sec" : ""}`}
             title="Transparent / Eraser"

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -1,0 +1,563 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import "./NsArt.css";
+
+type Tool = "pencil" | "brush" | "spray" | "eraser" | "fill" | "line" | "rect" | "oval" | "zoom";
+type FillMode = "outline" | "filled" | "both";
+
+interface CanvasSize { w: number; h: number }
+
+const PALETTE: string[] = [
+  // Row 1 — dark / brand
+  "#000000", "#7f7f7f", "#800000", "#cc4400",
+  "#ff6b00", "#808000", "#005500", "#006060",
+  "#000080", "#5b2d8e", "#7b3dbe", "#800080",
+  "#8b4513", "#c0c0c0",
+  // Row 2 — bright / light
+  "#ffffff", "#d4d0c8", "#ff4444", "#ff9933",
+  "#ffdd00", "#00cc44", "#00cccc", "#4488ff",
+  "#d0a0ff", "#ff44ff", "#ffcc88", "#aa66ff",
+  "#ffffaa", "#aaddff",
+];
+
+const CANVAS_PRESETS: CanvasSize[] = [
+  { w: 160, h: 120 },
+  { w: 320, h: 240 },
+  { w: 640, h: 480 },
+  { w: 800, h: 600 },
+];
+
+const BRUSH_SIZES = [2, 5, 10] as const;
+type BrushSize = typeof BRUSH_SIZES[number];
+
+const TOOLS: { id: Tool; label: string; title: string }[] = [
+  { id: "pencil", label: "✏",  title: "Pencil (1px)"     },
+  { id: "brush",  label: "⬤",  title: "Brush"            },
+  { id: "spray",  label: "∷",  title: "Spray Can"        },
+  { id: "eraser", label: "◻",  title: "Eraser"           },
+  { id: "fill",   label: "▤",  title: "Fill"             },
+  { id: "line",   label: "╱",  title: "Line"             },
+  { id: "rect",   label: "▭",  title: "Rectangle"        },
+  { id: "oval",   label: "⬭",  title: "Oval"             },
+  { id: "zoom",   label: "⊕",  title: "Zoom (right-click zooms out)" },
+];
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function floodFill(
+  ctx: CanvasRenderingContext2D,
+  sx: number,
+  sy: number,
+  fillColor: string,
+) {
+  const canvas = ctx.canvas;
+  const w = canvas.width;
+  const h = canvas.height;
+  if (sx < 0 || sy < 0 || sx >= w || sy >= h) return;
+
+  const imageData = ctx.getImageData(0, 0, w, h);
+  const d = imageData.data;
+  const byteIdx = (x: number, y: number) => (y * w + x) * 4;
+
+  const si = byteIdx(sx, sy);
+  const tR = d[si], tG = d[si + 1], tB = d[si + 2], tA = d[si + 3];
+
+  let fR: number, fG: number, fB: number, fA: number;
+  if (fillColor === "transparent") {
+    [fR, fG, fB, fA] = [0, 0, 0, 0];
+  } else {
+    const m = /^#(..)(..)(..)$/.exec(fillColor);
+    if (!m) return;
+    [fR, fG, fB, fA] = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255];
+  }
+
+  if (tR === fR && tG === fG && tB === fB && tA === fA) return;
+
+  const visited = new Uint8Array(w * h);
+  const stack: number[] = [si];
+
+  while (stack.length > 0) {
+    const i = stack.pop()!;
+    const pi = i >> 2;
+    if (visited[pi]) continue;
+    if (d[i] !== tR || d[i+1] !== tG || d[i+2] !== tB || d[i+3] !== tA) continue;
+    visited[pi] = 1;
+    d[i] = fR; d[i+1] = fG; d[i+2] = fB; d[i+3] = fA;
+    const x = pi % w;
+    const y = Math.floor(pi / w);
+    if (x > 0)     stack.push(i - 4);
+    if (x < w - 1) stack.push(i + 4);
+    if (y > 0)     stack.push(i - w * 4);
+    if (y < h - 1) stack.push(i + w * 4);
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+}
+
+function applyColor(ctx: CanvasRenderingContext2D, color: string, size: number) {
+  if (color === "transparent") {
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.strokeStyle = "rgba(0,0,0,1)";
+    ctx.fillStyle   = "rgba(0,0,0,1)";
+  } else {
+    ctx.globalCompositeOperation = "source-over";
+    ctx.strokeStyle = color;
+    ctx.fillStyle   = color;
+  }
+  ctx.lineWidth  = size;
+  ctx.lineCap    = "round";
+  ctx.lineJoin   = "round";
+}
+
+function resetCtx(ctx: CanvasRenderingContext2D) {
+  ctx.globalCompositeOperation = "source-over";
+}
+
+function strokeLine(
+  ctx: CanvasRenderingContext2D,
+  x0: number, y0: number,
+  x1: number, y1: number,
+  color: string,
+  size: number,
+) {
+  applyColor(ctx, color, size);
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  ctx.lineTo(x1, y1);
+  ctx.stroke();
+  resetCtx(ctx);
+}
+
+function strokeRect(
+  ctx: CanvasRenderingContext2D,
+  x0: number, y0: number,
+  x1: number, y1: number,
+  color: string,
+  size: number,
+  mode: FillMode,
+) {
+  applyColor(ctx, color, size);
+  const x = Math.min(x0, x1), y = Math.min(y0, y1);
+  const w = Math.abs(x1 - x0), h = Math.abs(y1 - y0);
+  if (mode === "filled" || mode === "both") ctx.fillRect(x, y, w, h);
+  if (mode === "outline" || mode === "both") ctx.strokeRect(x, y, w, h);
+  resetCtx(ctx);
+}
+
+function strokeOval(
+  ctx: CanvasRenderingContext2D,
+  x0: number, y0: number,
+  x1: number, y1: number,
+  color: string,
+  size: number,
+  mode: FillMode,
+) {
+  applyColor(ctx, color, size);
+  const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
+  const rx = Math.max(1, Math.abs(x1 - x0) / 2);
+  const ry = Math.max(1, Math.abs(y1 - y0) / 2);
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+  if (mode === "filled" || mode === "both") ctx.fill();
+  if (mode === "outline" || mode === "both") ctx.stroke();
+  resetCtx(ctx);
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function NsArt() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [tool,            setTool]           = useState<Tool>("pencil");
+  const [primaryColor,    setPrimaryColor]   = useState("#000000");
+  const [secondaryColor,  setSecondaryColor] = useState("#ffffff");
+  const [brushSize,       setBrushSize]      = useState<BrushSize>(2);
+  const [fillMode,        setFillMode]       = useState<FillMode>("outline");
+  const [zoom,            setZoom]           = useState(1);
+  const [canvasSize,      setCanvasSize]     = useState<CanvasSize>({ w: 640, h: 480 });
+  const [showSizeMenu,    setShowSizeMenu]   = useState(false);
+  const [status,          setStatus]         = useState("Ready");
+
+  const isDrawingRef        = useRef(false);
+  const startRef            = useRef({ x: 0, y: 0 });
+  const lastRef             = useRef({ x: 0, y: 0 });
+  const snapshotRef         = useRef<ImageData | null>(null);
+  const undoRef             = useRef<ImageData[]>([]);
+  const sprayRef            = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeColorRef      = useRef("#000000");
+  const activeSizeRef       = useRef<number>(1);
+
+  // White-fill whenever canvas size changes (creates new canvas element)
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    undoRef.current = [];
+  }, [canvasSize]);
+
+  const pushUndo = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    const snap = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const stack = undoRef.current;
+    undoRef.current = stack.length >= 5 ? [...stack.slice(1), snap] : [...stack, snap];
+  }, []);
+
+  const undo = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || undoRef.current.length === 0) return;
+    const ctx = canvas.getContext("2d")!;
+    const prev = undoRef.current[undoRef.current.length - 1];
+    undoRef.current = undoRef.current.slice(0, -1);
+    ctx.putImageData(prev, 0, 0);
+  }, []);
+
+  const newCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    pushUndo();
+    const ctx = canvas.getContext("2d")!;
+    ctx.globalCompositeOperation = "source-over";
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }, [pushUndo]);
+
+  const exportPng = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = "ns-art.png";
+    a.click();
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+        e.preventDefault();
+        undo();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [undo]);
+
+  function sprayAt(x: number, y: number, color: string, size: number) {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    applyColor(ctx, color, 1);
+    const radius  = size * 5;
+    const density = size * 4;
+    for (let i = 0; i < density; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const r     = Math.random() * radius;
+      ctx.fillRect(
+        Math.round(x + Math.cos(angle) * r),
+        Math.round(y + Math.sin(angle) * r),
+        1, 1,
+      );
+    }
+    resetCtx(ctx);
+  }
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx  = canvas.getContext("2d")!;
+      const pos  = { x: Math.floor((e.clientX - canvas.getBoundingClientRect().left) / zoom),
+                     y: Math.floor((e.clientY - canvas.getBoundingClientRect().top)  / zoom) };
+      const color = e.button === 2 ? secondaryColor : primaryColor;
+
+      if (tool === "zoom") {
+        setZoom(z => e.button === 2 ? Math.max(1, z / 2) : Math.min(4, z * 2));
+        return;
+      }
+
+      if (tool === "fill") {
+        pushUndo();
+        floodFill(ctx, pos.x, pos.y, color);
+        return;
+      }
+
+      isDrawingRef.current   = true;
+      startRef.current       = pos;
+      lastRef.current        = pos;
+      activeColorRef.current = color;
+      activeSizeRef.current  = tool === "pencil" ? 1 : brushSize;
+
+      if (tool === "pencil" || tool === "brush" || tool === "eraser") {
+        pushUndo();
+        const effectiveColor = tool === "eraser" ? "transparent" : color;
+        const effectiveSize  = tool === "pencil" ? 1 : brushSize;
+        // Draw initial dot
+        applyColor(ctx, effectiveColor, effectiveSize);
+        ctx.beginPath();
+        ctx.arc(pos.x, pos.y, effectiveSize / 2, 0, Math.PI * 2);
+        ctx.fill();
+        resetCtx(ctx);
+      } else if (tool === "spray") {
+        pushUndo();
+        sprayAt(pos.x, pos.y, color, brushSize);
+        const capturedColor = color;
+        const capturedSize  = brushSize;
+        sprayRef.current = setInterval(() => {
+          if (!isDrawingRef.current) return;
+          sprayAt(lastRef.current.x, lastRef.current.y, capturedColor, capturedSize);
+        }, 50);
+      } else {
+        // line / rect / oval — save snapshot for live preview
+        pushUndo();
+        snapshotRef.current = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      }
+    },
+    [tool, primaryColor, secondaryColor, brushSize, pushUndo, zoom],
+  );
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const pos  = {
+        x: Math.floor((e.clientX - rect.left) / zoom),
+        y: Math.floor((e.clientY - rect.top)  / zoom),
+      };
+      setStatus(`${pos.x}, ${pos.y}`);
+
+      if (!isDrawingRef.current) return;
+      const ctx   = canvas.getContext("2d")!;
+      const color = activeColorRef.current;
+      const size  = activeSizeRef.current;
+
+      if (tool === "pencil" || tool === "brush") {
+        strokeLine(ctx, lastRef.current.x, lastRef.current.y, pos.x, pos.y, color, size);
+      } else if (tool === "eraser") {
+        strokeLine(ctx, lastRef.current.x, lastRef.current.y, pos.x, pos.y, "transparent", brushSize);
+      } else if (tool === "spray") {
+        sprayAt(pos.x, pos.y, color, brushSize);
+      } else if (snapshotRef.current) {
+        ctx.putImageData(snapshotRef.current, 0, 0);
+        const { x: sx, y: sy } = startRef.current;
+        if (tool === "line") strokeLine(ctx, sx, sy, pos.x, pos.y, color, size);
+        else if (tool === "rect") strokeRect(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
+        else if (tool === "oval") strokeOval(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
+      }
+
+      lastRef.current = pos;
+    },
+    [tool, brushSize, fillMode, zoom],
+  );
+
+  const onMouseUp = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDrawingRef.current) return;
+      isDrawingRef.current = false;
+
+      if (sprayRef.current) {
+        clearInterval(sprayRef.current);
+        sprayRef.current = null;
+      }
+
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx   = canvas.getContext("2d")!;
+      const rect  = canvas.getBoundingClientRect();
+      const pos   = {
+        x: Math.floor((e.clientX - rect.left) / zoom),
+        y: Math.floor((e.clientY - rect.top)  / zoom),
+      };
+      const color = activeColorRef.current;
+      const size  = activeSizeRef.current;
+
+      if (snapshotRef.current) {
+        ctx.putImageData(snapshotRef.current, 0, 0);
+        const { x: sx, y: sy } = startRef.current;
+        if (tool === "line")      strokeLine(ctx, sx, sy, pos.x, pos.y, color, size);
+        else if (tool === "rect") strokeRect(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
+        else if (tool === "oval") strokeOval(ctx, sx, sy, pos.x, pos.y, color, size, fillMode);
+        snapshotRef.current = null;
+      }
+    },
+    [tool, fillMode, zoom],
+  );
+
+  const onMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      setStatus("Ready");
+      if (isDrawingRef.current) onMouseUp(e);
+    },
+    [onMouseUp],
+  );
+
+  const handleSizeSelect = useCallback((preset: CanvasSize) => {
+    setCanvasSize(preset);
+    setShowSizeMenu(false);
+    setZoom(1);
+  }, []);
+
+  const showFillMode = tool === "rect" || tool === "oval";
+
+  return (
+    <div className="ns-art">
+      {/* ── Action bar ── */}
+      <div className="ns-art__actions">
+        <button className="ns-art__action-btn" onClick={newCanvas}  title="New (clears canvas)">New</button>
+        <button className="ns-art__action-btn" onClick={exportPng}  title="Export as PNG">Export PNG</button>
+        <button className="ns-art__action-btn" onClick={undo}       title="Undo (Ctrl+Z)">Undo</button>
+        <div className="ns-art__action-sep" />
+        <div className="ns-art__size-picker">
+          <button
+            className="ns-art__action-btn"
+            onClick={() => setShowSizeMenu(s => !s)}
+            title="Change canvas size"
+          >
+            {canvasSize.w}×{canvasSize.h} ▾
+          </button>
+          {showSizeMenu && (
+            <div className="ns-art__size-menu">
+              {CANVAS_PRESETS.map(p => (
+                <button
+                  key={`${p.w}x${p.h}`}
+                  className={`ns-art__size-item${canvasSize.w === p.w && canvasSize.h === p.h ? " ns-art__size-item--active" : ""}`}
+                  onClick={() => handleSizeSelect(p)}
+                >
+                  {p.w}×{p.h}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Workspace ── */}
+      <div className="ns-art__workspace">
+        {/* Tool palette */}
+        <div className="ns-art__toolbox">
+          <div className="ns-art__tool-grid">
+            {TOOLS.map(t => (
+              <button
+                key={t.id}
+                className={`ns-art__tool${tool === t.id ? " ns-art__tool--active" : ""}`}
+                title={t.title}
+                onClick={() => setTool(t.id)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="ns-art__toolbox-sep" />
+
+          {/* Brush sizes */}
+          <div className="ns-art__size-dots">
+            {BRUSH_SIZES.map(s => (
+              <button
+                key={s}
+                className={`ns-art__size-dot-btn${brushSize === s ? " ns-art__size-dot-btn--active" : ""}`}
+                title={`Size ${s}px`}
+                onClick={() => setBrushSize(s)}
+              >
+                <span className="ns-art__dot" style={{ width: s + 4, height: s + 4 }} />
+              </button>
+            ))}
+          </div>
+
+          {/* Fill mode (shapes only) */}
+          {showFillMode && (
+            <>
+              <div className="ns-art__toolbox-sep" />
+              <div className="ns-art__fill-modes">
+                {(["outline", "filled", "both"] as FillMode[]).map(m => (
+                  <button
+                    key={m}
+                    className={`ns-art__fill-btn${fillMode === m ? " ns-art__fill-btn--active" : ""}`}
+                    title={m}
+                    onClick={() => setFillMode(m)}
+                  >
+                    {m === "outline" ? "□" : m === "filled" ? "■" : "▣"}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* Zoom indicator */}
+          {zoom > 1 && (
+            <>
+              <div className="ns-art__toolbox-sep" />
+              <div className="ns-art__zoom-label">{zoom}×</div>
+            </>
+          )}
+        </div>
+
+        {/* Canvas scroll area */}
+        <div className="ns-art__canvas-area">
+          <div
+            className="ns-art__canvas-wrap"
+            style={{ width: canvasSize.w * zoom, height: canvasSize.h * zoom }}
+          >
+            <canvas
+              ref={canvasRef}
+              className="ns-art__canvas"
+              width={canvasSize.w}
+              height={canvasSize.h}
+              style={{ width: canvasSize.w * zoom, height: canvasSize.h * zoom }}
+              onMouseDown={onMouseDown}
+              onMouseMove={onMouseMove}
+              onMouseUp={onMouseUp}
+              onMouseLeave={onMouseLeave}
+              onContextMenu={e => e.preventDefault()}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Bottom: color swatches + palette + status ── */}
+      <div className="ns-art__bottom">
+        {/* Active color display */}
+        <div className="ns-art__swatch-box">
+          <div
+            className="ns-art__swatch ns-art__swatch--secondary"
+            style={secondaryColor !== "transparent" ? { background: secondaryColor } : undefined}
+            data-transparent={secondaryColor === "transparent" || undefined}
+            title="Secondary color (right-click palette)"
+          />
+          <div
+            className="ns-art__swatch ns-art__swatch--primary"
+            style={primaryColor !== "transparent" ? { background: primaryColor } : undefined}
+            data-transparent={primaryColor === "transparent" || undefined}
+            title="Primary color (left-click palette)"
+          />
+        </div>
+
+        {/* Palette */}
+        <div className="ns-art__palette">
+          {PALETTE.map((color, i) => (
+            <button
+              key={i}
+              className={`ns-art__pal-swatch${color === primaryColor ? " ns-art__pal-swatch--pri" : ""}${color === secondaryColor ? " ns-art__pal-swatch--sec" : ""}`}
+              style={{ background: color }}
+              title={color}
+              onClick={() => setPrimaryColor(color)}
+              onContextMenu={e => { e.preventDefault(); setSecondaryColor(color); }}
+            />
+          ))}
+          {/* Transparent swatch */}
+          <button
+            className={`ns-art__pal-swatch ns-art__pal-swatch--transparent${primaryColor === "transparent" ? " ns-art__pal-swatch--pri" : ""}${secondaryColor === "transparent" ? " ns-art__pal-swatch--sec" : ""}`}
+            title="Transparent / Eraser"
+            onClick={() => setPrimaryColor("transparent")}
+            onContextMenu={e => { e.preventDefault(); setSecondaryColor("transparent"); }}
+          />
+        </div>
+
+        <div className="ns-art__status">{status}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -21,6 +21,7 @@ import FolderApp from "./FolderApp";
 import FilesApp from "./FilesApp";
 import NotebookApp from "./NotebookApp";
 import InternetApp from "./InternetApp";
+import NsArt from "../NsArt/NsArt";
 import TicTacToe from "../TicTacToe/TicTacToe";
 import DuckHunt from "../DuckHunt/DuckHunt";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
@@ -56,6 +57,7 @@ const EXPERIENCE_ICONS: Record<string, string> = {
   "bomb-finder":        "💣",
   "duck-hunt":          "🎯",
   "ns-doors-97":        "🚪",
+  "ns-art":             "🎨",
 };
 
 type DesktopIconAction =
@@ -71,7 +73,8 @@ type DesktopIconAction =
   | "my-doors"
   | "internet"
   | "files"
-  | "notebook";
+  | "notebook"
+  | "nsart";
 
 interface DesktopIconDef {
   id: string;
@@ -98,10 +101,11 @@ const EXPERIENCE_ICON_DEFS: DesktopIconDef[] = experiences
     title: e.title,
     icon: EXPERIENCE_ICONS[e.id] ?? "🖥️",
     action: (
-      e.id === "tic-tac-toe" ? "tictactoe" :
-      e.id === "number-muncher" ? "nomnom" :
-      e.id === "bomb-finder" ? "bombfinder" :
-      e.id === "duck-hunt" ? "duckhunt" :
+      e.id === "tic-tac-toe"     ? "tictactoe" :
+      e.id === "number-muncher"  ? "nomnom"    :
+      e.id === "bomb-finder"     ? "bombfinder":
+      e.id === "duck-hunt"       ? "duckhunt"  :
+      e.id === "ns-art"          ? "nsart"     :
       "experience"
     ) as DesktopIconAction,
   }));
@@ -124,7 +128,8 @@ type WindowContent =
   | { type: "internet" }
   | { type: "files" }
   | { type: "notebook"; filePath: string; fileName: string; initialContent: string }
-  | { type: "desktop-display" };
+  | { type: "desktop-display" }
+  | { type: "nsart" };
 
 interface OpenWindow {
   id: string;
@@ -367,6 +372,7 @@ export default function NsDoors97() {
         case "internet":     content = { type: "internet" };             width = 640; break;
         case "files":        content = { type: "files" };                width = 600; break;
         case "notebook":     content = { type: "notebook", filePath: "(new file)", fileName: "Untitled.txt", initialContent: "" }; width = 560; break;
+        case "nsart":        content = { type: "nsart" };                width = 760;                  break;
         case "tictactoe":    content = { type: "tictactoe" };            width = TTT_WINDOW_WIDTHS[3]; break;
         case "nomnom":       content = { type: "nomnom" };               width = 700; break;
         case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
@@ -586,6 +592,7 @@ export default function NsDoors97() {
               }
             />
           )}
+          {win.content.type === "nsart" && <NsArt />}
           {win.content.type === "tictactoe" && (
             <TicTacToe
               onBoardSizeChange={(size) =>

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -21,7 +21,7 @@ import FolderApp from "./FolderApp";
 import FilesApp from "./FilesApp";
 import NotebookApp from "./NotebookApp";
 import InternetApp from "./InternetApp";
-import NsArt from "../NsArt/NsArt";
+import NsArt, { type NsArtHandle } from "../NsArt/NsArt";
 import TicTacToe from "../TicTacToe/TicTacToe";
 import DuckHunt from "../DuckHunt/DuckHunt";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
@@ -74,7 +74,8 @@ type DesktopIconAction =
   | "internet"
   | "files"
   | "notebook"
-  | "nsart";
+  | "nsart"
+  | "art-backup";
 
 interface DesktopIconDef {
   id: string;
@@ -92,6 +93,7 @@ const STATIC_ICONS: DesktopIconDef[] = [
   { id: "internet",     title: "Internet",     icon: "🌐", action: "internet"     },
   { id: "screensavers", title: "Screensavers", icon: "💤", action: "screensavers" },
   { id: "cards",        title: "Cards",        icon: "🃏", action: "cards"        },
+  { id: "art-backup",   title: "Backup.png",   icon: "🖼️", action: "art-backup"   },
 ];
 
 const EXPERIENCE_ICON_DEFS: DesktopIconDef[] = experiences
@@ -129,7 +131,8 @@ type WindowContent =
   | { type: "files" }
   | { type: "notebook"; filePath: string; fileName: string; initialContent: string }
   | { type: "desktop-display" }
-  | { type: "nsart" };
+  | { type: "nsart" }
+  | { type: "nsart-backup" };
 
 interface OpenWindow {
   id: string;
@@ -191,15 +194,31 @@ export default function NsDoors97() {
   const skipBoot = (location.state as { skipBoot?: boolean } | null)?.skipBoot === true;
   const initialShouldBoot = !skipBoot && (fromTos || shouldShowBoot());
 
+  const nsArtRef       = useRef<NsArtHandle>(null);
+  const nsArtBackupRef = useRef<NsArtHandle>(null);
+  const [hasArtBackup, setHasArtBackup] = useState(() =>
+    Boolean(localStorage.getItem("ns-art-backup"))
+  );
+
   const [showBoot, setShowBoot]             = useState(initialShouldBoot);
   const [shuttingDown, setShuttingDown]     = useState(false);
   const [desktopLoading, setDesktopLoading] = useState(false);
 
-  // Icons start empty whenever there's a boot screen, all-visible otherwise.
+  // Icons start empty whenever there's a boot screen; all-visible otherwise.
+  // art-backup is excluded unless a saved backup exists.
   const [visibleIcons, setVisibleIcons] = useState<ReadonlySet<string>>(() => {
     if (initialShouldBoot) return new Set<string>();
-    return new Set(ALL_DESKTOP_ICONS.map((d) => d.id));
+    return new Set(
+      ALL_DESKTOP_ICONS.filter((d) => d.id !== "art-backup" || Boolean(localStorage.getItem("ns-art-backup"))).map((d) => d.id)
+    );
   });
+
+  // Reveal the Backup.png icon whenever a backup is first saved
+  useEffect(() => {
+    if (hasArtBackup) {
+      setVisibleIcons((prev) => new Set<string>([...prev, "art-backup"]));
+    }
+  }, [hasArtBackup]);
 
   // Called when the boot screen finishes (both initial boot and after restart)
   const handleBootComplete = useCallback(() => {
@@ -240,7 +259,12 @@ export default function NsDoors97() {
       document.body.style.cursor = "";
 
       // Phase 2 — icons pop in one by one in random order
-      const shuffled = [...ALL_DESKTOP_ICONS.map((d) => d.id)];
+      // art-backup only appears if a saved backup exists
+      const shuffled = [
+        ...ALL_DESKTOP_ICONS
+          .filter((d) => d.id !== "art-backup" || Boolean(localStorage.getItem("ns-art-backup")))
+          .map((d) => d.id),
+      ];
       for (let i = shuffled.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
@@ -372,7 +396,8 @@ export default function NsDoors97() {
         case "internet":     content = { type: "internet" };             width = 640; break;
         case "files":        content = { type: "files" };                width = 600; break;
         case "notebook":     content = { type: "notebook", filePath: "(new file)", fileName: "Untitled.txt", initialContent: "" }; width = 560; break;
-        case "nsart":        content = { type: "nsart" };                width = 760;                  break;
+        case "nsart":        content = { type: "nsart" };                width = 760; break;
+        case "art-backup":  content = { type: "nsart-backup" };         width = 760; break;
         case "tictactoe":    content = { type: "tictactoe" };            width = TTT_WINDOW_WIDTHS[3]; break;
         case "nomnom":       content = { type: "nomnom" };               width = 700; break;
         case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
@@ -580,6 +605,14 @@ export default function NsDoors97() {
           width={win.width}
           onClose={win.content.type === "cards-game" ? handleCardsGameClose : closeWindow}
           onFocus={focusWindow}
+          onCloseRequested={
+            (win.content.type === "nsart" || win.content.type === "nsart-backup")
+              ? (_id, proceed) => {
+                  const r = win.content.type === "nsart" ? nsArtRef : nsArtBackupRef;
+                  if (r.current) { r.current.requestClose(proceed); } else { proceed(); }
+                }
+              : undefined
+          }
         >
           {win.content.type === "app-launcher" && (
             <AppLauncher
@@ -592,7 +625,12 @@ export default function NsDoors97() {
               }
             />
           )}
-          {win.content.type === "nsart" && <NsArt />}
+          {win.content.type === "nsart" && (
+            <NsArt ref={nsArtRef} onBackupSaved={() => setHasArtBackup(true)} />
+          )}
+          {win.content.type === "nsart-backup" && (
+            <NsArt ref={nsArtBackupRef} onBackupSaved={() => setHasArtBackup(true)} />
+          )}
           {win.content.type === "tictactoe" && (
             <TicTacToe
               onBoardSizeChange={(size) =>

--- a/src/experiences/NsDoors97/Window.tsx
+++ b/src/experiences/NsDoors97/Window.tsx
@@ -12,6 +12,7 @@ interface WindowProps {
   width?: number;        // optional override — defaults to CSS 440px
   onClose: (id: string) => void;
   onFocus: (id: string) => void;
+  onCloseRequested?: (id: string, proceed: () => void) => void;
   children: React.ReactNode;
 }
 
@@ -47,6 +48,7 @@ export default function Window({
   width,
   onClose,
   onFocus,
+  onCloseRequested,
   children,
 }: WindowProps) {
   const nodeRef = useRef<HTMLDivElement>(null);
@@ -63,8 +65,16 @@ export default function Window({
     ...(scale < 1 ? { zoom: scale } : {}),
   };
 
+  function handleClose() {
+    if (onCloseRequested) {
+      onCloseRequested(id, () => onClose(id));
+    } else {
+      onClose(id);
+    }
+  }
+
   const titleBar = (
-    <TitleBar title={title} icon={icon} onClose={() => onClose(id)} />
+    <TitleBar title={title} icon={icon} onClose={handleClose} />
   );
 
   // Portrait mode: maximized, no drag

--- a/src/pages/NsArtPage.tsx
+++ b/src/pages/NsArtPage.tsx
@@ -1,0 +1,25 @@
+import NsArt from "../experiences/NsArt/NsArt";
+import StandaloneWindow from "../components/StandaloneWindow/StandaloneWindow";
+
+export default function NsArtPage() {
+  return (
+    <StandaloneWindow
+      title="NS Art"
+      icon="🎨"
+      helpContent={
+        <ul>
+          <li><strong>Left-click</strong> draws with primary color · <strong>Right-click</strong> draws with secondary color</li>
+          <li>Left-click palette to set primary · right-click palette to set secondary</li>
+          <li>Checkerboard swatch = transparent (erases to transparent)</li>
+          <li><strong>Zoom tool</strong> — left-click to zoom in · right-click to zoom out (max 4×)</li>
+          <li><strong>Shape tools</strong> — choose outline / filled / both from the toolbox</li>
+          <li><strong>Ctrl+Z</strong> — undo (5 levels)</li>
+          <li><strong>Export PNG</strong> — downloads your drawing (transparency preserved)</li>
+          <li><strong>New</strong> — clears the canvas (undoable)</li>
+        </ul>
+      }
+    >
+      <NsArt />
+    </StandaloneWindow>
+  );
+}


### PR DESCRIPTION
Implements a Win95-aesthetic canvas drawing program with pencil,
brush, spray can, eraser, flood fill, line, rectangle, and oval
tools. Features a Noahsoft-branded 28-color palette, 5-level undo,
zoom (1×–4×), canvas size presets (up to 800×600), and PNG export
with transparency support.

Accessible at /art (standalone StandaloneWindow page) and as a
draggable window inside NS Doors 97 via the 🎨 NS Art desktop icon.

Closes #30

https://claude.ai/code/session_01AAzH2oMd3MNWzf3MtU8KDk