### PR TITLE
Add Sound Recorder app to NS Doors 97

### DIFF
--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -26,6 +26,7 @@ import TicTacToe from "../TicTacToe/TicTacToe";
 import Pool from "../Pool/Pool";
 import DuckHunt from "../DuckHunt/DuckHunt";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
+import SoundRecorder, { lsGetSoundNames } from "./SoundRecorder";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import CardsLauncher from "../Cards/CardsLauncher";
 import War from "../Cards/War";
@@ -62,7 +63,8 @@ type AppAction =
   | "notebook"
   | "nsart"
   | "art-backup"
-  | "readme";
+  | "readme"
+  | "sound-recorder";
 
 interface AppDef {
   title: string;
@@ -85,8 +87,9 @@ const APP_REGISTRY: Record<string, AppDef> = {
   "number-muncher": { title: "Nom Nom Numerals",   icon: "🔢", action: "nomnom"        },
   "word-whirlwind": { title: "Word Whirlwind",     icon: "🌪️", action: "wordwhirlwind" },
   "bomb-finder":    { title: "Bomb Finder",        icon: "💣", action: "bombfinder"    },
-  "duck-hunt":      { title: "Duck & Learn",       icon: "🎯", action: "duckhunt"      },
-  "typing-racer":   { title: "Type 'Em Up",        icon: "⌨️", action: "experience"    },
+  "duck-hunt":      { title: "Duck & Learn",       icon: "🎯", action: "duckhunt"        },
+  "typing-racer":   { title: "Type 'Em Up",        icon: "⌨️", action: "experience"      },
+  "sound-recorder": { title: "Sound Recorder",     icon: "🎙️", action: "sound-recorder"  },
 };
 
 // ── Desktop icon entries (subset actually shown on desktop) ───────────────────
@@ -98,8 +101,9 @@ interface DesktopIconEntry {
 }
 
 const STATIC_DESKTOP_ICONS: DesktopIconEntry[] = [
-  { id: "my-doors", title: "My Doors", icon: "🖥️" },
-  { id: "dumpster", title: "Dumpster", icon: "🗑️" },
+  { id: "my-doors",        title: "My Doors",       icon: "🖥️" },
+  { id: "dumpster",        title: "Dumpster",        icon: "🗑️" },
+  { id: "sound-recorder",  title: "Sound Recorder",  icon: "🎙️" },
 ];
 
 const STATIC_RIGHT_ICONS: DesktopIconEntry[] = [
@@ -154,6 +158,10 @@ function loadSavedNotebookIcons(): DesktopIconEntry[] {
   return entries;
 }
 
+function loadSavedSoundIcons(): DesktopIconEntry[] {
+  return lsGetSoundNames().map(name => ({ id: `sound:${name}`, title: name, icon: "🎵" }));
+}
+
 // ── Window content union ───────────────────────────────────────────────────
 
 type WindowContent =
@@ -173,7 +181,8 @@ type WindowContent =
   | { type: "notebook"; filePath: string; fileName: string; initialContent: string }
   | { type: "desktop-display" }
   | { type: "nsart" }
-  | { type: "nsart-backup" };
+  | { type: "nsart-backup" }
+  | { type: "sound-recorder"; fileName?: string };
 
 interface OpenWindow {
   id: string;
@@ -253,6 +262,13 @@ export default function NsDoors97() {
   const savedNotebookIconsRef = useRef(savedNotebookIcons);
   useEffect(() => { savedNotebookIconsRef.current = savedNotebookIcons; }, [savedNotebookIcons]);
 
+  // Saved sound files that appear on the desktop
+  const [savedSoundIcons, setSavedSoundIcons] = useState<DesktopIconEntry[]>(
+    () => loadSavedSoundIcons()
+  );
+  const savedSoundIconsRef = useRef(savedSoundIcons);
+  useEffect(() => { savedSoundIconsRef.current = savedSoundIcons; }, [savedSoundIcons]);
+
   // Icons start empty whenever there's a boot screen; all-visible otherwise.
   const [visibleIcons, setVisibleIcons] = useState<ReadonlySet<string>>(() => {
     if (initialShouldBoot) return new Set<string>();
@@ -260,6 +276,7 @@ export default function NsDoors97() {
       ...STATIC_DESKTOP_ICONS.map((d) => d.id),
       ...STATIC_RIGHT_ICONS.map((d) => d.id),
       ...loadSavedNotebookIcons().map((d) => d.id),
+      ...loadSavedSoundIcons().map((d) => d.id),
     ]);
   });
 
@@ -306,6 +323,7 @@ export default function NsDoors97() {
         ...STATIC_DESKTOP_ICONS.map((d) => d.id),
         ...STATIC_RIGHT_ICONS.map((d) => d.id),
         ...savedNotebookIconsRef.current.map((d) => d.id),
+        ...savedSoundIconsRef.current.map((d) => d.id),
       ];
       const shuffled = [...allIds];
       for (let i = shuffled.length - 1; i > 0; i--) {
@@ -441,6 +459,37 @@ export default function NsDoors97() {
   );
 
   const openWindow = useCallback((id: string) => {
+    // Sound file desktop icons use "sound:{fileName}" id format
+    if (id.startsWith("sound:")) {
+      const soundFileName = id.slice(6);
+      const winId = `sound-recorder:${soundFileName}`;
+      setOpenWindows((prev) => {
+        if (prev.some((w) => w.id === winId)) {
+          maxZ++;
+          setActiveWindowId(winId);
+          return prev.map((w) => (w.id === winId ? { ...w, zIndex: maxZ } : w));
+        }
+        const offset = (windowSeq % 8) * 32;
+        windowSeq++;
+        maxZ++;
+        setActiveWindowId(winId);
+        return [
+          ...prev,
+          {
+            id: winId,
+            title: soundFileName,
+            icon: "🎵",
+            content: { type: "sound-recorder" as const, fileName: soundFileName },
+            zIndex: maxZ,
+            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            width: 420,
+            minimized: false,
+          },
+        ];
+      });
+      return;
+    }
+
     // Notebook saved-file desktop icons use "nb:{filePath}" id format
     if (id.startsWith("nb:")) {
       const filePath = id.slice(3);
@@ -488,7 +537,8 @@ export default function NsDoors97() {
         case "wordwhirlwind":content = { type: "word-whirlwind" };       width = 600; break;
         case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
         case "duckhunt":     content = { type: "duckhunt" };             width = 740; break;
-        case "cards":        content = { type: "cards-launcher" };       width = 320; break;
+        case "cards":          content = { type: "cards-launcher" };                           width = 320; break;
+        case "sound-recorder": content = { type: "sound-recorder" as const };                  width = 420; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -550,6 +600,16 @@ export default function NsDoors97() {
     setSavedNotebookIcons((prev) => {
       if (prev.some((d) => d.id === newId)) return prev;
       return [...prev, { id: newId, title: fileName, icon: "📝" }];
+    });
+    setVisibleIcons((prev) => new Set<string>([...prev, newId]));
+  }, []);
+
+  // Called by SoundRecorder when a file is saved — add its icon to the desktop
+  const handleSoundFileSaved = useCallback((name: string) => {
+    const newId = `sound:${name}`;
+    setSavedSoundIcons((prev) => {
+      if (prev.some((d) => d.id === newId)) return prev;
+      return [...prev, { id: newId, title: name, icon: "🎵" }];
     });
     setVisibleIcons((prev) => new Set<string>([...prev, newId]));
   }, []);
@@ -647,7 +707,7 @@ export default function NsDoors97() {
     return { background: getDesktopBackground(desktopSettings) };
   })();
 
-  const rightIcons = [...STATIC_RIGHT_ICONS, ...savedNotebookIcons];
+  const rightIcons = [...STATIC_RIGHT_ICONS, ...savedNotebookIcons, ...savedSoundIcons];
 
   return (
     <div className="ns-desktop" style={desktopStyle}>
@@ -802,6 +862,13 @@ export default function NsDoors97() {
               fileName={win.content.fileName}
               initialContent={win.content.initialContent}
               onFileSaved={handleNotebookFileSaved}
+            />
+          )}
+          {win.content.type === "sound-recorder" && (
+            <SoundRecorder
+              fileName={win.content.fileName}
+              onQuit={() => closeWindow(win.id)}
+              onFileSaved={handleSoundFileSaved}
             />
           )}
           {win.content.type === "desktop-display" && (

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -101,9 +101,8 @@ interface DesktopIconEntry {
 }
 
 const STATIC_DESKTOP_ICONS: DesktopIconEntry[] = [
-  { id: "my-doors",        title: "My Doors",       icon: "🖥️" },
-  { id: "dumpster",        title: "Dumpster",        icon: "🗑️" },
-  { id: "sound-recorder",  title: "Sound Recorder",  icon: "🎙️" },
+  { id: "my-doors",  title: "My Doors",  icon: "🖥️" },
+  { id: "dumpster",  title: "Dumpster",  icon: "🗑️" },
 ];
 
 const STATIC_RIGHT_ICONS: DesktopIconEntry[] = [

--- a/src/experiences/NsDoors97/SoundRecorder.css
+++ b/src/experiences/NsDoors97/SoundRecorder.css
@@ -1,0 +1,211 @@
+/* Sound Recorder — Win95 style */
+
+.sr {
+  background: #c0c0c0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 320px;
+  user-select: none;
+  position: relative;
+  font-family: "Press Start 2P", monospace;
+}
+
+/* ── Waveform display ── */
+
+.sr__display {
+  background: #000;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080; /* sunken */
+  position: relative;
+  height: 100px;
+  overflow: hidden;
+}
+
+.sr__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: crosshair;
+}
+
+.sr__rec-badge {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  color: #ff2200;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  animation: sr-blink 0.7s step-end infinite;
+  pointer-events: none;
+}
+
+@keyframes sr-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ── Tape controls ── */
+
+.sr__controls {
+  display: flex;
+  gap: 4px;
+  padding: 4px 2px;
+  justify-content: center;
+}
+
+.sr__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000000;
+  padding: 7px 12px;
+  cursor: pointer;
+  min-width: 52px;
+  text-align: center;
+  line-height: 1;
+}
+
+.sr__btn:active:not(:disabled),
+.sr__btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 8px 11px 6px 13px;
+}
+
+.sr__btn:disabled {
+  color: #808080;
+  cursor: default;
+}
+
+/* Play button — subtle highlight when playing */
+.sr__btn--play.sr__btn--active {
+  background: #d4d0c8;
+}
+
+/* Record button — red/orange accent */
+.sr__btn--rec {
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  color: #cc0000;
+  min-width: 60px;
+}
+
+.sr__btn--rec.sr__btn--active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+  background: #ffe8cc;
+  padding: 8px 11px 6px 13px;
+}
+
+/* ── Status bar ── */
+
+.sr__status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 5px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #ffffff;
+  font-size: 6px;
+  color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.sr__time     { flex: 0 0 auto; }
+.sr__filename { flex: 1; text-align: center; overflow: hidden; text-overflow: ellipsis; }
+.sr__msg      { flex: 0 0 auto; color: #444; }
+
+/* ── Dialogs ── */
+
+.sr__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.sr__dialog {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  min-width: 200px;
+  max-width: 280px;
+  display: flex;
+  flex-direction: column;
+}
+
+.sr__dialog-title {
+  background: linear-gradient(90deg, #000080, #1084d0);
+  color: #ffffff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 8px;
+}
+
+.sr__dialog-list {
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 6px;
+  background: #fff;
+}
+
+.sr__dialog-empty {
+  font-size: 6px;
+  color: #808080;
+  padding: 8px;
+  text-align: center;
+}
+
+.sr__dialog-item {
+  font-size: 7px;
+  padding: 4px 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sr__dialog-item:hover {
+  background: #000080;
+  color: #ffffff;
+}
+
+.sr__dialog-body {
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sr__label {
+  font-size: 7px;
+}
+
+.sr__input {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 3px 4px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #fff;
+  color: #000;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.sr__dialog-footer {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  padding: 4px 8px 8px;
+}

--- a/src/experiences/NsDoors97/SoundRecorder.tsx
+++ b/src/experiences/NsDoors97/SoundRecorder.tsx
@@ -55,6 +55,35 @@ async function idbListNames(): Promise<string[]> {
   });
 }
 
+// ── Draft (auto-save) helpers ─────────────────────────────────────────────────
+
+const DRAFT_KEY    = "__draft__";
+const LS_DRAFT_TS  = "ns97_sound_draft_ts";
+
+function saveDraftNow(samples: Float32Array, sr: number): void {
+  if (samples.length === 0) return;
+  localStorage.setItem(LS_DRAFT_TS, Date.now().toString());
+  idbSave(DRAFT_KEY, samples, sr).catch(() => {});
+}
+
+async function clearDraft(): Promise<void> {
+  localStorage.removeItem(LS_DRAFT_TS);
+  const db = await openIDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readwrite");
+    tx.objectStore(IDB_STORE).delete(DRAFT_KEY);
+    tx.oncomplete = () => { db.close(); resolve(); };
+    tx.onerror = () => { db.close(); reject(tx.error); };
+  });
+}
+
+function draftTimestamp(): string {
+  const raw = localStorage.getItem(LS_DRAFT_TS);
+  if (!raw) return "unknown time";
+  const d = new Date(parseInt(raw, 10));
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
 // ── localStorage: saved sound file names (for desktop icons) ──────────────────
 
 const LS_SOUNDS = "ns97_sound_names";
@@ -228,10 +257,12 @@ export default function SoundRecorder({
   const [statusMsg,   setStatusMsg]   = useState("Ready");
   const [displayPos,  setDisplayPos]  = useState(0);
   const [displayLen,  setDisplayLen]  = useState(0);
-  const [showOpenDlg,  setShowOpenDlg]  = useState(false);
-  const [openDlgFiles, setOpenDlgFiles] = useState<string[]>([]);
-  const [showSaveDlg,  setShowSaveDlg]  = useState(false);
-  const [saveDlgName,  setSaveDlgName]  = useState("Untitled.wav");
+  const [showOpenDlg,    setShowOpenDlg]    = useState(false);
+  const [openDlgFiles,   setOpenDlgFiles]   = useState<string[]>([]);
+  const [showSaveDlg,    setShowSaveDlg]    = useState(false);
+  const [saveDlgName,    setSaveDlgName]    = useState("Untitled.wav");
+  const [showRestoreDlg, setShowRestoreDlg] = useState(false);
+  const [draftTimeStr,   setDraftTimeStr]   = useState("");
 
   // Keep fileNameRef in sync so menu closures don't go stale
   useEffect(() => { fileNameRef.current = fileName; }, [fileName]);
@@ -367,20 +398,40 @@ export default function SoundRecorder({
     return () => obs.disconnect();
   }, [drawCanvas]);
 
-  // ── Load file on mount ────────────────────────────────────────────────────
+  // ── Load file on mount (or check for draft) ──────────────────────────────
 
   useEffect(() => {
-    if (!initFileName) return;
-    idbLoad(initFileName).then(result => {
-      if (!result) return;
-      samplesRef.current = result.samples;
-      srRef.current = result.sr;
-      playheadRef.current = 0;
-      setHasSamples(true);
-      setStatusMsg("File loaded");
-    }).catch(() => { setStatusMsg("Could not load file"); });
+    if (initFileName) {
+      // Opening a saved file — load it directly, ignore any draft
+      idbLoad(initFileName).then(result => {
+        if (!result) return;
+        samplesRef.current = result.samples;
+        srRef.current = result.sr;
+        playheadRef.current = 0;
+        setHasSamples(true);
+        setStatusMsg("File loaded");
+      }).catch(() => setStatusMsg("Could not load file"));
+    } else {
+      // Fresh session — check for an auto-saved draft
+      const ts = localStorage.getItem(LS_DRAFT_TS);
+      if (ts) {
+        setDraftTimeStr(draftTimestamp());
+        setShowRestoreDlg(true);
+      }
+    }
   // Run once on mount only
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Auto-save draft every 5 seconds ──────────────────────────────────────
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (samplesRef.current.length > 0) {
+        saveDraftNow(samplesRef.current, srRef.current);
+      }
+    }, 5000);
+    return () => clearInterval(id);
   }, []);
 
   // ── Playback ──────────────────────────────────────────────────────────────
@@ -431,6 +482,7 @@ export default function SoundRecorder({
     setIsRecording(false);
     setHasSamples(samplesRef.current.length > 0);
     setStatusMsg("Stopped");
+    saveDraftNow(samplesRef.current, srRef.current);
   }
 
   async function startRecord() {
@@ -534,6 +586,7 @@ export default function SoundRecorder({
     setHasSamples(false);
     setStatusMsg("New file");
     drawCanvas();
+    clearDraft().catch(() => {});
   }
 
   function handleOpenFile() {
@@ -591,6 +644,7 @@ export default function SoundRecorder({
       setHasSamples(true);
       setStatusMsg("File imported");
       drawCanvas();
+      saveDraftNow(mono, decoded.sampleRate);
     }).catch(() => setStatusMsg("Error importing file"));
     if (importInputRef.current) importInputRef.current.value = "";
   }
@@ -612,6 +666,7 @@ export default function SoundRecorder({
       setStatusMsg("Saved");
       onFileSaved?.(saveName);
       downloadWav(encodeWav(samplesRef.current, srRef.current), saveName);
+      clearDraft().catch(() => {});
     }).catch(() => setStatusMsg("Error saving"));
   }
 
@@ -625,6 +680,28 @@ export default function SoundRecorder({
     playheadRef.current = 0;
     setStatusMsg(`Applied: ${fx}`);
     drawCanvas();
+    saveDraftNow(samplesRef.current, srRef.current);
+  }
+
+  // ── Draft restore ─────────────────────────────────────────────────────────
+
+  function handleRestoreDraft() {
+    setShowRestoreDlg(false);
+    idbLoad(DRAFT_KEY).then(result => {
+      if (!result) { setStatusMsg("Draft not found"); return; }
+      samplesRef.current = result.samples;
+      srRef.current = result.sr;
+      playheadRef.current = 0;
+      setHasSamples(true);
+      setStatusMsg("Session restored");
+      drawCanvas();
+    }).catch(() => setStatusMsg("Could not restore draft"));
+  }
+
+  function handleDiscardDraft() {
+    setShowRestoreDlg(false);
+    clearDraft().catch(() => {});
+    setStatusMsg("Ready");
   }
 
   // ── Menus ─────────────────────────────────────────────────────────────────
@@ -736,6 +813,27 @@ export default function SoundRecorder({
         <span className="sr__filename">{fileName}</span>
         <span className="sr__msg">{statusMsg}</span>
       </div>
+
+      {/* Draft restore dialog */}
+      {showRestoreDlg && (
+        <div className="sr__overlay">
+          <div className="sr__dialog">
+            <div className="sr__dialog-title">Restore Session</div>
+            <div className="sr__dialog-body">
+              <label className="sr__label">
+                Unsaved work found from {draftTimeStr}.
+              </label>
+              <label className="sr__label" style={{ color: "#808080" }}>
+                Restore it?
+              </label>
+            </div>
+            <div className="sr__dialog-footer">
+              <button className="sr__btn" onClick={handleRestoreDraft}>Restore</button>
+              <button className="sr__btn" onClick={handleDiscardDraft}>Discard</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Open File dialog */}
       {showOpenDlg && (

--- a/src/experiences/NsDoors97/SoundRecorder.tsx
+++ b/src/experiences/NsDoors97/SoundRecorder.tsx
@@ -1,0 +1,793 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import "./SoundRecorder.css";
+
+// ── IndexedDB helpers ──────────────────────────────────────────────────────────
+
+const IDB_NAME = "ns97_sounds";
+const IDB_STORE = "files";
+
+function openIDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(IDB_STORE))
+        req.result.createObjectStore(IDB_STORE, { keyPath: "name" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbSave(name: string, samples: Float32Array, sr: number): Promise<void> {
+  const db = await openIDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readwrite");
+    tx.objectStore(IDB_STORE).put({ name, sr, buf: samples.slice().buffer });
+    tx.oncomplete = () => { db.close(); resolve(); };
+    tx.onerror = () => { db.close(); reject(tx.error); };
+  });
+}
+
+async function idbLoad(name: string): Promise<{ samples: Float32Array; sr: number } | null> {
+  const db = await openIDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readonly");
+    const req = tx.objectStore(IDB_STORE).get(name);
+    req.onsuccess = () => {
+      db.close();
+      if (!req.result) { resolve(null); return; }
+      const r = req.result as { name: string; sr: number; buf: ArrayBuffer };
+      resolve({ samples: new Float32Array(r.buf), sr: r.sr });
+    };
+    req.onerror = () => { db.close(); reject(req.error); };
+  });
+}
+
+async function idbListNames(): Promise<string[]> {
+  const db = await openIDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readonly");
+    const req = tx.objectStore(IDB_STORE).getAllKeys();
+    req.onsuccess = () => { db.close(); resolve(req.result as string[]); };
+    req.onerror = () => { db.close(); reject(req.error); };
+  });
+}
+
+// ── localStorage: saved sound file names (for desktop icons) ──────────────────
+
+const LS_SOUNDS = "ns97_sound_names";
+
+export function lsGetSoundNames(): string[] {
+  try { return JSON.parse(localStorage.getItem(LS_SOUNDS) ?? "[]") as string[]; }
+  catch { return []; }
+}
+
+function lsAddSoundName(name: string): void {
+  const names = lsGetSoundNames();
+  if (!names.includes(name)) {
+    localStorage.setItem(LS_SOUNDS, JSON.stringify([...names, name]));
+  }
+}
+
+// ── WAV export: 8-bit, 8 kHz, mono (authentic lo-fi) ─────────────────────────
+
+function encodeWav(samples: Float32Array, inputSr: number): ArrayBuffer {
+  const outSr = 8000;
+  const ratio = inputSr / outSr;
+  const outLen = Math.max(1, Math.floor(samples.length / ratio));
+  const pcm = new Uint8Array(outLen);
+  for (let i = 0; i < outLen; i++) {
+    const s = samples[Math.floor(i * ratio)] ?? 0;
+    pcm[i] = Math.max(0, Math.min(255, Math.round((s + 1) * 127.5)));
+  }
+  const buf = new ArrayBuffer(44 + outLen);
+  const v = new DataView(buf);
+  const ws = (o: number, s: string) => { for (let i = 0; i < s.length; i++) v.setUint8(o + i, s.charCodeAt(i)); };
+  ws(0, "RIFF"); v.setUint32(4, 36 + outLen, true); ws(8, "WAVE");
+  ws(12, "fmt "); v.setUint32(16, 16, true); v.setUint16(20, 1, true);
+  v.setUint16(22, 1, true); v.setUint32(24, outSr, true); v.setUint32(28, outSr, true);
+  v.setUint16(32, 1, true); v.setUint16(34, 8, true);
+  ws(36, "data"); v.setUint32(40, outLen, true);
+  new Uint8Array(buf, 44).set(pcm);
+  return buf;
+}
+
+function downloadWav(buf: ArrayBuffer, filename: string): void {
+  const blob = new Blob([buf], { type: "audio/wav" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = filename; a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+// ── Effects (all-or-nothing on full buffer) ───────────────────────────────────
+
+function runEffect(samples: Float32Array, sr: number, fx: string): Float32Array {
+  if (samples.length === 0) return samples;
+  switch (fx) {
+    case "speed-up": {
+      const out = new Float32Array(Math.floor(samples.length / 2));
+      for (let i = 0; i < out.length; i++) out[i] = samples[i * 2];
+      return out;
+    }
+    case "slow-down": {
+      const out = new Float32Array(samples.length * 2);
+      for (let i = 0; i < samples.length; i++) { out[i * 2] = samples[i]; out[i * 2 + 1] = samples[i]; }
+      return out;
+    }
+    case "vol-up": {
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = samples[i] * 1.5;
+      return out;
+    }
+    case "vol-down": {
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = samples[i] * 0.5;
+      return out;
+    }
+    case "reverse": {
+      const out = new Float32Array(samples);
+      out.reverse();
+      return out;
+    }
+    case "distortion": {
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = Math.max(-1, Math.min(1, samples[i] * 4));
+      return out;
+    }
+    case "normalize": {
+      let peak = 0;
+      for (let i = 0; i < samples.length; i++) { const a = Math.abs(samples[i]); if (a > peak) peak = a; }
+      if (peak < 1e-6) return samples;
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = samples[i] / peak;
+      return out;
+    }
+    case "echo": {
+      const delay = Math.round(sr * 0.2);
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) {
+        out[i] = samples[i] + (i >= delay ? samples[i - delay] * 0.5 : 0);
+      }
+      return out;
+    }
+    case "fade-in": {
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = samples[i] * (i / samples.length);
+      return out;
+    }
+    case "fade-out": {
+      const out = new Float32Array(samples.length);
+      for (let i = 0; i < samples.length; i++) out[i] = samples[i] * (1 - i / samples.length);
+      return out;
+    }
+    default: return samples;
+  }
+}
+
+// ── Time formatting ───────────────────────────────────────────────────────────
+
+function fmtTime(samplePos: number, sr: number): string {
+  const secs = sr > 0 ? samplePos / sr : 0;
+  const m = Math.floor(secs / 60).toString().padStart(2, "0");
+  const s = Math.floor(secs % 60).toString().padStart(2, "0");
+  const ds = Math.floor((secs % 1) * 10).toString();
+  return `${m}:${s}.${ds}`;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export interface SoundRecorderProps {
+  fileName?: string;
+  onQuit?: () => void;
+  onFileSaved?: (name: string) => void;
+}
+
+export default function SoundRecorder({
+  fileName: initFileName,
+  onQuit,
+  onFileSaved,
+}: SoundRecorderProps = {}) {
+
+  // ── Audio refs (mutated directly for real-time performance) ───────────────
+  const audioCtxRef    = useRef<AudioContext | null>(null);
+  const samplesRef     = useRef<Float32Array>(new Float32Array(0));
+  const srRef          = useRef<number>(44100); // sample rate
+  const playheadRef    = useRef<number>(0);     // position in samples
+  const isPlayingRef   = useRef<boolean>(false);
+  const isRecordingRef = useRef<boolean>(false);
+  const priorLenRef    = useRef<number>(0);     // samples.length before recording started
+  const recWriteRef    = useRef<number>(0);     // write position during recording
+
+  // Playback refs
+  const pbSourceRef    = useRef<AudioBufferSourceNode | null>(null);
+  const pbStartCtxRef  = useRef<number>(0);  // audioCtx.currentTime when play started
+  const pbStartSmpRef  = useRef<number>(0);  // sample index when play started
+
+  // Recording refs
+  const micStreamRef   = useRef<MediaStream | null>(null);
+  const micSrcRef      = useRef<MediaStreamAudioSourceNode | null>(null);
+  const spnRef         = useRef<ScriptProcessorNode | null>(null);
+  const silencerRef    = useRef<GainNode | null>(null);
+
+  // UI refs
+  const canvasRef      = useRef<HTMLCanvasElement>(null);
+  const rafRef         = useRef<number>(0);
+  const rwdTimerRef    = useRef<ReturnType<typeof setInterval> | null>(null);
+  const fwdTimerRef    = useRef<ReturnType<typeof setInterval> | null>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const fileNameRef    = useRef<string>(initFileName ?? "Untitled.wav");
+
+  // ── React state (only for UI rendering) ──────────────────────────────────
+  const [isPlaying,   setIsPlaying]   = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [hasSamples,  setHasSamples]  = useState(false);
+  const [fileName,    setFileName]    = useState(initFileName ?? "Untitled.wav");
+  const [statusMsg,   setStatusMsg]   = useState("Ready");
+  const [displayPos,  setDisplayPos]  = useState(0);
+  const [displayLen,  setDisplayLen]  = useState(0);
+  const [showOpenDlg,  setShowOpenDlg]  = useState(false);
+  const [openDlgFiles, setOpenDlgFiles] = useState<string[]>([]);
+  const [showSaveDlg,  setShowSaveDlg]  = useState(false);
+  const [saveDlgName,  setSaveDlgName]  = useState("Untitled.wav");
+
+  // Keep fileNameRef in sync so menu closures don't go stale
+  useEffect(() => { fileNameRef.current = fileName; }, [fileName]);
+
+  // ── AudioContext ──────────────────────────────────────────────────────────
+
+  function ensureCtx(): AudioContext {
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new AudioContext();
+      srRef.current = audioCtxRef.current.sampleRate;
+    }
+    if (audioCtxRef.current.state === "suspended") {
+      audioCtxRef.current.resume().catch(() => {});
+    }
+    return audioCtxRef.current;
+  }
+
+  // ── Canvas drawing ────────────────────────────────────────────────────────
+
+  const drawCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx2d = canvas.getContext("2d");
+    if (!ctx2d) return;
+    const W = canvas.width;
+    const H = canvas.height;
+
+    ctx2d.fillStyle = "#000000";
+    ctx2d.fillRect(0, 0, W, H);
+
+    const samples = samplesRef.current;
+
+    if (samples.length === 0) {
+      ctx2d.strokeStyle = "#003300";
+      ctx2d.lineWidth = 1;
+      ctx2d.beginPath();
+      ctx2d.moveTo(0, H / 2);
+      ctx2d.lineTo(W, H / 2);
+      ctx2d.stroke();
+    } else {
+      const samplesPerPx = samples.length / W;
+      ctx2d.strokeStyle = "#00bb00";
+      ctx2d.lineWidth = 1;
+      for (let x = 0; x < W; x++) {
+        const s0 = Math.floor(x * samplesPerPx);
+        const s1 = Math.min(samples.length - 1, Math.floor((x + 1) * samplesPerPx));
+        let lo = 1, hi = -1;
+        for (let i = s0; i <= s1; i++) {
+          if (samples[i] < lo) lo = samples[i];
+          if (samples[i] > hi) hi = samples[i];
+        }
+        const yHi = Math.round((1 - (hi + 1) * 0.5) * H);
+        const yLo = Math.round((1 - (lo + 1) * 0.5) * H);
+        ctx2d.beginPath();
+        ctx2d.moveTo(x + 0.5, yHi);
+        ctx2d.lineTo(x + 0.5, yLo + 1);
+        ctx2d.stroke();
+      }
+
+      // Playhead
+      const phX = Math.round((playheadRef.current / samples.length) * W);
+      ctx2d.strokeStyle = "#ffffff";
+      ctx2d.lineWidth = 1;
+      ctx2d.beginPath();
+      ctx2d.moveTo(phX + 0.5, 0);
+      ctx2d.lineTo(phX + 0.5, H);
+      ctx2d.stroke();
+    }
+  }, []);
+
+  // ── RAF loop ──────────────────────────────────────────────────────────────
+
+  const stopPlay = useCallback(() => {
+    if (!isPlayingRef.current) return;
+    isPlayingRef.current = false;
+    setIsPlaying(false);
+    try { pbSourceRef.current?.stop(); } catch { /* already stopped */ }
+    pbSourceRef.current = null;
+    setStatusMsg("Stopped");
+  }, []);
+
+  const startRAF = useCallback(() => {
+    const tick = () => {
+      if (isPlayingRef.current && audioCtxRef.current) {
+        const elapsed = (audioCtxRef.current.currentTime - pbStartCtxRef.current) * srRef.current;
+        playheadRef.current = pbStartSmpRef.current + elapsed;
+        if (playheadRef.current >= samplesRef.current.length) {
+          playheadRef.current = samplesRef.current.length;
+          stopPlay();
+        }
+      } else if (isRecordingRef.current) {
+        playheadRef.current = recWriteRef.current;
+      }
+      setDisplayPos(Math.round(playheadRef.current));
+      setDisplayLen(samplesRef.current.length);
+      drawCanvas();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [drawCanvas, stopPlay]);
+
+  // ── Mount / unmount ───────────────────────────────────────────────────────
+
+  useEffect(() => {
+    startRAF();
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      try { pbSourceRef.current?.stop(); } catch { /* ok */ }
+      spnRef.current?.disconnect();
+      micSrcRef.current?.disconnect();
+      silencerRef.current?.disconnect();
+      micStreamRef.current?.getTracks().forEach(t => t.stop());
+      if (rwdTimerRef.current) clearInterval(rwdTimerRef.current);
+      if (fwdTimerRef.current) clearInterval(fwdTimerRef.current);
+      audioCtxRef.current?.close().catch(() => {});
+    };
+  }, [startRAF]);
+
+  // ── Canvas resize ─────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = canvas.offsetWidth;
+    canvas.height = canvas.offsetHeight;
+    drawCanvas();
+    const obs = new ResizeObserver(() => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+      drawCanvas();
+    });
+    obs.observe(canvas);
+    return () => obs.disconnect();
+  }, [drawCanvas]);
+
+  // ── Load file on mount ────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!initFileName) return;
+    idbLoad(initFileName).then(result => {
+      if (!result) return;
+      samplesRef.current = result.samples;
+      srRef.current = result.sr;
+      playheadRef.current = 0;
+      setHasSamples(true);
+      setStatusMsg("File loaded");
+    }).catch(() => { setStatusMsg("Could not load file"); });
+  // Run once on mount only
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Playback ──────────────────────────────────────────────────────────────
+
+  function startPlay() {
+    if (samplesRef.current.length === 0) return;
+    const ctx = ensureCtx();
+    const startSmp = Math.min(playheadRef.current, samplesRef.current.length - 1);
+    const slice = samplesRef.current.subarray(startSmp);
+    const ab = ctx.createBuffer(1, slice.length, srRef.current);
+    ab.getChannelData(0).set(slice);
+    const source = ctx.createBufferSource();
+    source.buffer = ab;
+    source.connect(ctx.destination);
+    source.onended = () => { if (isPlayingRef.current) stopPlay(); };
+    pbSourceRef.current = source;
+    pbStartCtxRef.current = ctx.currentTime;
+    pbStartSmpRef.current = startSmp;
+    isPlayingRef.current = true;
+    setIsPlaying(true);
+    setStatusMsg("Playing...");
+    source.start();
+  }
+
+  function togglePlayPause() {
+    if (isPlayingRef.current) { stopPlay(); } else { startPlay(); }
+  }
+
+  // ── Recording ─────────────────────────────────────────────────────────────
+
+  function stopRecord() {
+    if (!isRecordingRef.current) return;
+    isRecordingRef.current = false;
+
+    const finalLen = Math.max(recWriteRef.current, priorLenRef.current);
+    if (samplesRef.current.length > finalLen) {
+      samplesRef.current = samplesRef.current.slice(0, finalLen);
+    }
+    playheadRef.current = recWriteRef.current;
+
+    spnRef.current?.disconnect();
+    micSrcRef.current?.disconnect();
+    silencerRef.current?.disconnect();
+    micStreamRef.current?.getTracks().forEach(t => t.stop());
+    spnRef.current = null; micSrcRef.current = null;
+    silencerRef.current = null; micStreamRef.current = null;
+
+    setIsRecording(false);
+    setHasSamples(samplesRef.current.length > 0);
+    setStatusMsg("Stopped");
+  }
+
+  async function startRecord() {
+    if (isPlayingRef.current) stopPlay();
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      const ctx = ensureCtx();
+      micStreamRef.current = stream;
+      const src = ctx.createMediaStreamSource(stream);
+      micSrcRef.current = src;
+      const spn = ctx.createScriptProcessor(4096, 1, 1);
+      spnRef.current = spn;
+      // GainNode at 0 prevents microphone feedback through speakers
+      const silence = ctx.createGain();
+      silence.gain.value = 0;
+      silencerRef.current = silence;
+      src.connect(spn);
+      spn.connect(silence);
+      silence.connect(ctx.destination);
+
+      priorLenRef.current = samplesRef.current.length;
+      recWriteRef.current = Math.round(playheadRef.current);
+      isRecordingRef.current = true;
+      setIsRecording(true);
+      setHasSamples(true);
+      setStatusMsg("Recording...");
+
+      spn.onaudioprocess = (e: AudioProcessingEvent) => {
+        if (!isRecordingRef.current) return;
+        const input = e.inputBuffer.getChannelData(0);
+        const writePos = recWriteRef.current;
+        const needed = writePos + input.length;
+        if (needed > samplesRef.current.length) {
+          const newLen = Math.max(needed, samplesRef.current.length + srRef.current * 2);
+          const grown = new Float32Array(newLen);
+          grown.set(samplesRef.current);
+          samplesRef.current = grown;
+        }
+        samplesRef.current.set(input, writePos);
+        recWriteRef.current += input.length;
+      };
+    } catch {
+      setStatusMsg("Mic access denied");
+    }
+  }
+
+  function toggleRecord() {
+    if (isRecordingRef.current) { stopRecord(); } else { startRecord().catch(() => {}); }
+  }
+
+  // ── Scrub (hold to move at ~4× speed) ────────────────────────────────────
+
+  const scrubAmount = () => Math.round(srRef.current * 4 * 0.04); // 4× at 25 fps
+
+  function startScrubRwd() {
+    if (isPlayingRef.current) stopPlay();
+    if (isRecordingRef.current) stopRecord();
+    if (rwdTimerRef.current) return;
+    rwdTimerRef.current = setInterval(() => {
+      playheadRef.current = Math.max(0, playheadRef.current - scrubAmount());
+      if (playheadRef.current === 0) stopScrubRwd();
+    }, 40);
+  }
+  function stopScrubRwd() {
+    if (rwdTimerRef.current) { clearInterval(rwdTimerRef.current); rwdTimerRef.current = null; }
+  }
+
+  function startScrubFwd() {
+    if (isPlayingRef.current) stopPlay();
+    if (isRecordingRef.current) stopRecord();
+    if (fwdTimerRef.current) return;
+    fwdTimerRef.current = setInterval(() => {
+      const maxPos = samplesRef.current.length;
+      playheadRef.current = Math.min(maxPos, playheadRef.current + scrubAmount());
+      if (playheadRef.current >= maxPos) stopScrubFwd();
+    }, 40);
+  }
+  function stopScrubFwd() {
+    if (fwdTimerRef.current) { clearInterval(fwdTimerRef.current); fwdTimerRef.current = null; }
+  }
+
+  // ── Canvas click — reposition playhead ───────────────────────────────────
+
+  function handleCanvasClick(e: React.MouseEvent<HTMLCanvasElement>) {
+    const canvas = canvasRef.current;
+    if (!canvas || samplesRef.current.length === 0) return;
+    if (isPlayingRef.current) stopPlay();
+    const rect = canvas.getBoundingClientRect();
+    playheadRef.current = Math.round(((e.clientX - rect.left) / rect.width) * samplesRef.current.length);
+  }
+
+  // ── File operations ───────────────────────────────────────────────────────
+
+  function handleNewFile() {
+    if (isPlayingRef.current) stopPlay();
+    if (isRecordingRef.current) stopRecord();
+    samplesRef.current = new Float32Array(0);
+    playheadRef.current = 0;
+    setFileName("Untitled.wav");
+    fileNameRef.current = "Untitled.wav";
+    setHasSamples(false);
+    setStatusMsg("New file");
+    drawCanvas();
+  }
+
+  function handleOpenFile() {
+    idbListNames().then(names => {
+      setOpenDlgFiles(names);
+      setShowOpenDlg(true);
+    }).catch(() => setStatusMsg("Error reading saved files"));
+  }
+
+  function handleOpenFileSelect(name: string) {
+    setShowOpenDlg(false);
+    idbLoad(name).then(result => {
+      if (!result) { setStatusMsg("File not found"); return; }
+      if (isPlayingRef.current) stopPlay();
+      if (isRecordingRef.current) stopRecord();
+      samplesRef.current = result.samples;
+      srRef.current = result.sr;
+      playheadRef.current = 0;
+      setFileName(name);
+      fileNameRef.current = name;
+      setHasSamples(true);
+      setStatusMsg("File loaded");
+      drawCanvas();
+    }).catch(() => setStatusMsg("Error loading file"));
+  }
+
+  function handleImportFile() {
+    importInputRef.current?.click();
+  }
+
+  function handleImportChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.arrayBuffer().then(rawBuf => {
+      const ctx = ensureCtx();
+      return ctx.decodeAudioData(rawBuf);
+    }).then(decoded => {
+      // Mix down to mono
+      const mono = new Float32Array(decoded.length);
+      for (let ch = 0; ch < decoded.numberOfChannels; ch++) {
+        const chData = decoded.getChannelData(ch);
+        for (let i = 0; i < decoded.length; i++) mono[i] += chData[i];
+      }
+      if (decoded.numberOfChannels > 1) {
+        for (let i = 0; i < mono.length; i++) mono[i] /= decoded.numberOfChannels;
+      }
+      if (isPlayingRef.current) stopPlay();
+      if (isRecordingRef.current) stopRecord();
+      samplesRef.current = mono;
+      srRef.current = decoded.sampleRate;
+      playheadRef.current = 0;
+      const name = file.name.replace(/\.[^.]+$/, ".wav");
+      setFileName(name);
+      fileNameRef.current = name;
+      setHasSamples(true);
+      setStatusMsg("File imported");
+      drawCanvas();
+    }).catch(() => setStatusMsg("Error importing file"));
+    if (importInputRef.current) importInputRef.current.value = "";
+  }
+
+  function handleSaveFile() {
+    setSaveDlgName(fileNameRef.current);
+    setShowSaveDlg(true);
+  }
+
+  function confirmSave() {
+    const name = saveDlgName.trim();
+    if (!name) return;
+    const saveName = name.endsWith(".wav") ? name : `${name}.wav`;
+    setShowSaveDlg(false);
+    idbSave(saveName, samplesRef.current, srRef.current).then(() => {
+      lsAddSoundName(saveName);
+      setFileName(saveName);
+      fileNameRef.current = saveName;
+      setStatusMsg("Saved");
+      onFileSaved?.(saveName);
+      downloadWav(encodeWav(samplesRef.current, srRef.current), saveName);
+    }).catch(() => setStatusMsg("Error saving"));
+  }
+
+  // ── Effects ───────────────────────────────────────────────────────────────
+
+  function applyFx(fx: string) {
+    if (samplesRef.current.length === 0) return;
+    if (isPlayingRef.current) stopPlay();
+    if (isRecordingRef.current) stopRecord();
+    samplesRef.current = runEffect(samplesRef.current, srRef.current, fx);
+    playheadRef.current = 0;
+    setStatusMsg(`Applied: ${fx}`);
+    drawCanvas();
+  }
+
+  // ── Menus ─────────────────────────────────────────────────────────────────
+
+  const menus = useMemo<MenuBarMenu[]>(() => [
+    {
+      label: "File",
+      items: [
+        { label: "New File",    onClick: handleNewFile },
+        { separator: true },
+        { label: "Open File",   onClick: handleOpenFile },
+        { label: "Import File", onClick: handleImportFile },
+        { separator: true },
+        { label: "Save File",   onClick: handleSaveFile, disabled: !hasSamples },
+        { separator: true },
+        { label: "Exit",        onClick: onQuit },
+      ],
+    },
+    {
+      label: "Effects",
+      items: [
+        { label: "Speed ×2",    onClick: () => applyFx("speed-up"),   disabled: !hasSamples },
+        { label: "Speed ÷2",    onClick: () => applyFx("slow-down"),  disabled: !hasSamples },
+        { separator: true },
+        { label: "Volume Up",   onClick: () => applyFx("vol-up"),     disabled: !hasSamples },
+        { label: "Volume Down", onClick: () => applyFx("vol-down"),   disabled: !hasSamples },
+        { separator: true },
+        { label: "Reverse",     onClick: () => applyFx("reverse"),    disabled: !hasSamples },
+        { label: "Distortion",  onClick: () => applyFx("distortion"), disabled: !hasSamples },
+        { separator: true },
+        { label: "Normalize",   onClick: () => applyFx("normalize"),  disabled: !hasSamples },
+        { label: "Echo",        onClick: () => applyFx("echo"),       disabled: !hasSamples },
+        { separator: true },
+        { label: "Fade In",     onClick: () => applyFx("fade-in"),    disabled: !hasSamples },
+        { label: "Fade Out",    onClick: () => applyFx("fade-out"),   disabled: !hasSamples },
+      ],
+    },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [hasSamples, onQuit]);
+
+  useWindowMenus(menus);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const sr = srRef.current;
+
+  return (
+    <div className="sr">
+      {/* Hidden import input */}
+      <input
+        ref={importInputRef}
+        type="file"
+        accept="audio/*"
+        style={{ display: "none" }}
+        onChange={handleImportChange}
+      />
+
+      {/* Waveform display */}
+      <div className="sr__display">
+        <canvas
+          ref={canvasRef}
+          className="sr__canvas"
+          onClick={handleCanvasClick}
+          title="Click to move playhead"
+        />
+        {isRecording && <div className="sr__rec-badge">● REC</div>}
+      </div>
+
+      {/* Tape controls */}
+      <div className="sr__controls">
+        <button
+          className="sr__btn"
+          onPointerDown={startScrubRwd}
+          onPointerUp={stopScrubRwd}
+          onPointerLeave={stopScrubRwd}
+          title="Hold to rewind"
+        >
+          ◀◀
+        </button>
+        <button
+          className="sr__btn"
+          onPointerDown={startScrubFwd}
+          onPointerUp={stopScrubFwd}
+          onPointerLeave={stopScrubFwd}
+          title="Hold to fast-forward"
+        >
+          ▶▶
+        </button>
+        <button
+          className={`sr__btn sr__btn--play${isPlaying ? " sr__btn--active" : ""}`}
+          onClick={togglePlayPause}
+          disabled={!hasSamples}
+          title={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? "‖" : "▶"}
+        </button>
+        <button
+          className={`sr__btn sr__btn--rec${isRecording ? " sr__btn--active" : ""}`}
+          onClick={toggleRecord}
+          title={isRecording ? "Stop Recording" : "Record"}
+        >
+          ●
+        </button>
+      </div>
+
+      {/* Status bar */}
+      <div className="sr__status">
+        <span className="sr__time">{fmtTime(displayPos, sr)} / {fmtTime(displayLen, sr)}</span>
+        <span className="sr__filename">{fileName}</span>
+        <span className="sr__msg">{statusMsg}</span>
+      </div>
+
+      {/* Open File dialog */}
+      {showOpenDlg && (
+        <div className="sr__overlay">
+          <div className="sr__dialog">
+            <div className="sr__dialog-title">Open Sound File</div>
+            <div className="sr__dialog-list">
+              {openDlgFiles.length === 0
+                ? <div className="sr__dialog-empty">No saved files found.</div>
+                : openDlgFiles.map(n => (
+                  <div
+                    key={n}
+                    className="sr__dialog-item"
+                    onClick={() => handleOpenFileSelect(n)}
+                  >
+                    🎵 {n}
+                  </div>
+                ))
+              }
+            </div>
+            <div className="sr__dialog-footer">
+              <button className="sr__btn" onClick={() => setShowOpenDlg(false)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Save File dialog */}
+      {showSaveDlg && (
+        <div className="sr__overlay">
+          <div className="sr__dialog">
+            <div className="sr__dialog-title">Save Sound File</div>
+            <div className="sr__dialog-body">
+              <label className="sr__label">File name:</label>
+              <input
+                className="sr__input"
+                value={saveDlgName}
+                onChange={e => setSaveDlgName(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === "Enter") confirmSave();
+                  if (e.key === "Escape") setShowSaveDlg(false);
+                }}
+                autoFocus
+              />
+            </div>
+            <div className="sr__dialog-footer">
+              <button className="sr__btn" onClick={confirmSave}>Save</button>
+              <button className="sr__btn" onClick={() => setShowSaveDlg(false)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -110,8 +110,9 @@ const GAMES_ITEMS = [
 ] as const;
 
 const TOOLS_ITEMS = [
-  { id: "notebook", icon: "📝", label: "Notebook" },
-  { id: "ns-art",   icon: "🎨", label: "NS Art"   },
+  { id: "notebook",       icon: "📝", label: "Notebook"       },
+  { id: "ns-art",         icon: "🎨", label: "NS Art"          },
+  { id: "sound-recorder", icon: "🎙️", label: "Sound Recorder" },
 ] as const;
 
 type OpenSubmenu = "games" | "tools" | "settings" | null;


### PR DESCRIPTION
Full cassette-tape-style audio recorder integrated into the fake OS:

- Black waveform display with green PCM overview; click to reposition playhead
- Hold-to-scrub rewind/fast-forward at ~4× speed
- Play/Pause toggle and Record button with blinking REC badge
- Real-time PCM capture via ScriptProcessorNode (overwrite at playhead
  position like a cassette — records over existing audio, extends if needed)
- File > New / Open / Import (decodes any browser-supported audio) / Save
- Save encodes lo-fi 8-bit 8 kHz mono WAV for download AND persists the
  file to IndexedDB; adds an icon to the NS Doors 97 virtual desktop
- Effects menu (all-or-nothing on full buffer): Speed ×2/÷2, Volume Up/Down,
  Reverse, Distortion, Normalize, Echo, Fade In, Fade Out
- Win95 beveled chrome, Press Start 2P font, orange record button accent

https://claude.ai/code/session_01FDLWLGXhnh2miS284KN2CD