### PR TITLE
Add basic MIDI editor — piano roll + step sequencer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import NsArtPage from "./pages/NsArtPage";
 import HellPage from "./pages/HellzonePage";
 import ComponentTestPage from "./pages/ComponentTestPage";
 import PoolPage from "./pages/PoolPage";
+import MidiEditorPage from "./pages/MidiEditorPage";
 
 export default function App() {
   return (
@@ -42,6 +43,7 @@ export default function App() {
         <Route path="/art" element={<NsArtPage />} />
         <Route path="/hell" element={<HellPage />} />
         <Route path="/pool" element={<PoolPage />} />
+        <Route path="/midi-editor" element={<MidiEditorPage />} />
         <Route path="/component-test" element={<ComponentTestPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -126,4 +126,11 @@ export const experiences: Experience[] = [
     category: "toy",
     path: "/art",
   },
+  {
+    id: "midi-editor",
+    title: "MIDI Editor",
+    description: "A retro piano roll and step sequencer. Draw melodies, program drums, and play them back.",
+    category: "toy",
+    path: "/midi-editor",
+  },
 ];

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -51,7 +51,7 @@
   color: #555;
 }
 
-/* Win95 buttons */
+/* ── Win95 buttons ─────────────────────────────────────────────────────────── */
 .me-btn {
   background: #c0c0c0;
   border: 2px solid;
@@ -93,6 +93,16 @@
   background: #d4d0c8;
 }
 
+.me-btn--primary {
+  background: #c0d8f0;
+  border-color: #ffffff #4060a0 #4060a0 #ffffff;
+}
+
+.me-btn--danger {
+  background: #f0c0c0;
+  border-color: #ffffff #a04040 #a04040 #ffffff;
+}
+
 .me-num-input {
   background: #ffffff;
   border: 2px solid;
@@ -121,45 +131,17 @@
   cursor: pointer;
 }
 
-/* Track tab buttons */
-.me-track-btn {
-  background: #c0c0c0;
-  border: 2px solid;
-  border-color: #ffffff #808080 #808080 #ffffff;
-  color: #000;
-  font-family: "Press Start 2P", monospace;
-  font-size: 7px;
-  cursor: pointer;
-  padding: 3px 6px;
-}
-
-.me-track-btn::before {
-  content: '';
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  background: var(--track-color);
-  margin-right: 4px;
-  border: 1px solid #000;
-  vertical-align: middle;
-}
-
-.me-track-btn--active {
-  border-color: #808080 #ffffff #ffffff #808080;
-  background: #d4d0c8;
-}
-
 /* Mute buttons */
 .me-mute-btn {
-  background: var(--track-color);
+  background: var(--tcolor, #c89000);
   border: 2px solid;
   border-color: #ffffff #808080 #808080 #ffffff;
   color: #fff;
   font-family: "Press Start 2P", monospace;
   font-size: 7px;
   cursor: pointer;
-  padding: 3px 5px;
-  min-width: 22px;
+  padding: 2px 4px;
+  min-width: 18px;
   text-align: center;
   text-shadow: 1px 1px 0 #000;
 }
@@ -171,67 +153,226 @@
   text-decoration: line-through;
 }
 
-/* ── Body layout ───────────────────────────────────────────────────────────── */
-.me-body {
+/* ── Main scrollable area (single 2D-sticky container) ─────────────────────── */
+.me-outer {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
   min-height: 0;
 }
 
-.me-section-label {
+/* Content column — position:relative anchors the absolute playhead */
+.me-inner {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+/* ── Time ruler (sticky top) ───────────────────────────────────────────────── */
+.me-ruler {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: row;
   flex-shrink: 0;
   background: #d4d0c8;
   border-bottom: 1px solid #808080;
-  padding: 2px 6px;
-  font-size: 6px;
-  color: #444;
-  letter-spacing: 1px;
 }
 
-/* Wrapper: passes height down into the piano roll */
-.me-piano-roll-wrap {
-  flex: 1;
-  display: flex;
-  overflow: hidden;
-  min-height: 0;
-}
-
-/* ── Piano Roll — split layout ─────────────────────────────────────────────── */
-/*
-  Row flex: [keys-col (fixed, 42px)] [grid-h-scroll (flex:1)]
-  keys-col:    piano keys (overflow:hidden, scroll-synced) + drum labels (fixed)
-  grid-h-scroll: overflows-x; inside: melodic grid (v-scroll, flex:1) + drum grid (fixed)
-  The drum section is always visible — no vertical scrolling required to reach it.
-*/
-
-.me-piano-roll {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  overflow: hidden;
-  min-height: 0;
-}
-
-/* Left sidebar: always visible, never scrolls horizontally */
-.me-keys-col {
+/* Corner cell: sticky in both axes (top + left) */
+.me-ruler-corner {
+  position: sticky;
+  left: 0;
+  z-index: 6;
   flex-shrink: 0;
-  width: 42px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
   background: #d4d0c8;
   border-right: 2px solid #808080;
 }
 
-/* Piano keys area — overflow hidden; scrollTop driven by JS scroll-sync */
-.me-keys-scroll {
-  flex: 1;
-  overflow: hidden;
-  min-height: 0;
+/* Ruler steps area — marks are absolutely positioned inside */
+.me-ruler-steps {
+  position: relative;
+  flex-shrink: 0;
 }
 
+.me-ruler-mark {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  padding-left: 2px;
+  font-size: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.me-ruler-mark--bar {
+  border-left: 2px solid #484440;
+  color: #000;
+}
+
+.me-ruler-mark--beat {
+  border-left: 1px solid #888880;
+  color: #999;
+  font-size: 5px;
+}
+
+/* ── Track sections (accordion) ────────────────────────────────────────────── */
+.me-track-section {
+  flex-shrink: 0;
+  border-bottom: 1px solid #808080;
+}
+
+/* Header row: sticky-left controls + tinted fill */
+.me-track-header-row {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  flex-shrink: 0;
+}
+
+.me-track-header-left {
+  position: sticky;
+  left: 0;
+  z-index: 4;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 4px;
+  background: #c0c0c0;
+  border-right: 2px solid #808080;
+  border-bottom: 1px solid #606060;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.me-track-header-fill {
+  flex-shrink: 0;
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+}
+
+.me-track-collapse {
+  background: none;
+  border: 1px solid #808080;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  cursor: pointer;
+  padding: 1px 3px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.me-track-collapse:hover { background: #d4d0c8; }
+
+.me-track-color-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border: 1px solid rgba(0,0,0,0.4);
+}
+
+.me-track-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 6px;
+  color: #000;
+}
+
+.me-track-header-btns {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.me-icon-btn {
+  background: none;
+  border: 1px solid #808080;
+  color: #000;
+  font-size: 8px;
+  cursor: pointer;
+  padding: 1px 3px;
+  line-height: 1;
+  font-family: monospace;
+}
+
+.me-icon-btn:hover { background: #d4d0c8; }
+
+.me-icon-btn--del { color: #a04040; }
+.me-icon-btn--del:hover { background: #f0c0c0; }
+
+/* Content row when track is expanded */
+.me-track-content {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  flex-shrink: 0;
+}
+
+/* Left sidebar: sticky in both axes; holds color strip + piano/drum labels */
+.me-track-left {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  background: #d4d0c8;
+  border-right: 2px solid #808080;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+/* Colored tint strip between edge and key labels */
+.me-track-color-strip {
+  flex: 1;
+  min-width: 0;
+}
+
+.me-track-keys-col {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Add-track footer row ──────────────────────────────────────────────────── */
+.me-add-track-row {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  flex-shrink: 0;
+  border-top: 2px solid #808080;
+}
+
+.me-add-track-left {
+  position: sticky;
+  left: 0;
+  z-index: 4;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+  background: #c0c0c0;
+  border-right: 2px solid #808080;
+  box-sizing: border-box;
+}
+
+.me-add-track-fill {
+  flex-shrink: 0;
+  background: #d4d0c8;
+}
+
+/* ── Piano keys ────────────────────────────────────────────────────────────── */
 .me-key {
   display: flex;
   align-items: center;
@@ -240,6 +381,7 @@
   cursor: pointer;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   box-sizing: border-box;
+  flex-shrink: 0;
 }
 
 .me-key--white { background: #f0f0e8; }
@@ -255,13 +397,7 @@
 
 .me-key--black .me-key__label { color: #aaa; }
 
-/* Separator between piano keys and drum labels in sidebar */
-.me-drum-key-sep {
-  flex-shrink: 0;
-  background: #606060;
-}
-
-/* Drum row labels in sidebar */
+/* Drum row labels */
 .me-drum-key {
   flex-shrink: 0;
   display: flex;
@@ -278,41 +414,13 @@
 
 .me-drum-key:hover { background: #c8beb6; }
 
-/* ── Grid area ─────────────────────────────────────────────────────────────── */
-
-/* Handles horizontal scroll for both melodic and drum grids */
-.me-grid-h-scroll {
-  flex: 1;
-  overflow-x: auto;
-  overflow-y: hidden;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-/* Content container: min-width forces horizontal scroll; positioned for playhead */
-.me-grid-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  min-height: 0;
-}
-
-/* Melodic grid: takes all remaining vertical space, scrolls vertically */
-.me-melodic-scroll {
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  min-height: 0;
-}
-
-/* Note grid canvas (melodic) */
+/* ── Note grid ─────────────────────────────────────────────────────────────── */
 .me-note-grid {
   position: relative;
+  flex-shrink: 0;
 }
 
-/* Step column overlays */
+/* Step column markers */
 .me-step-col {
   position: absolute;
   top: 0;
@@ -372,21 +480,12 @@
   z-index: 3;
 }
 
-/* ── Drum section ──────────────────────────────────────────────────────────── */
-
-/* Thick separator between melodic and drum areas */
-.me-drum-section-sep {
-  flex-shrink: 0;
-  background: #606060;
-}
-
-/* Drum grid: fixed height, always visible at bottom of grid area */
+/* ── Drum grid ─────────────────────────────────────────────────────────────── */
 .me-drum-grid {
-  flex-shrink: 0;
   position: relative;
+  flex-shrink: 0;
 }
 
-/* Drum step cells */
 .me-drum-cell {
   position: absolute;
   box-sizing: border-box;
@@ -400,7 +499,6 @@
 .me-drum-cell--bar  { background: #bcb8b0; }
 .me-drum-cell:hover { background: #d8c8a0; }
 
-/* Active cell — filled bubble via ::after */
 .me-drum-cell--on { cursor: pointer; }
 
 .me-drum-cell--on::after {
@@ -426,3 +524,138 @@
   z-index: 10;
   box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
 }
+
+/* ── Modal overlays ────────────────────────────────────────────────────────── */
+.me-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.me-modal {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  min-width: 240px;
+  max-width: 320px;
+  width: 90vw;
+  display: flex;
+  flex-direction: column;
+}
+
+.me-modal__title {
+  background: linear-gradient(90deg, #cc4400, #884400);
+  color: #fff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 4px 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.me-modal__close {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000;
+  font-size: 7px;
+  cursor: pointer;
+  padding: 1px 4px;
+  font-family: "Press Start 2P", monospace;
+  line-height: 1;
+}
+
+.me-modal__body {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.me-modal__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.me-modal__row--dim { opacity: 0.6; }
+
+.me-modal__footer {
+  padding: 6px 8px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  border-top: 1px solid #808080;
+  background: #d4d0c8;
+  flex-shrink: 0;
+}
+
+.me-text-input {
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 2px 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.me-color-swatches {
+  display: flex;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.me-color-swatch {
+  width: 16px;
+  height: 16px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  padding: 0;
+}
+
+.me-color-swatch--active {
+  border-color: #000 #000 #000 #000;
+  box-shadow: inset 0 0 0 1px #fff;
+}
+
+.me-slider {
+  flex: 1;
+  cursor: pointer;
+  accent-color: #cc4400;
+}
+
+/* ── Save / Load list ──────────────────────────────────────────────────────── */
+.me-save-list {
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #ffffff;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.me-save-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 3px 5px;
+  border-bottom: 1px solid #e0e0e0;
+  cursor: pointer;
+}
+
+.me-save-item:hover { background: #d4f0ff; }
+
+.me-save-item--load { cursor: default; }
+.me-save-item--load:hover { background: #f8f8f8; }

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -180,14 +180,6 @@
   min-height: 0;
 }
 
-.me-piano-section {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  min-height: 0;
-}
-
 .me-section-label {
   flex-shrink: 0;
   background: #d4d0c8;
@@ -202,21 +194,6 @@
   flex: 1;
   overflow: auto;
   min-height: 0;
-}
-
-.me-divider {
-  flex-shrink: 0;
-  height: 4px;
-  background: #c0c0c0;
-  border-top: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
-}
-
-.me-seq-section {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  background: #c0c0c0;
 }
 
 /* ── Piano Roll ────────────────────────────────────────────────────────────── */
@@ -270,6 +247,30 @@
 
 .me-key--black .me-key__label {
   color: #aaa;
+}
+
+/* Drum section separator in sidebar */
+.me-drum-key-sep {
+  background: #606060;
+  flex-shrink: 0;
+}
+
+/* Drum row labels in sidebar */
+.me-drum-key {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 3px;
+  font-size: 5px;
+  color: #000;
+  background: #b8b0a8;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
+  cursor: pointer;
+}
+
+.me-drum-key:hover {
+  background: #c8beb6;
 }
 
 /* Note grid */
@@ -370,7 +371,57 @@
   z-index: 3;
 }
 
-/* Piano roll playhead */
+/* ── Drum rows (unified grid) ───────────────────────────────────────────────── */
+
+/* Thick separator between melodic and drum sections */
+.me-drum-section-sep {
+  position: absolute;
+  background: #606060;
+  pointer-events: none;
+  z-index: 4;
+}
+
+/* Drum step cells */
+.me-drum-cell {
+  position: absolute;
+  box-sizing: border-box;
+  cursor: crosshair;
+  background: #ccc8c0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.me-drum-cell--beat {
+  background: #c4c0b8;
+}
+
+.me-drum-cell--bar {
+  background: #bcb8b0;
+}
+
+.me-drum-cell:hover {
+  background: #d8c8a0;
+}
+
+/* Active drum cell — bubble rendered via ::after */
+.me-drum-cell--on {
+  cursor: pointer;
+}
+
+.me-drum-cell--on::after {
+  content: '';
+  position: absolute;
+  inset: 2px 1px;
+  background: var(--drum-color, #c89000);
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+}
+
+.me-drum-cell--on:hover::after {
+  filter: brightness(1.15);
+}
+
+/* ── Piano roll playhead ────────────────────────────────────────────────────── */
 .me-playhead {
   position: absolute;
   top: 0;
@@ -379,108 +430,5 @@
   background: rgba(255, 80, 0, 0.75);
   pointer-events: none;
   z-index: 10;
-  box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
-}
-
-/* ── Step Sequencer ─────────────────────────────────────────────────────────── */
-.me-step-seq {
-  display: flex;
-  overflow-x: auto;
-  background: #c0c0c0;
-  border-top: 2px solid;
-  border-color: #ffffff #808080 #808080 #ffffff;
-}
-
-.me-step-seq__labels {
-  flex-shrink: 0;
-  width: 60px;
-  position: sticky;
-  left: 0;
-  z-index: 3;
-  background: #c0c0c0;
-  border-right: 2px solid #808080;
-}
-
-.me-step-seq__corner {
-  height: 28px;
-  border-bottom: 1px solid #808080;
-  background: #d4d0c8;
-}
-
-.me-drum-label {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding-right: 4px;
-  font-size: 6px;
-  color: #000;
-  border-bottom: 1px solid #b0b0b0;
-  box-sizing: border-box;
-}
-
-.me-step-seq__grid-wrap {
-  overflow: visible;
-}
-
-.me-step-seq__grid {
-  position: relative;
-}
-
-/* Step indicator row */
-.me-seq-indicator-row {
-  height: 28px;
-  display: flex;
-  border-bottom: 1px solid #808080;
-  background: #d4d0c8;
-}
-
-.me-seq-step-num {
-  flex-shrink: 0;
-  border-right: 1px solid rgba(0, 0, 0, 0.08);
-  box-sizing: border-box;
-}
-
-.me-seq-step-num--q4   { border-right: 1px solid #b8b4ae; }
-.me-seq-step-num--beat { border-right: 2px solid #888880; }
-.me-seq-step-num--bar  { border-right: 3px solid #484440; }
-
-/* Button rows — NO margin so playhead aligns exactly */
-.me-seq-row {
-  display: flex;
-}
-
-.me-seq-btn {
-  flex-shrink: 0;
-  border: 2px solid;
-  cursor: pointer;
-  box-sizing: border-box;
-  margin: 0;
-}
-
-.me-seq-btn--off {
-  background: #a8a8a8;
-  border-color: #d0d0d0 #606060 #606060 #d0d0d0;
-}
-
-.me-seq-btn--off.me-seq-btn--q4   { background: #b0acaa; }
-.me-seq-btn--off.me-seq-btn--beat { background: #b8b2a8; }
-.me-seq-btn--off.me-seq-btn--bar  { background: #c0bab0; }
-
-.me-seq-btn--on {
-  border-color: #ffffff #808080 #808080 #ffffff;
-}
-
-.me-seq-btn--off:hover {
-  background: #c0b090;
-}
-
-/* Step sequencer playhead — sits on top of button rows */
-.me-seq-playhead {
-  position: absolute;
-  left: 0;
-  width: 2px;
-  background: rgba(255, 80, 0, 0.75);
-  pointer-events: none;
-  z-index: 5;
   box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
 }

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -1,0 +1,457 @@
+/* ── Root ──────────────────────────────────────────────────────────────────── */
+.me-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  overflow: hidden;
+  user-select: none;
+}
+
+/* ── Transport ─────────────────────────────────────────────────────────────── */
+.me-transport {
+  flex-shrink: 0;
+  background: #c0c0c0;
+  border-bottom: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 4px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.me-transport__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.me-transport__group {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.me-transport__sep {
+  width: 1px;
+  height: 16px;
+  background: #808080;
+  margin: 0 4px;
+}
+
+.me-label {
+  color: #000;
+  white-space: nowrap;
+}
+
+.me-label--dim {
+  color: #555;
+}
+
+/* Win95 buttons */
+.me-btn {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  cursor: pointer;
+  padding: 3px 6px;
+  min-width: 24px;
+  text-align: center;
+}
+
+.me-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.me-btn--play {
+  background: #d4f0c0;
+  min-width: 28px;
+  font-size: 10px;
+}
+
+.me-btn--stop {
+  background: #f0d4c0;
+}
+
+.me-btn--sm {
+  padding: 2px 5px;
+  font-size: 8px;
+}
+
+.me-btn--new {
+  background: #d4d0c8;
+}
+
+.me-num-input {
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  width: 38px;
+  padding: 2px 3px;
+  text-align: center;
+}
+
+.me-num-input::-webkit-inner-spin-button,
+.me-num-input::-webkit-outer-spin-button {
+  display: none;
+}
+
+.me-select {
+  background: #ffffff;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 2px 3px;
+  cursor: pointer;
+}
+
+/* Track tab buttons */
+.me-track-btn {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  cursor: pointer;
+  padding: 3px 6px;
+  position: relative;
+}
+
+.me-track-btn::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--track-color);
+  margin-right: 4px;
+  border: 1px solid #000;
+  vertical-align: middle;
+}
+
+.me-track-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+/* Mute buttons */
+.me-mute-btn {
+  background: var(--track-color);
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #fff;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  cursor: pointer;
+  padding: 3px 5px;
+  min-width: 22px;
+  text-align: center;
+  text-shadow: 1px 1px 0 #000;
+}
+
+.me-mute-btn--muted {
+  background: #808080;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #c0c0c0;
+  text-decoration: line-through;
+}
+
+/* ── Body layout ───────────────────────────────────────────────────────────── */
+.me-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.me-piano-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.me-section-label {
+  flex-shrink: 0;
+  background: #d4d0c8;
+  border-bottom: 1px solid #808080;
+  padding: 2px 6px;
+  font-size: 6px;
+  color: #444;
+  letter-spacing: 1px;
+}
+
+.me-piano-roll-wrap {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.me-divider {
+  flex-shrink: 0;
+  height: 4px;
+  background: #c0c0c0;
+  border-top: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.me-seq-section {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+}
+
+/* ── Piano Roll ────────────────────────────────────────────────────────────── */
+.me-piano-roll {
+  display: flex;
+  align-items: flex-start;
+  min-width: max-content;
+}
+
+.me-piano-keys {
+  flex-shrink: 0;
+  width: 42px;
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  background: #d4d0c8;
+  border-right: 2px solid #808080;
+}
+
+.me-key {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 3px;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
+}
+
+.me-key--white {
+  background: #f0f0e8;
+}
+
+.me-key--black {
+  background: #404040;
+}
+
+.me-key--white:hover {
+  background: #ffddaa;
+}
+
+.me-key--black:hover {
+  background: #664400;
+}
+
+.me-key__label {
+  font-size: 5px;
+  color: #666;
+  pointer-events: none;
+}
+
+.me-key--black .me-key__label {
+  color: #aaa;
+}
+
+/* Note grid */
+.me-note-grid-wrap {
+  overflow: visible;
+}
+
+.me-note-grid {
+  position: relative;
+}
+
+/* Step column overlays (for divider lines) */
+.me-step-col {
+  position: absolute;
+  top: 0;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.me-step-col--beat {
+  border-left: 1px solid #b0b0b0;
+}
+
+.me-step-col--bar {
+  border-left: 2px solid #808080;
+}
+
+/* Note cells */
+.me-cell {
+  position: absolute;
+  box-sizing: border-box;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  border-right: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.me-cell--white {
+  background: #e8e4dc;
+}
+
+.me-cell--black {
+  background: #d0ccc4;
+}
+
+.me-cell--note {
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  z-index: 1;
+}
+
+.me-cell--white:hover:not(.me-cell--note) {
+  background: #ffe0b0;
+}
+
+.me-cell--black:hover:not(.me-cell--note) {
+  background: #d0a870;
+}
+
+/* Row divider (at each C note) */
+.me-row-divider {
+  position: absolute;
+  height: 2px;
+  background: #b0b0a0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Playhead */
+.me-playhead {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2px;
+  background: rgba(255, 80, 0, 0.7);
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
+}
+
+/* ── Step Sequencer ─────────────────────────────────────────────────────────── */
+.me-step-seq {
+  display: flex;
+  overflow-x: auto;
+  background: #c0c0c0;
+  border-top: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.me-step-seq__labels {
+  flex-shrink: 0;
+  width: 60px;
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  background: #c0c0c0;
+  border-right: 2px solid #808080;
+}
+
+.me-step-seq__corner {
+  height: 28px;
+  border-bottom: 1px solid #808080;
+  background: #d4d0c8;
+}
+
+.me-drum-label {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 4px;
+  font-size: 6px;
+  color: #000;
+  border-bottom: 1px solid #b0b0b0;
+  box-sizing: border-box;
+}
+
+.me-step-seq__grid-wrap {
+  overflow: visible;
+}
+
+.me-step-seq__grid {
+  position: relative;
+}
+
+/* Step indicator row */
+.me-seq-indicator-row {
+  height: 28px;
+  display: flex;
+  border-bottom: 1px solid #808080;
+  background: #d4d0c8;
+}
+
+.me-seq-step-num {
+  flex-shrink: 0;
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+
+.me-seq-step-num--beat {
+  border-right: 1px solid #a0a0a0;
+}
+
+.me-seq-step-num--bar {
+  border-right: 2px solid #808080;
+}
+
+/* Button rows */
+.me-seq-row {
+  display: flex;
+}
+
+.me-seq-btn {
+  flex-shrink: 0;
+  border: 2px solid;
+  cursor: pointer;
+  box-sizing: border-box;
+  margin: 1px;
+  transition: background 0.05s;
+}
+
+.me-seq-btn--off {
+  background: #a8a8a8;
+  border-color: #d0d0d0 #606060 #606060 #d0d0d0;
+}
+
+.me-seq-btn--off.me-seq-btn--beat {
+  background: #b8b4a8;
+}
+
+.me-seq-btn--off.me-seq-btn--bar {
+  background: #c0bab0;
+}
+
+.me-seq-btn--on {
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.me-seq-btn--off:hover {
+  background: #c0b090;
+}
+
+/* Playhead */
+.me-seq-playhead {
+  position: absolute;
+  left: 0;
+  width: 2px;
+  background: rgba(255, 80, 0, 0.7);
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
+}

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -420,6 +420,13 @@
   flex-shrink: 0;
 }
 
+/* In edit mode, give every touchable element its own touch-action:none so
+   mobile browsers don't intercept the pointer events for scrolling */
+.me-note-grid--edit .me-cell,
+.me-note-grid--edit .me-note-rect {
+  touch-action: none;
+}
+
 /* Step column markers */
 .me-step-col {
   position: absolute;
@@ -485,6 +492,10 @@
 .me-drum-grid {
   position: relative;
   flex-shrink: 0;
+}
+
+.me-drum-grid--edit .me-drum-cell {
+  touch-action: none;
 }
 
 .me-drum-cell {

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -450,10 +450,10 @@
   box-sizing: border-box;
 }
 
-/* Drum piece picker dropdown */
+/* Drum piece picker dropdown — opens upward so it overlays the grid, not the next track */
 .me-drum-piece-menu {
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 0;
   z-index: 20;
   background: #c0c0c0;

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -464,12 +464,13 @@
   right: 0;
   top: 0;
   bottom: 0;
-  width: 4px;
+  width: 16px;
   cursor: ew-resize;
-  background: rgba(0,0,0,0.28);
+  touch-action: none;
+  background: rgba(0,0,0,0.22);
 }
 
-.me-note-resize-handle:hover { background: rgba(0,0,0,0.5); }
+.me-note-resize-handle:hover { background: rgba(0,0,0,0.45); }
 
 /* Octave divider at each C */
 .me-row-divider {

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -39,7 +39,7 @@
   width: 1px;
   height: 16px;
   background: #808080;
-  margin: 0 4px;
+  margin: 0 2px;
 }
 
 .me-label {
@@ -69,6 +69,11 @@
   border-color: #808080 #ffffff #ffffff #808080;
 }
 
+.me-btn:disabled {
+  color: #888;
+  cursor: default;
+}
+
 .me-btn--play {
   background: #d4f0c0;
   min-width: 28px;
@@ -80,8 +85,8 @@
 }
 
 .me-btn--sm {
-  padding: 2px 5px;
-  font-size: 8px;
+  padding: 2px 4px;
+  font-size: 7px;
 }
 
 .me-btn--new {
@@ -126,7 +131,6 @@
   font-size: 7px;
   cursor: pointer;
   padding: 3px 6px;
-  position: relative;
 }
 
 .me-track-btn::before {
@@ -277,7 +281,7 @@
   position: relative;
 }
 
-/* Step column overlays (for divider lines) */
+/* Step column overlays — three levels of prominence */
 .me-step-col {
   position: absolute;
   top: 0;
@@ -285,21 +289,30 @@
   box-sizing: border-box;
 }
 
+/* Every 4th subdivision (only visible at 1/8 grid where stepsPerBeat=2) */
+.me-step-col--q4 {
+  border-left: 1px solid #c0bdb8;
+}
+
+/* Every beat (stepsPerBeat boundary) */
 .me-step-col--beat {
-  border-left: 1px solid #b0b0b0;
+  border-left: 2px solid #888880;
+  background: rgba(0, 0, 0, 0.025);
 }
 
+/* Every bar */
 .me-step-col--bar {
-  border-left: 2px solid #808080;
+  border-left: 3px solid #484440;
+  background: rgba(0, 0, 0, 0.04);
 }
 
-/* Note cells */
+/* Note cells (background) */
 .me-cell {
   position: absolute;
   box-sizing: border-box;
-  cursor: pointer;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-  border-right: 1px solid rgba(0, 0, 0, 0.06);
+  cursor: crosshair;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .me-cell--white {
@@ -310,17 +323,42 @@
   background: #d0ccc4;
 }
 
-.me-cell--note {
-  border: 1px solid rgba(0, 0, 0, 0.35);
-  z-index: 1;
-}
-
-.me-cell--white:hover:not(.me-cell--note) {
+.me-cell--white:hover {
   background: #ffe0b0;
 }
 
-.me-cell--black:hover:not(.me-cell--note) {
+.me-cell--black:hover {
   background: #d0a870;
+}
+
+/* Note rectangles (spans durationSteps) */
+.me-note-rect {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid rgba(0, 0, 0, 0.45);
+  border-radius: 1px;
+  cursor: pointer;
+  z-index: 2;
+  overflow: hidden;
+}
+
+.me-note-rect:hover {
+  filter: brightness(1.15);
+}
+
+/* Resize handle — rightmost 4px of note rect */
+.me-note-resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: ew-resize;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.me-note-resize-handle:hover {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 /* Row divider (at each C note) */
@@ -329,16 +367,16 @@
   height: 2px;
   background: #b0b0a0;
   pointer-events: none;
-  z-index: 2;
+  z-index: 3;
 }
 
-/* Playhead */
+/* Piano roll playhead */
 .me-playhead {
   position: absolute;
   top: 0;
   left: 0;
   width: 2px;
-  background: rgba(255, 80, 0, 0.7);
+  background: rgba(255, 80, 0, 0.75);
   pointer-events: none;
   z-index: 10;
   box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);
@@ -398,19 +436,15 @@
 
 .me-seq-step-num {
   flex-shrink: 0;
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
   box-sizing: border-box;
 }
 
-.me-seq-step-num--beat {
-  border-right: 1px solid #a0a0a0;
-}
+.me-seq-step-num--q4   { border-right: 1px solid #b8b4ae; }
+.me-seq-step-num--beat { border-right: 2px solid #888880; }
+.me-seq-step-num--bar  { border-right: 3px solid #484440; }
 
-.me-seq-step-num--bar {
-  border-right: 2px solid #808080;
-}
-
-/* Button rows */
+/* Button rows — NO margin so playhead aligns exactly */
 .me-seq-row {
   display: flex;
 }
@@ -420,8 +454,7 @@
   border: 2px solid;
   cursor: pointer;
   box-sizing: border-box;
-  margin: 1px;
-  transition: background 0.05s;
+  margin: 0;
 }
 
 .me-seq-btn--off {
@@ -429,13 +462,9 @@
   border-color: #d0d0d0 #606060 #606060 #d0d0d0;
 }
 
-.me-seq-btn--off.me-seq-btn--beat {
-  background: #b8b4a8;
-}
-
-.me-seq-btn--off.me-seq-btn--bar {
-  background: #c0bab0;
-}
+.me-seq-btn--off.me-seq-btn--q4   { background: #b0acaa; }
+.me-seq-btn--off.me-seq-btn--beat { background: #b8b2a8; }
+.me-seq-btn--off.me-seq-btn--bar  { background: #c0bab0; }
 
 .me-seq-btn--on {
   border-color: #ffffff #808080 #808080 #ffffff;
@@ -445,12 +474,12 @@
   background: #c0b090;
 }
 
-/* Playhead */
+/* Step sequencer playhead — sits on top of button rows */
 .me-seq-playhead {
   position: absolute;
   left: 0;
   width: 2px;
-  background: rgba(255, 80, 0, 0.7);
+  background: rgba(255, 80, 0, 0.75);
   pointer-events: none;
   z-index: 5;
   box-shadow: 0 0 4px rgba(255, 80, 0, 0.5);

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -402,8 +402,8 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  padding-right: 3px;
+  justify-content: space-between;
+  padding: 0 2px 0 4px;
   font-size: 5px;
   color: #000;
   background: #b8b0a8;
@@ -413,6 +413,75 @@
 }
 
 .me-drum-key:hover { background: #c8beb6; }
+
+.me-drum-row-remove {
+  background: none;
+  border: none;
+  color: #a04040;
+  cursor: pointer;
+  font-size: 9px;
+  line-height: 1;
+  padding: 0 1px;
+  flex-shrink: 0;
+}
+
+.me-drum-row-remove:hover { color: #cc0000; }
+
+/* Drum piece add row */
+.me-drum-add-piece-row {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  flex-shrink: 0;
+  border-top: 1px dashed #a0a090;
+}
+
+.me-drum-add-piece-left {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  background: #c8c4bc;
+  border-right: 2px solid #808080;
+  box-sizing: border-box;
+}
+
+/* Drum piece picker dropdown */
+.me-drum-piece-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 20;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  min-width: 72px;
+}
+
+.me-drum-piece-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #d4d0c8;
+  cursor: pointer;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #000;
+}
+
+.me-drum-piece-option:hover { background: #d4d0c8; }
+
+/* EDIT button in track header — slightly larger than icon buttons */
+.me-btn--edit {
+  background: #d4d0c8;
+}
 
 /* ── Note grid ─────────────────────────────────────────────────────────────── */
 .me-note-grid {
@@ -450,8 +519,16 @@
 
 .me-cell--white { background: #e8e4dc; }
 .me-cell--black { background: #d0ccc4; }
-.me-cell--white:hover { background: #ffe0b0; }
-.me-cell--black:hover { background: #d0a870; }
+.me-cell--white.me-cell--beat { background: #ddd9d0; }
+.me-cell--black.me-cell--beat { background: #c8c3bb; }
+.me-cell--white.me-cell--bar  { background: #d4d0c8; }
+.me-cell--black.me-cell--bar  { background: #bebab2; }
+.me-cell--white:hover,
+.me-cell--white.me-cell--beat:hover,
+.me-cell--white.me-cell--bar:hover  { background: #ffe0b0; }
+.me-cell--black:hover,
+.me-cell--black.me-cell--beat:hover,
+.me-cell--black.me-cell--bar:hover  { background: #d0a870; }
 
 /* Note rectangles */
 .me-note-rect {

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -190,27 +190,46 @@
   letter-spacing: 1px;
 }
 
+/* Wrapper: passes height down into the piano roll */
 .me-piano-roll-wrap {
   flex: 1;
-  overflow: auto;
+  display: flex;
+  overflow: hidden;
   min-height: 0;
 }
 
-/* ── Piano Roll ────────────────────────────────────────────────────────────── */
+/* ── Piano Roll — split layout ─────────────────────────────────────────────── */
+/*
+  Row flex: [keys-col (fixed, 42px)] [grid-h-scroll (flex:1)]
+  keys-col:    piano keys (overflow:hidden, scroll-synced) + drum labels (fixed)
+  grid-h-scroll: overflows-x; inside: melodic grid (v-scroll, flex:1) + drum grid (fixed)
+  The drum section is always visible — no vertical scrolling required to reach it.
+*/
+
 .me-piano-roll {
+  flex: 1;
   display: flex;
-  align-items: flex-start;
-  min-width: max-content;
+  flex-direction: row;
+  overflow: hidden;
+  min-height: 0;
 }
 
-.me-piano-keys {
+/* Left sidebar: always visible, never scrolls horizontally */
+.me-keys-col {
   flex-shrink: 0;
   width: 42px;
-  position: sticky;
-  left: 0;
-  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   background: #d4d0c8;
   border-right: 2px solid #808080;
+}
+
+/* Piano keys area — overflow hidden; scrollTop driven by JS scroll-sync */
+.me-keys-scroll {
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
 }
 
 .me-key {
@@ -223,21 +242,10 @@
   box-sizing: border-box;
 }
 
-.me-key--white {
-  background: #f0f0e8;
-}
-
-.me-key--black {
-  background: #404040;
-}
-
-.me-key--white:hover {
-  background: #ffddaa;
-}
-
-.me-key--black:hover {
-  background: #664400;
-}
+.me-key--white { background: #f0f0e8; }
+.me-key--black { background: #404040; }
+.me-key--white:hover { background: #ffddaa; }
+.me-key--black:hover { background: #664400; }
 
 .me-key__label {
   font-size: 5px;
@@ -245,18 +253,17 @@
   pointer-events: none;
 }
 
-.me-key--black .me-key__label {
-  color: #aaa;
-}
+.me-key--black .me-key__label { color: #aaa; }
 
-/* Drum section separator in sidebar */
+/* Separator between piano keys and drum labels in sidebar */
 .me-drum-key-sep {
-  background: #606060;
   flex-shrink: 0;
+  background: #606060;
 }
 
 /* Drum row labels in sidebar */
 .me-drum-key {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -269,20 +276,43 @@
   cursor: pointer;
 }
 
-.me-drum-key:hover {
-  background: #c8beb6;
+.me-drum-key:hover { background: #c8beb6; }
+
+/* ── Grid area ─────────────────────────────────────────────────────────────── */
+
+/* Handles horizontal scroll for both melodic and drum grids */
+.me-grid-h-scroll {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
-/* Note grid */
-.me-note-grid-wrap {
-  overflow: visible;
+/* Content container: min-width forces horizontal scroll; positioned for playhead */
+.me-grid-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 0;
 }
 
+/* Melodic grid: takes all remaining vertical space, scrolls vertically */
+.me-melodic-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+/* Note grid canvas (melodic) */
 .me-note-grid {
   position: relative;
 }
 
-/* Step column overlays — three levels of prominence */
+/* Step column overlays */
 .me-step-col {
   position: absolute;
   top: 0;
@@ -290,64 +320,37 @@
   box-sizing: border-box;
 }
 
-/* Every 4th subdivision (only visible at 1/8 grid where stepsPerBeat=2) */
-.me-step-col--q4 {
-  border-left: 1px solid #c0bdb8;
-}
+.me-step-col--q4   { border-left: 1px solid #c0bdb8; }
+.me-step-col--beat { border-left: 2px solid #888880; background: rgba(0,0,0,0.025); }
+.me-step-col--bar  { border-left: 3px solid #484440; background: rgba(0,0,0,0.04); }
 
-/* Every beat (stepsPerBeat boundary) */
-.me-step-col--beat {
-  border-left: 2px solid #888880;
-  background: rgba(0, 0, 0, 0.025);
-}
-
-/* Every bar */
-.me-step-col--bar {
-  border-left: 3px solid #484440;
-  background: rgba(0, 0, 0, 0.04);
-}
-
-/* Note cells (background) */
+/* Melodic cells */
 .me-cell {
   position: absolute;
   box-sizing: border-box;
   cursor: crosshair;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  border-right: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid rgba(0,0,0,0.05);
+  border-right: 1px solid rgba(0,0,0,0.05);
 }
 
-.me-cell--white {
-  background: #e8e4dc;
-}
+.me-cell--white { background: #e8e4dc; }
+.me-cell--black { background: #d0ccc4; }
+.me-cell--white:hover { background: #ffe0b0; }
+.me-cell--black:hover { background: #d0a870; }
 
-.me-cell--black {
-  background: #d0ccc4;
-}
-
-.me-cell--white:hover {
-  background: #ffe0b0;
-}
-
-.me-cell--black:hover {
-  background: #d0a870;
-}
-
-/* Note rectangles (spans durationSteps) */
+/* Note rectangles */
 .me-note-rect {
   position: absolute;
   box-sizing: border-box;
-  border: 1px solid rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(0,0,0,0.45);
   border-radius: 1px;
   cursor: pointer;
   z-index: 2;
   overflow: hidden;
 }
 
-.me-note-rect:hover {
-  filter: brightness(1.15);
-}
+.me-note-rect:hover { filter: brightness(1.15); }
 
-/* Resize handle — rightmost 4px of note rect */
 .me-note-resize-handle {
   position: absolute;
   right: 0;
@@ -355,14 +358,12 @@
   bottom: 0;
   width: 4px;
   cursor: ew-resize;
-  background: rgba(0, 0, 0, 0.28);
+  background: rgba(0,0,0,0.28);
 }
 
-.me-note-resize-handle:hover {
-  background: rgba(0, 0, 0, 0.5);
-}
+.me-note-resize-handle:hover { background: rgba(0,0,0,0.5); }
 
-/* Row divider (at each C note) */
+/* Octave divider at each C */
 .me-row-divider {
   position: absolute;
   height: 2px;
@@ -371,14 +372,18 @@
   z-index: 3;
 }
 
-/* ── Drum rows (unified grid) ───────────────────────────────────────────────── */
+/* ── Drum section ──────────────────────────────────────────────────────────── */
 
-/* Thick separator between melodic and drum sections */
+/* Thick separator between melodic and drum areas */
 .me-drum-section-sep {
-  position: absolute;
+  flex-shrink: 0;
   background: #606060;
-  pointer-events: none;
-  z-index: 4;
+}
+
+/* Drum grid: fixed height, always visible at bottom of grid area */
+.me-drum-grid {
+  flex-shrink: 0;
+  position: relative;
 }
 
 /* Drum step cells */
@@ -387,26 +392,16 @@
   box-sizing: border-box;
   cursor: crosshair;
   background: #ccc8c0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  border-right: 1px solid rgba(0,0,0,0.08);
 }
 
-.me-drum-cell--beat {
-  background: #c4c0b8;
-}
+.me-drum-cell--beat { background: #c4c0b8; }
+.me-drum-cell--bar  { background: #bcb8b0; }
+.me-drum-cell:hover { background: #d8c8a0; }
 
-.me-drum-cell--bar {
-  background: #bcb8b0;
-}
-
-.me-drum-cell:hover {
-  background: #d8c8a0;
-}
-
-/* Active drum cell — bubble rendered via ::after */
-.me-drum-cell--on {
-  cursor: pointer;
-}
+/* Active cell — filled bubble via ::after */
+.me-drum-cell--on { cursor: pointer; }
 
 .me-drum-cell--on::after {
   content: '';
@@ -414,17 +409,16 @@
   inset: 2px 1px;
   background: var(--drum-color, #c89000);
   border-radius: 3px;
-  border: 1px solid rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(0,0,0,0.35);
 }
 
-.me-drum-cell--on:hover::after {
-  filter: brightness(1.15);
-}
+.me-drum-cell--on:hover::after { filter: brightness(1.15); }
 
-/* ── Piano roll playhead ────────────────────────────────────────────────────── */
+/* ── Playhead ──────────────────────────────────────────────────────────────── */
 .me-playhead {
   position: absolute;
   top: 0;
+  bottom: 0;
   left: 0;
   width: 2px;
   background: rgba(255, 80, 0, 0.75);

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -199,7 +199,7 @@ interface PianoRollProps {
   stepsPerBeat: number;
   beatsPerBar: number;
   playheadRef: React.RefObject<HTMLDivElement | null>;
-  paintModeRef: React.RefObject<'add' | 'remove' | null>;
+  paintModeRef: React.MutableRefObject<'add' | 'remove' | null>;
   onAddNote: (pitch: number, step: number) => void;
   onRemoveNote: (noteId: string) => void;
   onStartResize: (noteId: string, startX: number, origDuration: number, noteStartStep: number) => void;
@@ -388,7 +388,7 @@ interface StepSeqProps {
   stepsPerBeat: number;
   beatsPerBar: number;
   seqPlayheadRef: React.RefObject<HTMLDivElement | null>;
-  seqPaintModeRef: React.RefObject<'add' | 'remove' | null>;
+  seqPaintModeRef: React.MutableRefObject<'add' | 'remove' | null>;
   onAddDrumNote: (pitch: number, step: number) => void;
   onRemoveDrumNote: (noteId: string) => void;
   onPreviewDrum: (pitch: number) => void;
@@ -528,8 +528,8 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const seqPlayheadRef = useRef<HTMLDivElement | null>(null);
 
   // Paint drag refs (cleared on global mouseup)
-  const paintModeRef = useRef<'add' | 'remove' | null>(null);
-  const seqPaintModeRef = useRef<'add' | 'remove' | null>(null);
+  const paintModeRef = useRef(null) as React.MutableRefObject<'add' | 'remove' | null>;
+  const seqPaintModeRef = useRef(null) as React.MutableRefObject<'add' | 'remove' | null>;
 
   // Resize drag refs
   const resizeModeRef = useRef(false);

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -6,6 +6,7 @@ import {
   type Track,
   type Note,
   type DrumType,
+  type OscWaveform,
   DRUM_TYPES,
   DRUM_LABELS,
   DRUM_PITCHES,
@@ -19,21 +20,28 @@ import {
   pitchName,
   makeNoteId,
   createInitialPattern,
+  TRACK_COLORS,
 } from './types';
 import { resumeAudio, playNote, playDrum } from './audio';
 import './MidiEditor.css';
 
+// ── Module-level constants ─────────────────────────────────────────────────────
+
 const PITCH_RANGE: number[] = [];
 for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
 
-function buildNoteSet(track: Track): Set<string> {
-  const s = new Set<string>();
+const PITCH_TO_ROW = new Map<number, number>();
+PITCH_RANGE.forEach((p, i) => PITCH_TO_ROW.set(p, i));
+
+// Maps `${pitch},${step}` → noteId (including all cells spanned by the note)
+function buildNoteMap(track: Track): Map<string, string> {
+  const m = new Map<string, string>();
   track.notes.forEach(n => {
     for (let d = 0; d < n.durationSteps; d++) {
-      s.add(`${n.pitch},${n.startStep + d}`);
+      m.set(`${n.pitch},${n.startStep + d}`, n.id);
     }
   });
-  return s;
+  return m;
 }
 
 // ── Transport ──────────────────────────────────────────────────────────────────
@@ -42,6 +50,8 @@ interface TransportProps {
   pattern: Pattern;
   isPlaying: boolean;
   activeTrackIdx: number;
+  activeTrack: Track;
+  melodicTrackCount: number;
   onPlay: () => void;
   onStop: () => void;
   onBpmChange: (bpm: number) => void;
@@ -49,6 +59,9 @@ interface TransportProps {
   onStepsPerBeatChange: (spb: number) => void;
   onActiveTrackChange: (idx: number) => void;
   onMuteTrack: (trackId: string) => void;
+  onChangeWaveform: (trackId: string, waveform: OscWaveform) => void;
+  onAddTrack: () => void;
+  onRemoveTrack: () => void;
   onNewPattern: () => void;
 }
 
@@ -56,6 +69,8 @@ function Transport({
   pattern,
   isPlaying,
   activeTrackIdx,
+  activeTrack,
+  melodicTrackCount,
   onPlay,
   onStop,
   onBpmChange,
@@ -63,6 +78,9 @@ function Transport({
   onStepsPerBeatChange,
   onActiveTrackChange,
   onMuteTrack,
+  onChangeWaveform,
+  onAddTrack,
+  onRemoveTrack,
   onNewPattern,
 }: TransportProps) {
   const melodicTracks = pattern.tracks.filter(t => !t.isDrum);
@@ -97,34 +115,26 @@ function Transport({
 
         <div className="me-transport__group">
           <span className="me-label">BARS</span>
-          <select
-            className="me-select"
-            value={pattern.bars}
-            onChange={e => onBarsChange(Number(e.target.value))}
-          >
+          <select className="me-select" value={pattern.bars} onChange={e => onBarsChange(Number(e.target.value))}>
             {[1, 2, 4, 8].map(n => <option key={n} value={n}>{n}</option>)}
           </select>
         </div>
 
         <div className="me-transport__group">
           <span className="me-label">GRID</span>
-          <select
-            className="me-select"
-            value={pattern.stepsPerBeat}
-            onChange={e => onStepsPerBeatChange(Number(e.target.value))}
-          >
+          <select className="me-select" value={pattern.stepsPerBeat} onChange={e => onStepsPerBeatChange(Number(e.target.value))}>
             <option value={2}>1/8</option>
             <option value={4}>1/16</option>
           </select>
         </div>
 
         <div className="me-transport__sep" />
-
         <button className="me-btn me-btn--new" onMouseDown={onNewPattern}>NEW</button>
+        <span className="me-label me-label--dim">SPACE=play</span>
       </div>
 
       <div className="me-transport__row">
-        <span className="me-label me-label--dim">PIANO ROLL:</span>
+        <span className="me-label me-label--dim">ROLL:</span>
         {melodicTracks.map((t, i) => (
           <button
             key={t.id}
@@ -135,6 +145,32 @@ function Transport({
             {t.name}
           </button>
         ))}
+        <button
+          className="me-btn me-btn--sm"
+          onMouseDown={onAddTrack}
+          disabled={melodicTrackCount >= 10}
+          title="Add melodic track"
+        >+TRK</button>
+        <button
+          className="me-btn me-btn--sm"
+          onMouseDown={onRemoveTrack}
+          disabled={melodicTrackCount <= 1}
+          title="Remove active track"
+        >-TRK</button>
+
+        <div className="me-transport__sep" />
+
+        <span className="me-label me-label--dim">WAVE:</span>
+        <select
+          className="me-select"
+          value={activeTrack.waveform}
+          onChange={e => onChangeWaveform(activeTrack.id, e.target.value as OscWaveform)}
+        >
+          <option value="sine">Sine</option>
+          <option value="triangle">Tri</option>
+          <option value="square">Sqr</option>
+          <option value="sawtooth">Saw</option>
+        </select>
 
         <div className="me-transport__sep" />
 
@@ -163,7 +199,10 @@ interface PianoRollProps {
   stepsPerBeat: number;
   beatsPerBar: number;
   playheadRef: React.RefObject<HTMLDivElement | null>;
-  onToggleNote: (pitch: number, step: number) => void;
+  paintModeRef: React.RefObject<'add' | 'remove' | null>;
+  onAddNote: (pitch: number, step: number) => void;
+  onRemoveNote: (noteId: string) => void;
+  onStartResize: (noteId: string, startX: number, origDuration: number, noteStartStep: number) => void;
   onPreviewPitch: (pitch: number) => void;
 }
 
@@ -173,13 +212,65 @@ function PianoRoll({
   stepsPerBeat,
   beatsPerBar,
   playheadRef,
-  onToggleNote,
+  paintModeRef,
+  onAddNote,
+  onRemoveNote,
+  onStartResize,
   onPreviewPitch,
 }: PianoRollProps) {
-  const noteSet = useMemo(() => buildNoteSet(track), [track]);
+  const noteMap = useMemo(() => buildNoteMap(track), [track]);
+  const lastPaintedRef = useRef('');
+  const lastPreviewPitchRef = useRef(-1);
 
   const gridWidth = totalSteps * STEP_W;
   const gridHeight = PITCH_RANGE.length * ROW_H;
+
+  function handleCellDown(pitch: number, step: number) {
+    paintModeRef.current = 'add';
+    lastPaintedRef.current = `${pitch},${step}`;
+    lastPreviewPitchRef.current = pitch;
+    onAddNote(pitch, step);
+    onPreviewPitch(pitch);
+  }
+
+  function handleCellEnter(pitch: number, step: number) {
+    if (paintModeRef.current !== 'add') return;
+    const key = `${pitch},${step}`;
+    if (key === lastPaintedRef.current) return;
+    lastPaintedRef.current = key;
+    onAddNote(pitch, step);
+    if (pitch !== lastPreviewPitchRef.current) {
+      lastPreviewPitchRef.current = pitch;
+      onPreviewPitch(pitch);
+    }
+  }
+
+  function handleNoteDown(e: React.MouseEvent, note: Note, noteW: number) {
+    e.stopPropagation();
+    e.preventDefault();
+    const localX = e.nativeEvent.offsetX;
+    if (localX >= noteW - 6) {
+      // Resize handle
+      paintModeRef.current = null;
+      onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
+    } else {
+      paintModeRef.current = 'remove';
+      lastPaintedRef.current = note.id;
+      onRemoveNote(note.id);
+    }
+  }
+
+  function handleNoteEnter(note: Note) {
+    if (paintModeRef.current !== 'remove') return;
+    if (note.id === lastPaintedRef.current) return;
+    lastPaintedRef.current = note.id;
+    onRemoveNote(note.id);
+  }
+
+  const noteRects = useMemo(() =>
+    track.notes.filter(n => n.startStep < totalSteps),
+    [track.notes, totalSteps],
+  );
 
   return (
     <div className="me-piano-roll">
@@ -193,7 +284,8 @@ function PianoRoll({
               key={pitch}
               className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
               style={{ height: ROW_H }}
-              onMouseDown={() => onPreviewPitch(pitch)}
+              onMouseDown={() => { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }}
+              onMouseEnter={e => { if (e.buttons === 1) { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; } }}
             >
               {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
             </div>
@@ -203,49 +295,76 @@ function PianoRoll({
 
       {/* Note grid */}
       <div className="me-note-grid-wrap">
-        <div
-          className="me-note-grid"
-          style={{ width: gridWidth, height: gridHeight }}
-        >
-          {/* Beat / bar dividers */}
-          {Array.from({ length: totalSteps }, (_, s) => s).map(step => (
-            <div
-              key={`div-${step}`}
-              className={`me-step-col ${step % (stepsPerBeat * beatsPerBar) === 0 ? 'me-step-col--bar' : step % stepsPerBeat === 0 ? 'me-step-col--beat' : ''}`}
-              style={{ left: step * STEP_W, width: STEP_W, height: gridHeight }}
-            />
-          ))}
+        <div className="me-note-grid" style={{ width: gridWidth, height: gridHeight }}>
 
-          {/* Note cells */}
+          {/* Step column markers (beat / bar lines) */}
+          {Array.from({ length: totalSteps }, (_, s) => s).map(step => {
+            const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+            const isBeat = !isBar && step % stepsPerBeat === 0;
+            const isQ4   = !isBar && !isBeat && step % 4 === 0;
+            return (
+              <div
+                key={`col-${step}`}
+                className={`me-step-col${isBar ? ' me-step-col--bar' : isBeat ? ' me-step-col--beat' : isQ4 ? ' me-step-col--q4' : ''}`}
+                style={{ left: step * STEP_W, width: STEP_W, height: gridHeight }}
+              />
+            );
+          })}
+
+          {/* Background cells (only where no note occupies) */}
           {PITCH_RANGE.map((pitch, rowIdx) => {
             const isBlack = isBlackPitch(pitch);
             return Array.from({ length: totalSteps }, (_, step) => {
-              const hasNote = noteSet.has(`${pitch},${step}`);
+              if (noteMap.has(`${pitch},${step}`)) return null;
               return (
                 <div
-                  key={`${pitch}-${step}`}
-                  className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'} ${hasNote ? 'me-cell--note' : ''}`}
-                  style={{
-                    left: step * STEP_W,
-                    top: rowIdx * ROW_H,
-                    width: STEP_W,
-                    height: ROW_H,
-                    ...(hasNote ? { background: track.color } : {}),
-                  }}
-                  onMouseDown={() => onToggleNote(pitch, step)}
+                  key={`bg-${pitch}-${step}`}
+                  className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
+                  style={{ left: step * STEP_W, top: rowIdx * ROW_H, width: STEP_W, height: ROW_H }}
+                  onMouseDown={e => { e.preventDefault(); handleCellDown(pitch, step); }}
+                  onMouseEnter={() => handleCellEnter(pitch, step)}
                 />
               );
             });
           })}
 
-          {/* Horizontal dividers (pitch rows) */}
+          {/* Note rectangles */}
+          {noteRects.map(note => {
+            const rowIdx = PITCH_TO_ROW.get(note.pitch);
+            if (rowIdx === undefined) return null;
+            const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
+            const noteW = displayDur * STEP_W;
+            return (
+              <div
+                key={note.id}
+                className="me-note-rect"
+                style={{
+                  left: note.startStep * STEP_W,
+                  top: rowIdx * ROW_H,
+                  width: noteW,
+                  height: ROW_H,
+                  background: track.color,
+                }}
+                onMouseDown={e => handleNoteDown(e, note, noteW)}
+                onMouseEnter={() => handleNoteEnter(note)}
+              >
+                <div
+                  className="me-note-resize-handle"
+                  onMouseDown={e => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    paintModeRef.current = null;
+                    onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
+                  }}
+                />
+              </div>
+            );
+          })}
+
+          {/* Octave dividers (at each C) */}
           {PITCH_RANGE.map((pitch, rowIdx) =>
             pitch % 12 === 0 ? (
-              <div
-                key={`row-div-${pitch}`}
-                className="me-row-divider"
-                style={{ top: rowIdx * ROW_H, width: gridWidth }}
-              />
+              <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * ROW_H, width: gridWidth }} />
             ) : null
           )}
 
@@ -269,7 +388,10 @@ interface StepSeqProps {
   stepsPerBeat: number;
   beatsPerBar: number;
   seqPlayheadRef: React.RefObject<HTMLDivElement | null>;
-  onToggleNote: (pitch: number, step: number) => void;
+  seqPaintModeRef: React.RefObject<'add' | 'remove' | null>;
+  onAddDrumNote: (pitch: number, step: number) => void;
+  onRemoveDrumNote: (noteId: string) => void;
+  onPreviewDrum: (pitch: number) => void;
 }
 
 function StepSeq({
@@ -278,12 +400,46 @@ function StepSeq({
   stepsPerBeat,
   beatsPerBar,
   seqPlayheadRef,
-  onToggleNote,
+  seqPaintModeRef,
+  onAddDrumNote,
+  onRemoveDrumNote,
+  onPreviewDrum,
 }: StepSeqProps) {
-  const drumNoteSet = useMemo(() => buildNoteSet(track), [track]);
+  const drumNoteMap = useMemo(() => buildNoteMap(track), [track]);
+  const lastPaintedRef = useRef('');
 
   const gridWidth = totalSteps * SEQ_BTN_W;
   const gridHeight = DRUM_TYPES.length * SEQ_BTN_H;
+
+  function handleBtnDown(pitch: number, step: number) {
+    const key = `${pitch},${step}`;
+    const existingId = drumNoteMap.get(key);
+    if (existingId) {
+      seqPaintModeRef.current = 'remove';
+      lastPaintedRef.current = existingId;
+      onRemoveDrumNote(existingId);
+    } else {
+      seqPaintModeRef.current = 'add';
+      lastPaintedRef.current = key;
+      onAddDrumNote(pitch, step);
+      onPreviewDrum(pitch);
+    }
+  }
+
+  function handleBtnEnter(pitch: number, step: number) {
+    const key = `${pitch},${step}`;
+    if (seqPaintModeRef.current === 'add') {
+      if (key === lastPaintedRef.current || drumNoteMap.has(key)) return;
+      lastPaintedRef.current = key;
+      onAddDrumNote(pitch, step);
+      onPreviewDrum(pitch);
+    } else if (seqPaintModeRef.current === 'remove') {
+      const existingId = drumNoteMap.get(key);
+      if (!existingId || existingId === lastPaintedRef.current) return;
+      lastPaintedRef.current = existingId;
+      onRemoveDrumNote(existingId);
+    }
+  }
 
   return (
     <div className="me-step-seq">
@@ -298,34 +454,40 @@ function StepSeq({
 
       <div className="me-step-seq__grid-wrap">
         <div className="me-step-seq__grid" style={{ width: gridWidth, height: gridHeight + SEQ_BTN_H }}>
+
           {/* Step indicator row */}
           <div className="me-seq-indicator-row" style={{ width: gridWidth }}>
-            {Array.from({ length: totalSteps }, (_, s) => s).map(step => (
-              <div
-                key={step}
-                className={`me-seq-step-num ${step % (stepsPerBeat * beatsPerBar) === 0 ? 'me-seq-step-num--bar' : step % stepsPerBeat === 0 ? 'me-seq-step-num--beat' : ''}`}
-                style={{ width: SEQ_BTN_W }}
-              />
-            ))}
+            {Array.from({ length: totalSteps }, (_, s) => s).map(step => {
+              const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+              const isBeat = !isBar && step % stepsPerBeat === 0;
+              const isQ4   = !isBar && !isBeat && step % 4 === 0;
+              return (
+                <div
+                  key={step}
+                  className={`me-seq-step-num${isBar ? ' me-seq-step-num--bar' : isBeat ? ' me-seq-step-num--beat' : isQ4 ? ' me-seq-step-num--q4' : ''}`}
+                  style={{ width: SEQ_BTN_W }}
+                />
+              );
+            })}
           </div>
 
           {/* Button rows */}
-          {DRUM_TYPES.map((dt: DrumType, rowIdx) => {
+          {DRUM_TYPES.map((dt: DrumType) => {
             const pitch = DRUM_PITCHES[dt];
             return (
               <div key={dt} className="me-seq-row" style={{ height: SEQ_BTN_H }}>
                 {Array.from({ length: totalSteps }, (_, step) => {
-                  const isOn = drumNoteSet.has(`${pitch},${step}`);
-                  const isBeat = step % stepsPerBeat === 0;
-                  const isBar = step % (stepsPerBeat * beatsPerBar) === 0;
+                  const isOn   = drumNoteMap.has(`${pitch},${step}`);
+                  const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+                  const isBeat = !isBar && step % stepsPerBeat === 0;
+                  const isQ4   = !isBar && !isBeat && step % 4 === 0;
                   return (
                     <button
                       key={step}
-                      className={`me-seq-btn ${isOn ? 'me-seq-btn--on' : 'me-seq-btn--off'} ${isBeat ? 'me-seq-btn--beat' : ''} ${isBar ? 'me-seq-btn--bar' : ''}`}
+                      className={`me-seq-btn${isOn ? ' me-seq-btn--on' : ' me-seq-btn--off'}${isBar ? ' me-seq-btn--bar' : isBeat ? ' me-seq-btn--beat' : isQ4 ? ' me-seq-btn--q4' : ''}`}
                       style={{ width: SEQ_BTN_W, height: SEQ_BTN_H, ...(isOn ? { background: track.color } : {}) }}
-                      onMouseDown={() => onToggleNote(pitch, step)}
-                      data-row={rowIdx}
-                      data-step={step}
+                      onMouseDown={e => { e.preventDefault(); handleBtnDown(pitch, step); }}
+                      onMouseEnter={() => handleBtnEnter(pitch, step)}
                     />
                   );
                 })}
@@ -365,32 +527,41 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const playheadRef = useRef<HTMLDivElement | null>(null);
   const seqPlayheadRef = useRef<HTMLDivElement | null>(null);
 
-  const melodicTracks = useMemo(
-    () => pattern.tracks.filter(t => !t.isDrum),
-    [pattern.tracks],
-  );
-  const drumTrack = useMemo(
-    () => pattern.tracks.find(t => t.isDrum)!,
-    [pattern.tracks],
-  );
-  const activeTrack = melodicTracks[activeTrackIdx] ?? melodicTracks[0];
+  // Paint drag refs (cleared on global mouseup)
+  const paintModeRef = useRef<'add' | 'remove' | null>(null);
+  const seqPaintModeRef = useRef<'add' | 'remove' | null>(null);
+
+  // Resize drag refs
+  const resizeModeRef = useRef(false);
+  const resizeStateRef = useRef<{
+    noteId: string; trackId: string;
+    startX: number; origDuration: number; noteStartStep: number;
+  } | null>(null);
+
+  const activeTrackRef = useRef<Track | null>(null);
+
+  const melodicTracks = useMemo(() => pattern.tracks.filter(t => !t.isDrum), [pattern.tracks]);
+  const drumTrack = useMemo(() => pattern.tracks.find(t => t.isDrum)!, [pattern.tracks]);
+
+  const clampedIdx = Math.min(activeTrackIdx, melodicTracks.length - 1);
+  const activeTrack = melodicTracks[clampedIdx] ?? melodicTracks[0];
+  activeTrackRef.current = activeTrack;
 
   const totalSteps = useMemo(
     () => pattern.bars * pattern.beatsPerBar * pattern.stepsPerBeat,
     [pattern.bars, pattern.beatsPerBar, pattern.stepsPerBeat],
   );
 
-  // Move playhead refs — called from timer, no React state change
+  // ── Playback ─────────────────────────────────────────────────────────────────
+
   function movePlayhead(step: number) {
-    const x = step * STEP_W;
     if (playheadRef.current) {
       playheadRef.current.style.display = 'block';
-      playheadRef.current.style.transform = `translateX(${x}px)`;
+      playheadRef.current.style.transform = `translateX(${step * STEP_W}px)`;
     }
-    const sx = step * SEQ_BTN_W;
     if (seqPlayheadRef.current) {
       seqPlayheadRef.current.style.display = 'block';
-      seqPlayheadRef.current.style.transform = `translateX(${sx}px)`;
+      seqPlayheadRef.current.style.transform = `translateX(${step * SEQ_BTN_W}px)`;
     }
   }
 
@@ -401,10 +572,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const stopPlayback = useCallback(() => {
     isPlayingRef.current = false;
-    if (timerRef.current !== null) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
+    if (timerRef.current !== null) { clearTimeout(timerRef.current); timerRef.current = null; }
     stepRef.current = 0;
     setIsPlaying(false);
     hidePlayhead();
@@ -422,20 +590,15 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     pat.tracks.forEach(track => {
       if (track.muted) return;
       track.notes.forEach((note: Note) => {
-        if (note.startStep !== step) return;
-        if (note.startStep >= total) return;
+        if (note.startStep !== step || note.startStep >= total) return;
         const dur = note.durationSteps * stepDurSec * 0.85;
-        if (track.isDrum) {
-          playDrum(note.pitch, note.velocity);
-        } else {
-          playNote(note.pitch, note.velocity, dur, track.waveform);
-        }
+        if (track.isDrum) playDrum(note.pitch, note.velocity);
+        else playNote(note.pitch, note.velocity, dur, track.waveform);
       });
     });
 
     stepRef.current = (step + 1) % total;
-    const ms = (60_000 / pat.bpm) / pat.stepsPerBeat;
-    timerRef.current = setTimeout(tick, ms);
+    timerRef.current = setTimeout(tick, (60_000 / pat.bpm) / pat.stepsPerBeat);
   }, []);
 
   const startPlayback = useCallback(() => {
@@ -443,42 +606,139 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     isPlayingRef.current = true;
     stepRef.current = 0;
     setIsPlaying(true);
-    const ms = (60_000 / patternRef.current.bpm) / patternRef.current.stepsPerBeat;
-    timerRef.current = setTimeout(tick, ms);
+    timerRef.current = setTimeout(tick, (60_000 / patternRef.current.bpm) / patternRef.current.stepsPerBeat);
   }, [tick]);
 
-  // Clean up on unmount
   useEffect(() => () => { stopPlayback(); }, [stopPlayback]);
 
-  const toggleNote = useCallback((trackId: string, pitch: number, step: number) => {
+  // ── Global mouse events (resize + clear paint mode) ───────────────────────────
+
+  useEffect(() => {
+    function handleMouseMove(e: MouseEvent) {
+      if (!resizeModeRef.current || !resizeStateRef.current) return;
+      const { noteId, trackId, startX, origDuration, noteStartStep } = resizeStateRef.current;
+      const deltaSteps = Math.round((e.clientX - startX) / STEP_W);
+      const pat = patternRef.current;
+      const maxDur = pat.bars * pat.beatsPerBar * pat.stepsPerBeat - noteStartStep;
+      const newDur = Math.max(1, Math.min(maxDur, origDuration + deltaSteps));
+      setPattern(prev => ({
+        ...prev,
+        tracks: prev.tracks.map(t => t.id !== trackId ? t : {
+          ...t,
+          notes: t.notes.map(n => n.id !== noteId ? n : { ...n, durationSteps: newDur }),
+        }),
+      }));
+    }
+
+    function handleMouseUp() {
+      paintModeRef.current = null;
+      seqPaintModeRef.current = null;
+      resizeModeRef.current = false;
+      resizeStateRef.current = null;
+    }
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, []);
+
+  // ── Spacebar play/pause ───────────────────────────────────────────────────────
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.code !== 'Space') return;
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+      e.preventDefault();
+      if (isPlayingRef.current) stopPlayback(); else startPlayback();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [startPlayback, stopPlayback]);
+
+  // ── Note editing ──────────────────────────────────────────────────────────────
+
+  const addNote = useCallback((trackId: string, pitch: number, step: number) => {
     setPattern(prev => ({
       ...prev,
-      tracks: prev.tracks.map(track => {
-        if (track.id !== trackId) return track;
-        const existing = track.notes.find(n => n.startStep === step && n.pitch === pitch);
-        if (existing) {
-          return { ...track, notes: track.notes.filter(n => n.id !== existing.id) };
-        }
-        const newNote: Note = {
-          id: makeNoteId(),
-          pitch,
-          startStep: step,
-          durationSteps: 1,
-          velocity: 100,
-        };
-        return { ...track, notes: [...track.notes, newNote] };
+      tracks: prev.tracks.map(t => {
+        if (t.id !== trackId) return t;
+        if (t.notes.some(n => n.startStep === step && n.pitch === pitch)) return t;
+        const newNote: Note = { id: makeNoteId(), pitch, startStep: step, durationSteps: 1, velocity: 100 };
+        return { ...t, notes: [...t.notes, newNote] };
       }),
     }));
   }, []);
 
-  const muteTrack = useCallback((trackId: string) => {
+  const removeNote = useCallback((trackId: string, noteId: string) => {
     setPattern(prev => ({
       ...prev,
       tracks: prev.tracks.map(t =>
-        t.id === trackId ? { ...t, muted: !t.muted } : t
+        t.id !== trackId ? t : { ...t, notes: t.notes.filter(n => n.id !== noteId) }
       ),
     }));
   }, []);
+
+  const startResizeNote = useCallback((noteId: string, startX: number, origDuration: number, noteStartStep: number) => {
+    resizeModeRef.current = true;
+    resizeStateRef.current = {
+      noteId,
+      trackId: activeTrackRef.current?.id ?? '',
+      startX,
+      origDuration,
+      noteStartStep,
+    };
+  }, []);
+
+  // ── Track management ──────────────────────────────────────────────────────────
+
+  const muteTrack = useCallback((trackId: string) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t => t.id === trackId ? { ...t, muted: !t.muted } : t),
+    }));
+  }, []);
+
+  const changeWaveform = useCallback((trackId: string, waveform: OscWaveform) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t => t.id === trackId ? { ...t, waveform } : t),
+    }));
+  }, []);
+
+  const addTrack = useCallback(() => {
+    setPattern(prev => {
+      const melodic = prev.tracks.filter(t => !t.isDrum);
+      if (melodic.length >= 10) return prev;
+      const idx = melodic.length;
+      const newTrack: Track = {
+        id: `t${makeNoteId()}`,
+        name: `Trk ${idx + 1}`,
+        color: TRACK_COLORS[idx % TRACK_COLORS.length],
+        waveform: 'sine',
+        notes: [],
+        muted: false,
+        isDrum: false,
+      };
+      return {
+        ...prev,
+        tracks: [...prev.tracks.filter(t => !t.isDrum), newTrack, ...prev.tracks.filter(t => t.isDrum)],
+      };
+    });
+  }, []);
+
+  const removeActiveTrack = useCallback(() => {
+    setPattern(prev => {
+      const melodic = prev.tracks.filter(t => !t.isDrum);
+      if (melodic.length <= 1) return prev;
+      const toRemove = melodic[Math.min(activeTrackIdx, melodic.length - 1)];
+      return { ...prev, tracks: prev.tracks.filter(t => t.id !== toRemove.id) };
+    });
+    setActiveTrackIdx(prev => Math.max(0, prev - 1));
+  }, [activeTrackIdx]);
 
   const newPattern = useCallback(() => {
     stopPlayback();
@@ -486,12 +746,19 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     setActiveTrackIdx(0);
   }, [stopPlayback]);
 
+  // ── Preview ───────────────────────────────────────────────────────────────────
+
   const previewPitch = useCallback((pitch: number) => {
     resumeAudio();
-    playNote(pitch, 100, 0.4, activeTrack.waveform);
-  }, [activeTrack]);
+    playNote(pitch, 100, 0.35, activeTrackRef.current?.waveform ?? 'sine');
+  }, []);
 
-  // ── Window menus ─────────────────────────────────────────────────────────────
+  const previewDrum = useCallback((pitch: number) => {
+    resumeAudio();
+    playDrum(pitch, 100);
+  }, []);
+
+  // ── Window menus ──────────────────────────────────────────────────────────────
 
   const menus = useMemo<MenuBarMenu[]>(() => [
     {
@@ -515,11 +782,11 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       label: 'Track',
       items: melodicTracks.map((t, i) => ({
         label: t.name,
-        checked: i === activeTrackIdx,
+        checked: i === clampedIdx,
         onClick: () => setActiveTrackIdx(i),
       })),
     },
-  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit, melodicTracks, activeTrackIdx]);
+  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit, melodicTracks, clampedIdx]);
 
   useWindowMenus(menus);
 
@@ -530,14 +797,19 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       <Transport
         pattern={pattern}
         isPlaying={isPlaying}
-        activeTrackIdx={activeTrackIdx}
+        activeTrackIdx={clampedIdx}
+        activeTrack={activeTrack}
+        melodicTrackCount={melodicTracks.length}
         onPlay={startPlayback}
         onStop={stopPlayback}
         onBpmChange={bpm => setPattern(p => ({ ...p, bpm: Math.max(40, Math.min(240, bpm)) }))}
         onBarsChange={bars => { stopPlayback(); setPattern(p => ({ ...p, bars })); }}
-        onStepsPerBeatChange={stepsPerBeat => { stopPlayback(); setPattern(p => ({ ...p, stepsPerBeat })); }}
+        onStepsPerBeatChange={spb => { stopPlayback(); setPattern(p => ({ ...p, stepsPerBeat: spb })); }}
         onActiveTrackChange={setActiveTrackIdx}
         onMuteTrack={muteTrack}
+        onChangeWaveform={changeWaveform}
+        onAddTrack={addTrack}
+        onRemoveTrack={removeActiveTrack}
         onNewPattern={newPattern}
       />
 
@@ -551,7 +823,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
               stepsPerBeat={pattern.stepsPerBeat}
               beatsPerBar={pattern.beatsPerBar}
               playheadRef={playheadRef}
-              onToggleNote={(pitch, step) => toggleNote(activeTrack.id, pitch, step)}
+              paintModeRef={paintModeRef}
+              onAddNote={(pitch, step) => addNote(activeTrack.id, pitch, step)}
+              onRemoveNote={noteId => removeNote(activeTrack.id, noteId)}
+              onStartResize={startResizeNote}
               onPreviewPitch={previewPitch}
             />
           </div>
@@ -567,7 +842,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
             stepsPerBeat={pattern.stepsPerBeat}
             beatsPerBar={pattern.beatsPerBar}
             seqPlayheadRef={seqPlayheadRef}
-            onToggleNote={(pitch, step) => toggleNote(drumTrack.id, pitch, step)}
+            seqPaintModeRef={seqPaintModeRef}
+            onAddDrumNote={(pitch, step) => addNote(drumTrack.id, pitch, step)}
+            onRemoveDrumNote={noteId => removeNote(drumTrack.id, noteId)}
+            onPreviewDrum={previewDrum}
           />
         </div>
       </div>

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -3,8 +3,9 @@ import { useWindowMenus } from '../../components/Window/useWindowMenus';
 import type { MenuBarMenu } from '../../components/MenuBar/MenuBar';
 import {
   type Pattern, type Track, type Note, type DrumType, type OscWaveform,
-  DRUM_TYPES, DRUM_LABELS, DRUM_PITCHES, PIANO_MIN, PIANO_MAX,
+  DRUM_LABELS, DRUM_PITCHES, PIANO_MIN, PIANO_MAX,
   isBlackPitch, pitchName, makeNoteId, createInitialPattern, TRACK_COLORS,
+  drumPitchLabel, DEFAULT_DRUM_ROWS,
 } from './types';
 import { resumeAudio, playNote, playDrum } from './audio';
 import './MidiEditor.css';
@@ -45,8 +46,9 @@ const STORAGE_SAVES = 'midi-editor-saves';
 const STORAGE_ZOOM  = 'midi-editor-zoom';
 
 function migrateTrack(t: Track): Track {
-  const defaults = { volume: 1, attack: 0.01, release: 0.3, collapsed: false };
-  return { ...defaults, ...t };
+  const defaults: Partial<Track> = { volume: 1, attack: 0.01, release: 0.3, collapsed: false };
+  if (t.isDrum && !t.drumRows) defaults.drumRows = [...DEFAULT_DRUM_ROWS];
+  return { ...defaults, ...t } as Track;
 }
 
 function migratePattern(raw: unknown): Pattern {
@@ -103,17 +105,29 @@ function buildNoteMap(track: Track): Map<string, string> {
 
 interface InstrumentModalProps {
   track: Track;
+  canDelete: boolean;
   onSave: (updates: Partial<Track>) => void;
   onClose: () => void;
+  onDelete: () => void;
 }
 
-function InstrumentModal({ track, onSave, onClose }: InstrumentModalProps) {
+function InstrumentModal({ track, canDelete, onSave, onClose, onDelete }: InstrumentModalProps) {
   const [name,     setName]     = useState(track.name);
   const [color,    setColor]    = useState(track.color);
   const [waveform, setWaveform] = useState(track.waveform);
   const [volume,   setVolume]   = useState(Math.round(track.volume * 100));
 
   function save() { onSave({ name, color, waveform, volume: volume / 100 }); }
+
+  function previewSound() {
+    resumeAudio();
+    if (track.isDrum) {
+      const pitch = track.drumRows?.[0] ?? 36;
+      playDrum(pitch, 100);
+    } else {
+      playNote(60, 100, 1.0, waveform, undefined, volume / 100, track.attack, track.release);
+    }
+  }
 
   return (
     <div className="me-modal-backdrop" onPointerDown={onClose}>
@@ -173,6 +187,11 @@ function InstrumentModal({ track, onSave, onClose }: InstrumentModalProps) {
             />
           </div>
 
+          <div className="me-modal__row">
+            <label className="me-label">PREVIEW</label>
+            <button className="me-btn me-btn--sm" onClick={previewSound}>🔊 Play</button>
+          </div>
+
           <div className="me-modal__row me-modal__row--dim">
             <label className="me-label">SOUND</label>
             <span className="me-label me-label--dim">Upload sample (coming soon)</span>
@@ -180,6 +199,11 @@ function InstrumentModal({ track, onSave, onClose }: InstrumentModalProps) {
         </div>
 
         <div className="me-modal__footer">
+          {canDelete && (
+            <button className="me-btn me-btn--sm me-btn--danger" onClick={() => { onDelete(); }}>
+              Delete Track
+            </button>
+          )}
           <button className="me-btn" onClick={onClose}>Cancel</button>
           <button className="me-btn me-btn--primary" onClick={save}>Save</button>
         </div>
@@ -290,16 +314,13 @@ interface TransportProps {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onNew: () => void;
-  onSave: () => void;
-  onLoad: () => void;
-  onDownload: () => void;
   onToggleEditMode: () => void;
 }
 
 function Transport({
   pattern, isPlaying, zoomIdx, editMode,
   onPlay, onStop, onBpmChange, onBarsChange, onStepsPerBeatChange,
-  onZoomIn, onZoomOut, onNew, onSave, onLoad, onDownload, onToggleEditMode,
+  onZoomIn, onZoomOut, onNew, onToggleEditMode,
 }: TransportProps) {
   function nudge(delta: number) {
     onBpmChange(Math.max(40, Math.min(240, pattern.bpm + delta)));
@@ -357,10 +378,7 @@ function Transport({
 
         <div className="me-transport__sep" />
 
-        <button className="me-btn me-btn--sm" onPointerDown={onNew}      title="New pattern">NEW</button>
-        <button className="me-btn me-btn--sm" onPointerDown={onSave}     title="Save to library">SAVE</button>
-        <button className="me-btn me-btn--sm" onPointerDown={onLoad}     title="Load from library">LOAD</button>
-        <button className="me-btn me-btn--sm" onPointerDown={onDownload} title="Download as JSON">⤓JSON</button>
+        <button className="me-btn me-btn--sm" onPointerDown={onNew} title="New pattern">NEW</button>
 
         <span className="me-label me-label--dim">SPACE=play</span>
       </div>
@@ -434,10 +452,13 @@ function MelodicGrid({
         const isBlack = isBlackPitch(pitch);
         return Array.from({ length: totalSteps }, (_, step) => {
           if (noteMap.has(`${pitch},${step}`)) return null;
+          const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+          const isBeat = !isBar && step % stepsPerBeat === 0;
+          const beatCls = isBar ? ' me-cell--bar' : isBeat ? ' me-cell--beat' : '';
           return (
             <div
               key={`bg-${pitch}-${step}`}
-              className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
+              className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}${beatCls}`}
               style={{ left: step * stepW, top: rowIdx * rowH, width: stepW, height: rowH }}
               data-pitch={pitch}
               data-step={step}
@@ -464,6 +485,7 @@ function MelodicGrid({
             }}
             data-note-id={note.id}
             data-track-id={track.id}
+            onContextMenu={(e: React.MouseEvent) => { e.preventDefault(); onRemoveNote(note.id); }}
             {...(editMode ? {
               onPointerDown: (e: React.PointerEvent) => {
                 e.preventDefault(); e.stopPropagation();
@@ -514,9 +536,10 @@ function DrumGrid({
   track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, editMode,
   paintModeRef, onAddNote, onRemoveNote, onPreviewDrum,
 }: DrumGridProps) {
-  const drumNoteMap = useMemo(() => buildNoteMap(track), [track]);
+  const drumNoteMap   = useMemo(() => buildNoteMap(track), [track]);
+  const activeDrumRows = track.drumRows?.length ? track.drumRows : DEFAULT_DRUM_ROWS;
   const gridW = totalSteps * stepW;
-  const gridH = DRUM_TYPES.length * rowH;
+  const gridH = activeDrumRows.length * rowH;
 
   function cellDown(pitch: number, step: number, existingId: string | undefined) {
     if (existingId) {
@@ -546,8 +569,7 @@ function DrumGrid({
       })}
 
       {/* Drum cells */}
-      {DRUM_TYPES.map((dt: DrumType, rowIdx) => {
-        const pitch  = DRUM_PITCHES[dt];
+      {activeDrumRows.map((pitch, rowIdx) => {
         const rowTop = rowIdx * rowH;
         return Array.from({ length: totalSteps }, (_, step) => {
           const existingId = drumNoteMap.get(`${pitch},${step}`);
@@ -555,7 +577,7 @@ function DrumGrid({
           const isBeat = !isBar && step % stepsPerBeat === 0;
           return (
             <div
-              key={`dcell-${dt}-${step}`}
+              key={`dcell-${pitch}-${step}`}
               className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
               style={{
                 left: step * stepW, top: rowTop, width: stepW, height: rowH,
@@ -565,6 +587,7 @@ function DrumGrid({
               data-step={step}
               data-track-id={track.id}
               data-note-id={existingId ?? ''}
+              onContextMenu={(e: React.MouseEvent) => { if (existingId) { e.preventDefault(); onRemoveNote(existingId); } }}
               {...(editMode ? { onPointerDown: (e: React.PointerEvent) => { e.preventDefault(); cellDown(pitch, step, existingId); } } : {})}
             />
           );
@@ -583,29 +606,36 @@ interface TrackSectionProps {
   beatsPerBar: number;
   stepW: number;
   rowH: number;
-  canDelete: boolean;
   editMode: boolean;
   paintModeRef: React.MutableRefObject<PaintState>;
   onToggleCollapse: () => void;
   onGear: () => void;
-  onDelete: () => void;
   onMute: () => void;
   onAddNote: (pitch: number, step: number) => void;
   onRemoveNote: (noteId: string) => void;
   onStartResize: (noteId: string, startX: number, origDur: number, noteStart: number) => void;
   onPreviewPitch: (pitch: number) => void;
   onPreviewDrum: (pitch: number) => void;
+  onAddDrumPiece: (pitch: number) => void;
+  onRemoveDrumPiece: (pitch: number) => void;
 }
 
 function TrackSection({
-  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, canDelete, editMode,
-  paintModeRef, onToggleCollapse, onGear, onDelete, onMute,
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, editMode,
+  paintModeRef, onToggleCollapse, onGear, onMute,
   onAddNote, onRemoveNote, onStartResize, onPreviewPitch, onPreviewDrum,
+  onAddDrumPiece, onRemoveDrumPiece,
 }: TrackSectionProps) {
+  const [showAddPiece, setShowAddPiece] = useState(false);
+
+  const activeDrumRows = track.drumRows?.length ? track.drumRows : DEFAULT_DRUM_ROWS;
   const gridW    = totalSteps * stepW;
   const pitchH   = PITCH_RANGE.length * rowH;
-  const drumH    = DRUM_TYPES.length * rowH;
+  const drumH    = activeDrumRows.length * rowH;
   const contentH = track.isDrum ? drumH : pitchH;
+
+  const availablePieces = (Object.keys(DRUM_PITCHES) as DrumType[])
+    .filter(dt => !activeDrumRows.includes(DRUM_PITCHES[dt]));
 
   return (
     <div className="me-track-section" style={{ '--tcolor': track.color } as React.CSSProperties}>
@@ -615,10 +645,7 @@ function TrackSection({
           <button className="me-track-collapse" onPointerDown={onToggleCollapse} title="Collapse">
             {track.collapsed ? '▶' : '▼'}
           </button>
-          <span
-            className="me-track-color-dot"
-            style={{ background: track.color }}
-          />
+          <span className="me-track-color-dot" style={{ background: track.color }} />
           <span className="me-track-name">{track.name}</span>
           <div className="me-track-header-btns">
             <button
@@ -626,86 +653,118 @@ function TrackSection({
               onPointerDown={onMute}
               title={track.muted ? 'Unmute' : 'Mute'}
             >M</button>
-            <button className="me-icon-btn" onPointerDown={onGear} title="Track settings">⚙</button>
-            {canDelete && (
-              <button className="me-icon-btn me-icon-btn--del" onPointerDown={onDelete} title="Delete track">✕</button>
-            )}
+            <button className="me-btn me-btn--sm me-btn--edit" onPointerDown={onGear} title="Track settings">EDIT</button>
           </div>
         </div>
-        <div
-          className="me-track-header-fill"
-          style={{ width: gridW, background: track.color + '18' }}
-        />
+        <div className="me-track-header-fill" style={{ width: gridW, background: track.color + '18' }} />
       </div>
 
       {/* Content: left sidebar (keys/labels) + note grid */}
       {!track.collapsed && (
-        <div className="me-track-content">
-          {/* Left sidebar: color strip + keys/labels */}
-          <div className="me-track-left" style={{ width: LEFT_W, height: contentH }}>
-            <div className="me-track-color-strip" style={{ background: track.color + '28' }} />
-            <div className="me-track-keys-col" style={{ width: KEYS_W }}>
-              {track.isDrum
-                ? DRUM_TYPES.map((dt: DrumType) => (
-                    <div
-                      key={dt}
-                      className="me-drum-key"
-                      style={{ height: rowH }}
-                      onPointerDown={() => onPreviewDrum(DRUM_PITCHES[dt])}
-                    >
-                      {DRUM_LABELS[dt]}
-                    </div>
-                  ))
-                : PITCH_RANGE.map(pitch => {
-                    const isBlack = isBlackPitch(pitch);
-                    const isC     = pitch % 12 === 0;
-                    return (
+        <>
+          <div className="me-track-content">
+            {/* Left sidebar: color strip + keys/labels */}
+            <div className="me-track-left" style={{ width: LEFT_W, height: contentH }}>
+              <div className="me-track-color-strip" style={{ background: track.color + '28' }} />
+              <div className="me-track-keys-col" style={{ width: KEYS_W }}>
+                {track.isDrum
+                  ? activeDrumRows.map(pitch => (
                       <div
                         key={pitch}
-                        className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
+                        className="me-drum-key"
                         style={{ height: rowH }}
-                        onPointerDown={() => { onPreviewPitch(pitch); }}
-                        onPointerEnter={e => { if (e.buttons === 1) onPreviewPitch(pitch); }}
+                        onPointerDown={() => onPreviewDrum(pitch)}
                       >
-                        {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
+                        <span>{drumPitchLabel(pitch)}</span>
+                        <button
+                          className="me-drum-row-remove"
+                          onPointerDown={e => { e.stopPropagation(); onRemoveDrumPiece(pitch); }}
+                          title="Remove row"
+                        >×</button>
                       </div>
-                    );
-                  })
-              }
+                    ))
+                  : PITCH_RANGE.map(pitch => {
+                      const isBlack = isBlackPitch(pitch);
+                      const isC     = pitch % 12 === 0;
+                      return (
+                        <div
+                          key={pitch}
+                          className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
+                          style={{ height: rowH }}
+                          onPointerDown={() => { onPreviewPitch(pitch); }}
+                          onPointerEnter={e => { if (e.buttons === 1) onPreviewPitch(pitch); }}
+                        >
+                          {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
+                        </div>
+                      );
+                    })
+                }
+              </div>
             </div>
+
+            {/* Note / drum grid */}
+            {track.isDrum
+              ? <DrumGrid
+                  track={track}
+                  totalSteps={totalSteps}
+                  stepsPerBeat={stepsPerBeat}
+                  beatsPerBar={beatsPerBar}
+                  stepW={stepW}
+                  rowH={rowH}
+                  editMode={editMode}
+                  paintModeRef={paintModeRef}
+                  onAddNote={onAddNote}
+                  onRemoveNote={onRemoveNote}
+                  onPreviewDrum={onPreviewDrum}
+                />
+              : <MelodicGrid
+                  track={track}
+                  totalSteps={totalSteps}
+                  stepsPerBeat={stepsPerBeat}
+                  beatsPerBar={beatsPerBar}
+                  stepW={stepW}
+                  rowH={rowH}
+                  editMode={editMode}
+                  paintModeRef={paintModeRef}
+                  onAddNote={onAddNote}
+                  onRemoveNote={onRemoveNote}
+                  onStartResize={onStartResize}
+                  onPreviewPitch={onPreviewPitch}
+                />
+            }
           </div>
 
-          {/* Note / drum grid */}
-          {track.isDrum
-            ? <DrumGrid
-                track={track}
-                totalSteps={totalSteps}
-                stepsPerBeat={stepsPerBeat}
-                beatsPerBar={beatsPerBar}
-                stepW={stepW}
-                rowH={rowH}
-                editMode={editMode}
-                paintModeRef={paintModeRef}
-                onAddNote={onAddNote}
-                onRemoveNote={onRemoveNote}
-                onPreviewDrum={onPreviewDrum}
-              />
-            : <MelodicGrid
-                track={track}
-                totalSteps={totalSteps}
-                stepsPerBeat={stepsPerBeat}
-                beatsPerBar={beatsPerBar}
-                stepW={stepW}
-                rowH={rowH}
-                editMode={editMode}
-                paintModeRef={paintModeRef}
-                onAddNote={onAddNote}
-                onRemoveNote={onRemoveNote}
-                onStartResize={onStartResize}
-                onPreviewPitch={onPreviewPitch}
-              />
-          }
-        </div>
+          {/* + Piece row for drum tracks */}
+          {track.isDrum && (
+            <div className="me-drum-add-piece-row" style={{ height: HDR_H }}>
+              <div className="me-drum-add-piece-left" style={{ width: LEFT_W }}>
+                <div style={{ position: 'relative' }}>
+                  <button
+                    className="me-btn me-btn--sm"
+                    onPointerDown={() => setShowAddPiece(v => !v)}
+                    disabled={availablePieces.length === 0}
+                  >
+                    + Piece
+                  </button>
+                  {showAddPiece && (
+                    <div className="me-drum-piece-menu">
+                      {availablePieces.map(dt => (
+                        <button
+                          key={dt}
+                          className="me-drum-piece-option"
+                          onPointerDown={() => { onAddDrumPiece(DRUM_PITCHES[dt]); setShowAddPiece(false); }}
+                        >
+                          {DRUM_LABELS[dt]}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="me-add-track-fill" style={{ width: gridW }} />
+            </div>
+          )}
+        </>
       )}
     </div>
   );
@@ -789,7 +848,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       track.notes.forEach((note: Note) => {
         if (note.startStep !== step || note.startStep >= total) return;
         if (track.isDrum) playDrum(note.pitch, note.velocity);
-        else playNote(note.pitch, note.velocity, note.durationSteps * stepDur * 0.85, track.waveform, undefined, track.volume);
+        else playNote(note.pitch, note.velocity, note.durationSteps * stepDur, track.waveform, undefined, track.volume, track.attack, track.release);
       });
     });
     stepRef.current = (step + 1) % total;
@@ -995,18 +1054,42 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const addDrumTrack = useCallback(() => {
     setPattern(prev => {
-      const drumCount  = prev.tracks.filter(t => t.isDrum).length;
+      const drumCount   = prev.tracks.filter(t => t.isDrum).length;
       const lastDrumIdx = prev.tracks.reduce((acc, t, i) => t.isDrum ? i : acc, -1);
       const newTrack: Track = {
         id: `d${makeNoteId()}`, name: `Drums ${drumCount + 1}`,
         color: TRACK_COLORS[(drumCount + 3) % TRACK_COLORS.length],
         waveform: 'sine', notes: [], muted: false, isDrum: true,
         volume: 1, attack: 0.01, release: 0.3, collapsed: false,
+        drumRows: [...DEFAULT_DRUM_ROWS],
       };
       const tracks = [...prev.tracks];
       tracks.splice(lastDrumIdx + 1, 0, newTrack);
       return { ...prev, tracks };
     });
+  }, []);
+
+  const addDrumPiece = useCallback((trackId: string, pitch: number) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t => {
+        if (t.id !== trackId) return t;
+        const rows = t.drumRows?.length ? t.drumRows : [...DEFAULT_DRUM_ROWS];
+        if (rows.includes(pitch)) return t;
+        return { ...t, drumRows: [...rows, pitch] };
+      }),
+    }));
+  }, []);
+
+  const removeDrumPiece = useCallback((trackId: string, pitch: number) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t => {
+        if (t.id !== trackId) return t;
+        const rows = (t.drumRows?.length ? t.drumRows : [...DEFAULT_DRUM_ROWS]).filter(p => p !== pitch);
+        return { ...t, drumRows: rows, notes: t.notes.filter(n => n.pitch !== pitch) };
+      }),
+    }));
   }, []);
 
   const newPattern = useCallback(() => {
@@ -1021,10 +1104,18 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       label: 'File',
       items: [
         { label: 'New Pattern',       onClick: newPattern },
+        { separator: true },
         { label: 'Save to Library…',  onClick: () => setShowSave(true) },
         { label: 'Load from Library…',onClick: () => setShowLoad(true) },
         { label: 'Download JSON',     onClick: () => downloadJson(patternRef.current) },
         ...(onQuit ? [{ separator: true as const }, { label: 'Close', onClick: onQuit }] : []),
+      ],
+    },
+    {
+      label: 'Track',
+      items: [
+        { label: 'Add Melody Track', onClick: addMelodicTrack },
+        { label: 'Add Drum Track',   onClick: addDrumTrack },
       ],
     },
     {
@@ -1037,7 +1128,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         { label: 'BPM 160', onClick: () => setPattern(p => ({ ...p, bpm: 160 })) },
       ],
     },
-  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit]);
+  ], [isPlaying, startPlayback, stopPlayback, newPattern, addMelodicTrack, addDrumTrack, onQuit]);
 
   useWindowMenus(menus);
 
@@ -1070,9 +1161,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         onZoomIn={() => setZoomIdx(i => Math.min(i + 1, ZOOM_PRESETS.length - 1))}
         onZoomOut={() => setZoomIdx(i => Math.max(i - 1, 0))}
         onNew={newPattern}
-        onSave={() => setShowSave(true)}
-        onLoad={() => setShowLoad(true)}
-        onDownload={() => downloadJson(patternRef.current)}
         onToggleEditMode={() => setEditMode(m => !m)}
       />
 
@@ -1106,12 +1194,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
               beatsPerBar={pattern.beatsPerBar}
               stepW={stepW}
               rowH={rowH}
-              canDelete={pattern.tracks.length > 1}
               editMode={editMode}
               paintModeRef={paintModeRef}
               onToggleCollapse={() => toggleCollapse(track.id)}
               onGear={() => setModalTid(track.id)}
-              onDelete={() => deleteTrack(track.id)}
               onMute={() => muteTrack(track.id)}
               onAddNote={(pitch, step) => addNote(track.id, pitch, step)}
               onRemoveNote={noteId => removeNote(track.id, noteId)}
@@ -1120,13 +1206,14 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
               }
               onPreviewPitch={pitch => previewPitch(track, pitch)}
               onPreviewDrum={previewDrum}
+              onAddDrumPiece={pitch => addDrumPiece(track.id, pitch)}
+              onRemoveDrumPiece={pitch => removeDrumPiece(track.id, pitch)}
             />
           ))}
 
           {/* Add track row */}
           <div className="me-add-track-row" style={{ height: HDR_H }}>
             <div className="me-add-track-left" style={{ width: LEFT_W }}>
-              <button className="me-btn me-btn--sm" onPointerDown={addDrumTrack}>+ Drums</button>
               <button className="me-btn me-btn--sm" onPointerDown={addMelodicTrack}>+ Melody</button>
             </div>
             <div className="me-add-track-fill" style={{ width: gridW }} />
@@ -1145,8 +1232,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       {modalTrack && (
         <InstrumentModal
           track={modalTrack}
+          canDelete={pattern.tracks.length > 1}
           onSave={updates => { updateTrack(modalTrack.id, updates); setModalTid(null); }}
           onClose={() => setModalTid(null)}
+          onDelete={() => { deleteTrack(modalTrack.id); setModalTid(null); }}
         />
       )}
       {showSave && (

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -2,28 +2,28 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useWindowMenus } from '../../components/Window/useWindowMenus';
 import type { MenuBarMenu } from '../../components/MenuBar/MenuBar';
 import {
-  type Pattern,
-  type Track,
-  type Note,
-  type DrumType,
-  type OscWaveform,
-  DRUM_TYPES,
-  DRUM_LABELS,
-  DRUM_PITCHES,
-  PIANO_MIN,
-  PIANO_MAX,
-  STEP_W,
-  ROW_H,
-  isBlackPitch,
-  pitchName,
-  makeNoteId,
-  createInitialPattern,
-  TRACK_COLORS,
+  type Pattern, type Track, type Note, type DrumType, type OscWaveform,
+  DRUM_TYPES, DRUM_LABELS, DRUM_PITCHES, PIANO_MIN, PIANO_MAX,
+  isBlackPitch, pitchName, makeNoteId, createInitialPattern, TRACK_COLORS,
 } from './types';
 import { resumeAudio, playNote, playDrum } from './audio';
 import './MidiEditor.css';
 
-// ── Module-level constants ─────────────────────────────────────────────────────
+// ── Layout & zoom constants ────────────────────────────────────────────────────
+
+const ZOOM_PRESETS = [
+  { stepW: 14, rowH: 10 },
+  { stepW: 18, rowH: 13 },
+  { stepW: 24, rowH: 16 },   // default
+  { stepW: 32, rowH: 22 },
+  { stepW: 44, rowH: 30 },
+] as const;
+const DEFAULT_ZOOM = 2;
+
+const LEFT_W  = 100; // sticky left sidebar (track controls + piano keys)
+const KEYS_W  = 40;  // piano keys / drum labels within the sidebar
+const RULER_H = 24;  // time ruler row height
+const HDR_H   = 32;  // track header row height
 
 const PITCH_RANGE: number[] = [];
 for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
@@ -31,82 +31,299 @@ for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
 const PITCH_TO_ROW = new Map<number, number>();
 PITCH_RANGE.forEach((p, i) => PITCH_TO_ROW.set(p, i));
 
-const DRUM_SEP_H = 5;
-const MELODIC_H  = PITCH_RANGE.length * ROW_H;
-const DRUM_H     = DRUM_TYPES.length * ROW_H;
+// ── Types ──────────────────────────────────────────────────────────────────────
 
-type PaintState = { action: 'add' | 'remove'; section: 'melodic' | 'drum' } | null;
+type PaintState = { action: 'add' | 'remove'; trackId: string } | null;
+type ResizeState = { noteId: string; trackId: string; startX: number; origDuration: number; noteStartStep: number };
+
+interface SaveEntry { name: string; pattern: Pattern; savedAt: string }
+
+// ── Storage helpers ────────────────────────────────────────────────────────────
+
+const STORAGE_AUTO = 'midi-editor-pattern';
+const STORAGE_SAVES = 'midi-editor-saves';
+const STORAGE_ZOOM  = 'midi-editor-zoom';
+
+function migrateTrack(t: Track): Track {
+  const defaults = { volume: 1, attack: 0.01, release: 0.3, collapsed: false };
+  return { ...defaults, ...t };
+}
+
+function migratePattern(raw: unknown): Pattern {
+  const p = raw as Pattern;
+  return { ...p, tracks: p.tracks.map(migrateTrack) };
+}
+
+function loadPattern(): Pattern {
+  try {
+    const raw = localStorage.getItem(STORAGE_AUTO);
+    if (raw) return migratePattern(JSON.parse(raw));
+  } catch { /* ignore */ }
+  return createInitialPattern();
+}
+
+function loadZoomIdx(): number {
+  try { return Number(localStorage.getItem(STORAGE_ZOOM)) || DEFAULT_ZOOM; } catch { return DEFAULT_ZOOM; }
+}
+
+function getSaves(): SaveEntry[] {
+  try { return JSON.parse(localStorage.getItem(STORAGE_SAVES) || '[]'); } catch { return []; }
+}
+
+function persistSave(name: string, pattern: Pattern) {
+  const saves = getSaves().filter(s => s.name !== name);
+  saves.unshift({ name, pattern, savedAt: new Date().toISOString() });
+  try { localStorage.setItem(STORAGE_SAVES, JSON.stringify(saves.slice(0, 20))); } catch { /* ignore */ }
+}
+
+function deleteSave(name: string) {
+  const saves = getSaves().filter(s => s.name !== name);
+  try { localStorage.setItem(STORAGE_SAVES, JSON.stringify(saves)); } catch { /* ignore */ }
+}
+
+function downloadJson(pattern: Pattern) {
+  const blob = new Blob([JSON.stringify(pattern, null, 2)], { type: 'application/json' });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href = url; a.download = 'midi-pattern.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Build note map (pitch,step → noteId) ──────────────────────────────────────
 
 function buildNoteMap(track: Track): Map<string, string> {
   const m = new Map<string, string>();
   track.notes.forEach(n => {
-    for (let d = 0; d < n.durationSteps; d++) {
-      m.set(`${n.pitch},${n.startStep + d}`, n.id);
-    }
+    for (let d = 0; d < n.durationSteps; d++) m.set(`${n.pitch},${n.startStep + d}`, n.id);
   });
   return m;
 }
 
-// ── Transport ──────────────────────────────────────────────────────────────────
+// ── Instrument modal ───────────────────────────────────────────────────────────
+
+interface InstrumentModalProps {
+  track: Track;
+  onSave: (updates: Partial<Track>) => void;
+  onClose: () => void;
+}
+
+function InstrumentModal({ track, onSave, onClose }: InstrumentModalProps) {
+  const [name,     setName]     = useState(track.name);
+  const [color,    setColor]    = useState(track.color);
+  const [waveform, setWaveform] = useState(track.waveform);
+  const [volume,   setVolume]   = useState(Math.round(track.volume * 100));
+
+  function save() { onSave({ name, color, waveform, volume: volume / 100 }); }
+
+  return (
+    <div className="me-modal-backdrop" onPointerDown={onClose}>
+      <div className="me-modal" onPointerDown={e => e.stopPropagation()}>
+        <div className="me-modal__title">
+          <span>⚙ Track Settings</span>
+          <button className="me-modal__close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="me-modal__body">
+          <div className="me-modal__row">
+            <label className="me-label">NAME</label>
+            <input
+              className="me-text-input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={16}
+            />
+          </div>
+
+          <div className="me-modal__row">
+            <label className="me-label">COLOR</label>
+            <div className="me-color-swatches">
+              {TRACK_COLORS.map(c => (
+                <button
+                  key={c}
+                  className={`me-color-swatch${c === color ? ' me-color-swatch--active' : ''}`}
+                  style={{ background: c }}
+                  onClick={() => setColor(c)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {!track.isDrum && (
+            <div className="me-modal__row">
+              <label className="me-label">SYNTH</label>
+              <select
+                className="me-select"
+                value={waveform}
+                onChange={e => setWaveform(e.target.value as OscWaveform)}
+              >
+                <option value="sine">Sine</option>
+                <option value="triangle">Triangle</option>
+                <option value="square">Square</option>
+                <option value="sawtooth">Sawtooth</option>
+              </select>
+            </div>
+          )}
+
+          <div className="me-modal__row">
+            <label className="me-label">VOL {volume}%</label>
+            <input
+              type="range" min={0} max={100} value={volume}
+              onChange={e => setVolume(Number(e.target.value))}
+              className="me-slider"
+            />
+          </div>
+
+          <div className="me-modal__row me-modal__row--dim">
+            <label className="me-label">SOUND</label>
+            <span className="me-label me-label--dim">Upload sample (coming soon)</span>
+          </div>
+        </div>
+
+        <div className="me-modal__footer">
+          <button className="me-btn" onClick={onClose}>Cancel</button>
+          <button className="me-btn me-btn--primary" onClick={save}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Save / Load dialogs ────────────────────────────────────────────────────────
+
+interface SaveDialogProps { onSave: (name: string) => void; onClose: () => void }
+
+function SaveDialog({ onSave, onClose }: SaveDialogProps) {
+  const [name, setName] = useState('My Pattern');
+  const saves = getSaves();
+  return (
+    <div className="me-modal-backdrop" onPointerDown={onClose}>
+      <div className="me-modal" onPointerDown={e => e.stopPropagation()}>
+        <div className="me-modal__title">
+          <span>💾 Save Pattern</span>
+          <button className="me-modal__close" onClick={onClose}>✕</button>
+        </div>
+        <div className="me-modal__body">
+          <div className="me-modal__row">
+            <label className="me-label">NAME</label>
+            <input
+              className="me-text-input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={32}
+              autoFocus
+            />
+          </div>
+          {saves.length > 0 && (
+            <div className="me-save-list">
+              {saves.map(s => (
+                <div key={s.name} className="me-save-item" onClick={() => setName(s.name)}>
+                  <span>{s.name}</span>
+                  <span className="me-label--dim">{s.savedAt.slice(0, 10)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="me-modal__footer">
+          <button className="me-btn" onClick={onClose}>Cancel</button>
+          <button className="me-btn me-btn--primary" onClick={() => { if (name.trim()) onSave(name.trim()); }}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface LoadDialogProps { onLoad: (p: Pattern) => void; onClose: () => void }
+
+function LoadDialog({ onLoad, onClose }: LoadDialogProps) {
+  const [saves, setSaves] = useState(getSaves);
+  return (
+    <div className="me-modal-backdrop" onPointerDown={onClose}>
+      <div className="me-modal" onPointerDown={e => e.stopPropagation()}>
+        <div className="me-modal__title">
+          <span>📂 Load Pattern</span>
+          <button className="me-modal__close" onClick={onClose}>✕</button>
+        </div>
+        <div className="me-modal__body">
+          {saves.length === 0
+            ? <p className="me-label me-label--dim">No saved patterns.</p>
+            : (
+              <div className="me-save-list">
+                {saves.map(s => (
+                  <div key={s.name} className="me-save-item me-save-item--load">
+                    <button className="me-btn me-btn--sm" onClick={() => onLoad(migratePattern(s.pattern))}>
+                      Load
+                    </button>
+                    <span>{s.name}</span>
+                    <span className="me-label--dim">{s.savedAt.slice(0, 10)}</span>
+                    <button
+                      className="me-btn me-btn--sm me-btn--danger"
+                      onClick={() => { deleteSave(s.name); setSaves(getSaves()); }}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+        </div>
+        <div className="me-modal__footer">
+          <button className="me-btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Transport bar ──────────────────────────────────────────────────────────────
 
 interface TransportProps {
   pattern: Pattern;
   isPlaying: boolean;
-  activeTrackIdx: number;
-  activeTrack: Track;
-  melodicTrackCount: number;
+  zoomIdx: number;
   onPlay: () => void;
   onStop: () => void;
   onBpmChange: (bpm: number) => void;
   onBarsChange: (bars: number) => void;
   onStepsPerBeatChange: (spb: number) => void;
-  onActiveTrackChange: (idx: number) => void;
-  onMuteTrack: (trackId: string) => void;
-  onChangeWaveform: (trackId: string, waveform: OscWaveform) => void;
-  onAddTrack: () => void;
-  onRemoveTrack: () => void;
-  onNewPattern: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onNew: () => void;
+  onSave: () => void;
+  onLoad: () => void;
+  onDownload: () => void;
 }
 
 function Transport({
-  pattern, isPlaying, activeTrackIdx, activeTrack, melodicTrackCount,
+  pattern, isPlaying, zoomIdx,
   onPlay, onStop, onBpmChange, onBarsChange, onStepsPerBeatChange,
-  onActiveTrackChange, onMuteTrack, onChangeWaveform, onAddTrack, onRemoveTrack, onNewPattern,
+  onZoomIn, onZoomOut, onNew, onSave, onLoad, onDownload,
 }: TransportProps) {
-  const melodicTracks = pattern.tracks.filter(t => !t.isDrum);
-
-  function nudgeBpm(delta: number) {
+  function nudge(delta: number) {
     onBpmChange(Math.max(40, Math.min(240, pattern.bpm + delta)));
   }
 
   return (
     <div className="me-transport">
       <div className="me-transport__row">
-        <button
-          className={`me-btn me-btn--play ${isPlaying ? 'me-btn--stop' : ''}`}
-          onMouseDown={isPlaying ? onStop : onPlay}
-        >
+        <button className={`me-btn me-btn--play${isPlaying ? ' me-btn--stop' : ''}`} onPointerDown={isPlaying ? onStop : onPlay}>
           {isPlaying ? '■' : '▶'}
         </button>
 
         <div className="me-transport__group">
           <span className="me-label">BPM</span>
-          <button className="me-btn me-btn--sm" onMouseDown={() => nudgeBpm(-5)}>-</button>
+          <button className="me-btn me-btn--sm" onPointerDown={() => nudge(-5)}>−</button>
           <input
-            className="me-num-input"
-            type="number"
-            min={40}
-            max={240}
-            value={pattern.bpm}
+            className="me-num-input" type="number" min={40} max={240} value={pattern.bpm}
             onChange={e => onBpmChange(Number(e.target.value))}
           />
-          <button className="me-btn me-btn--sm" onMouseDown={() => nudgeBpm(5)}>+</button>
+          <button className="me-btn me-btn--sm" onPointerDown={() => nudge(5)}>+</button>
         </div>
 
         <div className="me-transport__group">
           <span className="me-label">BARS</span>
           <select className="me-select" value={pattern.bars} onChange={e => onBarsChange(Number(e.target.value))}>
-            {[1, 2, 4, 8].map(n => <option key={n} value={n}>{n}</option>)}
+            {[1,2,4,8].map(n => <option key={n} value={n}>{n}</option>)}
           </select>
         </div>
 
@@ -119,404 +336,412 @@ function Transport({
         </div>
 
         <div className="me-transport__sep" />
-        <button className="me-btn me-btn--new" onMouseDown={onNewPattern}>NEW</button>
+
+        <div className="me-transport__group">
+          <span className="me-label">ZOOM</span>
+          <button className="me-btn me-btn--sm" onPointerDown={onZoomOut} disabled={zoomIdx <= 0}>−</button>
+          <button className="me-btn me-btn--sm" onPointerDown={onZoomIn}  disabled={zoomIdx >= ZOOM_PRESETS.length - 1}>+</button>
+        </div>
+
+        <div className="me-transport__sep" />
+
+        <button className="me-btn me-btn--sm" onPointerDown={onNew}      title="New pattern">NEW</button>
+        <button className="me-btn me-btn--sm" onPointerDown={onSave}     title="Save to library">SAVE</button>
+        <button className="me-btn me-btn--sm" onPointerDown={onLoad}     title="Load from library">LOAD</button>
+        <button className="me-btn me-btn--sm" onPointerDown={onDownload} title="Download as JSON">⤓JSON</button>
+
         <span className="me-label me-label--dim">SPACE=play</span>
-      </div>
-
-      <div className="me-transport__row">
-        <span className="me-label me-label--dim">ROLL:</span>
-        {melodicTracks.map((t, i) => (
-          <button
-            key={t.id}
-            className={`me-track-btn ${i === activeTrackIdx ? 'me-track-btn--active' : ''}`}
-            style={{ '--track-color': t.color } as React.CSSProperties}
-            onMouseDown={() => onActiveTrackChange(i)}
-          >
-            {t.name}
-          </button>
-        ))}
-        <button className="me-btn me-btn--sm" onMouseDown={onAddTrack} disabled={melodicTrackCount >= 10} title="Add track">+TRK</button>
-        <button className="me-btn me-btn--sm" onMouseDown={onRemoveTrack} disabled={melodicTrackCount <= 1} title="Remove active track">-TRK</button>
-
-        <div className="me-transport__sep" />
-
-        <span className="me-label me-label--dim">WAVE:</span>
-        <select
-          className="me-select"
-          value={activeTrack.waveform}
-          onChange={e => onChangeWaveform(activeTrack.id, e.target.value as OscWaveform)}
-        >
-          <option value="sine">Sine</option>
-          <option value="triangle">Tri</option>
-          <option value="square">Sqr</option>
-          <option value="sawtooth">Saw</option>
-        </select>
-
-        <div className="me-transport__sep" />
-        <span className="me-label me-label--dim">MUTE:</span>
-        {pattern.tracks.map(t => (
-          <button
-            key={t.id}
-            className={`me-mute-btn ${t.muted ? 'me-mute-btn--muted' : ''}`}
-            style={{ '--track-color': t.color } as React.CSSProperties}
-            onMouseDown={() => onMuteTrack(t.id)}
-            title={`${t.muted ? 'Unmute' : 'Mute'} ${t.name}`}
-          >
-            {t.name[0]}
-          </button>
-        ))}
       </div>
     </div>
   );
 }
 
-// ── Piano Roll ─────────────────────────────────────────────────────────────────
-// Layout: left sidebar (keys + drum labels, always visible) + right grid area
-// (horizontal scroll). Inside the grid area: melodic grid scrolls vertically;
-// drum grid is pinned at the bottom so it's always reachable without scrolling.
+// ── Melodic note grid ──────────────────────────────────────────────────────────
 
-interface PianoRollProps {
-  melodicTrack: Track;
-  drumTrack: Track;
+interface MelodicGridProps {
+  track: Track;
   totalSteps: number;
   stepsPerBeat: number;
   beatsPerBar: number;
-  playheadRef: React.RefObject<HTMLDivElement | null>;
+  stepW: number;
+  rowH: number;
   paintModeRef: React.MutableRefObject<PaintState>;
-  onAddNote: (trackId: string, pitch: number, step: number) => void;
-  onRemoveNote: (trackId: string, noteId: string) => void;
-  onStartResize: (noteId: string, startX: number, origDuration: number, noteStartStep: number) => void;
+  onAddNote: (pitch: number, step: number) => void;
+  onRemoveNote: (noteId: string) => void;
+  onStartResize: (noteId: string, startX: number, origDur: number, noteStart: number) => void;
   onPreviewPitch: (pitch: number) => void;
-  onPreviewDrum: (pitch: number) => void;
 }
 
-function PianoRoll({
-  melodicTrack, drumTrack, totalSteps, stepsPerBeat, beatsPerBar,
-  playheadRef, paintModeRef, onAddNote, onRemoveNote, onStartResize,
-  onPreviewPitch, onPreviewDrum,
-}: PianoRollProps) {
-  const noteMap     = useMemo(() => buildNoteMap(melodicTrack), [melodicTrack]);
-  const drumNoteMap = useMemo(() => buildNoteMap(drumTrack),    [drumTrack]);
+function MelodicGrid({
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH,
+  paintModeRef, onAddNote, onRemoveNote, onStartResize, onPreviewPitch,
+}: MelodicGridProps) {
+  const noteMap  = useMemo(() => buildNoteMap(track), [track]);
+  const gridW    = totalSteps * stepW;
+  const gridH    = PITCH_RANGE.length * rowH;
 
-  const lastPaintedRef      = useRef('');
-  const lastPreviewPitchRef = useRef(-1);
+  const noteRects = useMemo(
+    () => track.notes.filter(n => n.startStep < totalSteps),
+    [track.notes, totalSteps],
+  );
 
-  // Scroll sync: piano keys track the melodic grid's vertical scroll position
-  const keysScrollRef    = useRef<HTMLDivElement>(null);
-  const melodicScrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const mel  = melodicScrollRef.current;
-    const keys = keysScrollRef.current;
-    if (!mel || !keys) return;
-    function sync() { if (keys) keys.scrollTop = mel!.scrollTop; }
-    mel.addEventListener('scroll', sync, { passive: true });
-    return () => mel.removeEventListener('scroll', sync);
-  }, []);
-
-  const gridWidth = totalSteps * STEP_W;
-
-  // ── Melodic cell handlers ──────────────────────────────────────────────────
-
-  function handleCellDown(pitch: number, step: number) {
-    paintModeRef.current        = { action: 'add', section: 'melodic' };
-    lastPaintedRef.current      = `m:${pitch},${step}`;
-    lastPreviewPitchRef.current = pitch;
-    onAddNote(melodicTrack.id, pitch, step);
-    onPreviewPitch(pitch);
-  }
-
-  function handleCellEnter(pitch: number, step: number) {
-    const pm = paintModeRef.current;
-    if (!pm || pm.section !== 'melodic' || pm.action !== 'add') return;
-    const key = `m:${pitch},${step}`;
-    if (key === lastPaintedRef.current || noteMap.has(`${pitch},${step}`)) return;
-    lastPaintedRef.current = key;
-    onAddNote(melodicTrack.id, pitch, step);
-    if (pitch !== lastPreviewPitchRef.current) {
-      lastPreviewPitchRef.current = pitch;
+  function cellDown(pitch: number, step: number) {
+    const existingId = noteMap.get(`${pitch},${step}`);
+    if (existingId) {
+      paintModeRef.current = { action: 'remove', trackId: track.id };
+      onRemoveNote(existingId);
+    } else {
+      paintModeRef.current = { action: 'add', trackId: track.id };
+      onAddNote(pitch, step);
       onPreviewPitch(pitch);
     }
   }
 
-  function handleNoteDown(e: React.MouseEvent, note: Note, noteW: number) {
-    e.stopPropagation();
-    e.preventDefault();
-    if (e.nativeEvent.offsetX >= noteW - 6) {
-      paintModeRef.current = null;
-      onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
-    } else {
-      paintModeRef.current    = { action: 'remove', section: 'melodic' };
-      lastPaintedRef.current  = note.id;
-      onRemoveNote(melodicTrack.id, note.id);
-    }
-  }
+  return (
+    <div
+      className="me-note-grid"
+      style={{ width: gridW, height: gridH }}
+    >
+      {/* Step column markers */}
+      {Array.from({ length: totalSteps }, (_, s) => {
+        const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
+        const isBeat = !isBar && s % stepsPerBeat === 0;
+        const isQ4   = !isBar && !isBeat && s % 4 === 0;
+        return (
+          <div
+            key={`sc-${s}`}
+            className={`me-step-col${isBar?' me-step-col--bar':isBeat?' me-step-col--beat':isQ4?' me-step-col--q4':''}`}
+            style={{ left: s * stepW, width: stepW, height: gridH }}
+          />
+        );
+      })}
 
-  function handleNoteEnter(note: Note) {
-    const pm = paintModeRef.current;
-    if (!pm || pm.section !== 'melodic' || pm.action !== 'remove') return;
-    if (note.id === lastPaintedRef.current) return;
-    lastPaintedRef.current = note.id;
-    onRemoveNote(melodicTrack.id, note.id);
-  }
+      {/* Background cells */}
+      {PITCH_RANGE.map((pitch, rowIdx) => {
+        const isBlack = isBlackPitch(pitch);
+        return Array.from({ length: totalSteps }, (_, step) => {
+          if (noteMap.has(`${pitch},${step}`)) return null;
+          return (
+            <div
+              key={`bg-${pitch}-${step}`}
+              className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
+              style={{ left: step * stepW, top: rowIdx * rowH, width: stepW, height: rowH }}
+              data-pitch={pitch}
+              data-step={step}
+              data-track-id={track.id}
+              onPointerDown={e => { e.preventDefault(); cellDown(pitch, step); }}
+            />
+          );
+        });
+      })}
 
-  // ── Drum cell handlers ─────────────────────────────────────────────────────
+      {/* Note rectangles */}
+      {noteRects.map(note => {
+        const rowIdx = PITCH_TO_ROW.get(note.pitch);
+        if (rowIdx === undefined) return null;
+        const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
+        const noteW = displayDur * stepW;
+        return (
+          <div
+            key={note.id}
+            className="me-note-rect"
+            style={{
+              left: note.startStep * stepW, top: rowIdx * rowH,
+              width: noteW, height: rowH, background: track.color,
+            }}
+            data-note-id={note.id}
+            data-track-id={track.id}
+            onPointerDown={e => {
+              e.preventDefault(); e.stopPropagation();
+              paintModeRef.current = { action: 'remove', trackId: track.id };
+              onRemoveNote(note.id);
+            }}
+          >
+            <div
+              className="me-note-resize-handle"
+              onPointerDown={e => {
+                e.stopPropagation(); e.preventDefault();
+                paintModeRef.current = null;
+                onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
+              }}
+            />
+          </div>
+        );
+      })}
 
-  function handleDrumDown(pitch: number, step: number, existingId: string | undefined) {
-    if (existingId) {
-      paintModeRef.current   = { action: 'remove', section: 'drum' };
-      lastPaintedRef.current = existingId;
-      onRemoveNote(drumTrack.id, existingId);
-    } else {
-      paintModeRef.current   = { action: 'add', section: 'drum' };
-      lastPaintedRef.current = `d:${pitch},${step}`;
-      onAddNote(drumTrack.id, pitch, step);
-      onPreviewDrum(pitch);
-    }
-  }
-
-  function handleDrumEnter(pitch: number, step: number, existingId: string | undefined) {
-    const pm = paintModeRef.current;
-    if (!pm || pm.section !== 'drum') return;
-    if (pm.action === 'add') {
-      const key = `d:${pitch},${step}`;
-      if (key === lastPaintedRef.current || existingId) return;
-      lastPaintedRef.current = key;
-      onAddNote(drumTrack.id, pitch, step);
-      onPreviewDrum(pitch);
-    } else {
-      if (!existingId || existingId === lastPaintedRef.current) return;
-      lastPaintedRef.current = existingId;
-      onRemoveNote(drumTrack.id, existingId);
-    }
-  }
-
-  const noteRects = useMemo(
-    () => melodicTrack.notes.filter(n => n.startStep < totalSteps),
-    [melodicTrack.notes, totalSteps],
+      {/* Octave dividers at each C */}
+      {PITCH_RANGE.map((pitch, rowIdx) =>
+        pitch % 12 === 0
+          ? <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * rowH, width: gridW }} />
+          : null
+      )}
+    </div>
   );
+}
 
-  // Step column elements reused in both grids
-  function renderStepCols(height: number, prefix: string) {
-    return Array.from({ length: totalSteps }, (_, s) => {
-      const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
-      const isBeat = !isBar && s % stepsPerBeat === 0;
-      const isQ4   = !isBar && !isBeat && s % 4 === 0;
-      const cls = isBar ? ' me-step-col--bar' : isBeat ? ' me-step-col--beat' : isQ4 ? ' me-step-col--q4' : '';
-      return (
-        <div
-          key={`${prefix}-${s}`}
-          className={`me-step-col${cls}`}
-          style={{ left: s * STEP_W, width: STEP_W, height }}
-        />
-      );
-    });
+// ── Drum grid ──────────────────────────────────────────────────────────────────
+
+interface DrumGridProps {
+  track: Track;
+  totalSteps: number;
+  stepsPerBeat: number;
+  beatsPerBar: number;
+  stepW: number;
+  rowH: number;
+  paintModeRef: React.MutableRefObject<PaintState>;
+  onAddNote: (pitch: number, step: number) => void;
+  onRemoveNote: (noteId: string) => void;
+  onPreviewDrum: (pitch: number) => void;
+}
+
+function DrumGrid({
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH,
+  paintModeRef, onAddNote, onRemoveNote, onPreviewDrum,
+}: DrumGridProps) {
+  const drumNoteMap = useMemo(() => buildNoteMap(track), [track]);
+  const gridW = totalSteps * stepW;
+  const gridH = DRUM_TYPES.length * rowH;
+
+  function cellDown(pitch: number, step: number, existingId: string | undefined) {
+    if (existingId) {
+      paintModeRef.current = { action: 'remove', trackId: track.id };
+      onRemoveNote(existingId);
+    } else {
+      paintModeRef.current = { action: 'add', trackId: track.id };
+      onAddNote(pitch, step);
+      onPreviewDrum(pitch);
+    }
   }
 
   return (
-    <div className="me-piano-roll">
-
-      {/* ── Left sidebar: always visible regardless of scroll ─────────────── */}
-      <div className="me-keys-col">
-
-        {/* Piano keys — overflow hidden; scrollTop synced from melodic grid */}
-        <div className="me-keys-scroll" ref={keysScrollRef}>
-          {PITCH_RANGE.map(pitch => {
-            const isBlack = isBlackPitch(pitch);
-            const isC     = pitch % 12 === 0;
-            return (
-              <div
-                key={pitch}
-                className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
-                style={{ height: ROW_H }}
-                onMouseDown={() => { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }}
-                onMouseEnter={e => {
-                  if (e.buttons === 1) { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }
-                }}
-              >
-                {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="me-drum-key-sep" style={{ height: DRUM_SEP_H }} />
-
-        {DRUM_TYPES.map((dt: DrumType) => (
+    <div className="me-drum-grid" style={{ width: gridW, height: gridH }}>
+      {/* Step columns */}
+      {Array.from({ length: totalSteps }, (_, s) => {
+        const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
+        const isBeat = !isBar && s % stepsPerBeat === 0;
+        const isQ4   = !isBar && !isBeat && s % 4 === 0;
+        return (
           <div
-            key={dt}
-            className="me-drum-key"
-            style={{ height: ROW_H }}
-            onMouseDown={() => onPreviewDrum(DRUM_PITCHES[dt])}
-            onMouseEnter={e => { if (e.buttons === 1) onPreviewDrum(DRUM_PITCHES[dt]); }}
-          >
-            {DRUM_LABELS[dt]}
+            key={`ds-${s}`}
+            className={`me-step-col${isBar?' me-step-col--bar':isBeat?' me-step-col--beat':isQ4?' me-step-col--q4':''}`}
+            style={{ left: s * stepW, width: stepW, height: gridH }}
+          />
+        );
+      })}
+
+      {/* Drum cells */}
+      {DRUM_TYPES.map((dt: DrumType, rowIdx) => {
+        const pitch  = DRUM_PITCHES[dt];
+        const rowTop = rowIdx * rowH;
+        return Array.from({ length: totalSteps }, (_, step) => {
+          const existingId = drumNoteMap.get(`${pitch},${step}`);
+          const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+          const isBeat = !isBar && step % stepsPerBeat === 0;
+          return (
+            <div
+              key={`dcell-${dt}-${step}`}
+              className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
+              style={{
+                left: step * stepW, top: rowTop, width: stepW, height: rowH,
+                ...((existingId ? { '--drum-color': track.color } : {}) as React.CSSProperties),
+              }}
+              data-drum-pitch={pitch}
+              data-step={step}
+              data-track-id={track.id}
+              data-note-id={existingId ?? ''}
+              onPointerDown={e => { e.preventDefault(); cellDown(pitch, step, existingId); }}
+            />
+          );
+        });
+      })}
+    </div>
+  );
+}
+
+// ── Track section (accordion row) ─────────────────────────────────────────────
+
+interface TrackSectionProps {
+  track: Track;
+  totalSteps: number;
+  stepsPerBeat: number;
+  beatsPerBar: number;
+  stepW: number;
+  rowH: number;
+  canDelete: boolean;
+  paintModeRef: React.MutableRefObject<PaintState>;
+  onToggleCollapse: () => void;
+  onGear: () => void;
+  onDelete: () => void;
+  onMute: () => void;
+  onAddNote: (pitch: number, step: number) => void;
+  onRemoveNote: (noteId: string) => void;
+  onStartResize: (noteId: string, startX: number, origDur: number, noteStart: number) => void;
+  onPreviewPitch: (pitch: number) => void;
+  onPreviewDrum: (pitch: number) => void;
+}
+
+function TrackSection({
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, canDelete,
+  paintModeRef, onToggleCollapse, onGear, onDelete, onMute,
+  onAddNote, onRemoveNote, onStartResize, onPreviewPitch, onPreviewDrum,
+}: TrackSectionProps) {
+  const gridW    = totalSteps * stepW;
+  const pitchH   = PITCH_RANGE.length * rowH;
+  const drumH    = DRUM_TYPES.length * rowH;
+  const contentH = track.isDrum ? drumH : pitchH;
+
+  return (
+    <div className="me-track-section" style={{ '--tcolor': track.color } as React.CSSProperties}>
+      {/* Header row: sticky-left controls + colored fill */}
+      <div className="me-track-header-row" style={{ height: HDR_H }}>
+        <div className="me-track-header-left" style={{ width: LEFT_W }}>
+          <button className="me-track-collapse" onPointerDown={onToggleCollapse} title="Collapse">
+            {track.collapsed ? '▶' : '▼'}
+          </button>
+          <span
+            className="me-track-color-dot"
+            style={{ background: track.color }}
+          />
+          <span className="me-track-name">{track.name}</span>
+          <div className="me-track-header-btns">
+            <button
+              className={`me-mute-btn${track.muted ? ' me-mute-btn--muted' : ''}`}
+              onPointerDown={onMute}
+              title={track.muted ? 'Unmute' : 'Mute'}
+            >M</button>
+            <button className="me-icon-btn" onPointerDown={onGear} title="Track settings">⚙</button>
+            {canDelete && (
+              <button className="me-icon-btn me-icon-btn--del" onPointerDown={onDelete} title="Delete track">✕</button>
+            )}
           </div>
-        ))}
+        </div>
+        <div
+          className="me-track-header-fill"
+          style={{ width: gridW, background: track.color + '18' }}
+        />
       </div>
 
-      {/* ── Grid area: horizontal scroll; melodic scrolls vertically inside ── */}
-      <div className="me-grid-h-scroll">
-        <div className="me-grid-content" style={{ minWidth: gridWidth }}>
-
-          {/* Melodic grid — vertically scrollable */}
-          <div className="me-melodic-scroll" ref={melodicScrollRef}>
-            <div className="me-note-grid" style={{ width: gridWidth, height: MELODIC_H }}>
-
-              {renderStepCols(MELODIC_H, 'mc')}
-
-              {/* Melodic background cells */}
-              {PITCH_RANGE.map((pitch, rowIdx) => {
-                const isBlack = isBlackPitch(pitch);
-                return Array.from({ length: totalSteps }, (_, step) => {
-                  if (noteMap.has(`${pitch},${step}`)) return null;
-                  return (
+      {/* Content: left sidebar (keys/labels) + note grid */}
+      {!track.collapsed && (
+        <div className="me-track-content">
+          {/* Left sidebar: color strip + keys/labels */}
+          <div className="me-track-left" style={{ width: LEFT_W, height: contentH }}>
+            <div className="me-track-color-strip" style={{ background: track.color + '28' }} />
+            <div className="me-track-keys-col" style={{ width: KEYS_W }}>
+              {track.isDrum
+                ? DRUM_TYPES.map((dt: DrumType) => (
                     <div
-                      key={`bg-${pitch}-${step}`}
-                      className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
-                      style={{ left: step * STEP_W, top: rowIdx * ROW_H, width: STEP_W, height: ROW_H }}
-                      onMouseDown={e => { e.preventDefault(); handleCellDown(pitch, step); }}
-                      onMouseEnter={() => handleCellEnter(pitch, step)}
-                    />
-                  );
-                });
-              })}
-
-              {/* Note rectangles */}
-              {noteRects.map(note => {
-                const rowIdx = PITCH_TO_ROW.get(note.pitch);
-                if (rowIdx === undefined) return null;
-                const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
-                const noteW = displayDur * STEP_W;
-                return (
-                  <div
-                    key={note.id}
-                    className="me-note-rect"
-                    style={{
-                      left: note.startStep * STEP_W,
-                      top: rowIdx * ROW_H,
-                      width: noteW,
-                      height: ROW_H,
-                      background: melodicTrack.color,
-                    }}
-                    onMouseDown={e => handleNoteDown(e, note, noteW)}
-                    onMouseEnter={() => handleNoteEnter(note)}
-                  >
-                    <div
-                      className="me-note-resize-handle"
-                      onMouseDown={e => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        paintModeRef.current = null;
-                        onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
-                      }}
-                    />
-                  </div>
-                );
-              })}
-
-              {/* Octave dividers */}
-              {PITCH_RANGE.map((pitch, rowIdx) =>
-                pitch % 12 === 0 ? (
-                  <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * ROW_H, width: gridWidth }} />
-                ) : null
-              )}
+                      key={dt}
+                      className="me-drum-key"
+                      style={{ height: rowH }}
+                      onPointerDown={() => onPreviewDrum(DRUM_PITCHES[dt])}
+                    >
+                      {DRUM_LABELS[dt]}
+                    </div>
+                  ))
+                : PITCH_RANGE.map(pitch => {
+                    const isBlack = isBlackPitch(pitch);
+                    const isC     = pitch % 12 === 0;
+                    return (
+                      <div
+                        key={pitch}
+                        className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
+                        style={{ height: rowH }}
+                        onPointerDown={() => { onPreviewPitch(pitch); }}
+                        onPointerEnter={e => { if (e.buttons === 1) onPreviewPitch(pitch); }}
+                      >
+                        {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
+                      </div>
+                    );
+                  })
+              }
             </div>
           </div>
 
-          {/* Drum section separator — always visible */}
-          <div className="me-drum-section-sep" style={{ height: DRUM_SEP_H }} />
-
-          {/* Drum grid — always visible at bottom, no vertical scroll needed */}
-          <div className="me-drum-grid" style={{ width: gridWidth, height: DRUM_H }}>
-
-            {renderStepCols(DRUM_H, 'dc')}
-
-            {DRUM_TYPES.map((dt: DrumType, drumRowIdx) => {
-              const pitch  = DRUM_PITCHES[dt];
-              const rowTop = drumRowIdx * ROW_H;
-              return Array.from({ length: totalSteps }, (_, step) => {
-                const cellKey    = `${pitch},${step}`;
-                const existingId = drumNoteMap.get(cellKey);
-                const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
-                const isBeat = !isBar && step % stepsPerBeat === 0;
-                return (
-                  <div
-                    key={`drum-${dt}-${step}`}
-                    className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
-                    style={{
-                      left: step * STEP_W,
-                      top: rowTop,
-                      width: STEP_W,
-                      height: ROW_H,
-                      ...((existingId ? { '--drum-color': drumTrack.color } : {}) as React.CSSProperties),
-                    }}
-                    onMouseDown={e => { e.preventDefault(); handleDrumDown(pitch, step, existingId); }}
-                    onMouseEnter={() => handleDrumEnter(pitch, step, existingId)}
-                  />
-                );
-              });
-            })}
-          </div>
-
-          {/* Playhead — absolutely positioned over the full grid content area */}
-          <div
-            className="me-playhead"
-            ref={playheadRef as React.RefObject<HTMLDivElement>}
-            style={{ display: 'none' }}
-          />
+          {/* Note / drum grid */}
+          {track.isDrum
+            ? <DrumGrid
+                track={track}
+                totalSteps={totalSteps}
+                stepsPerBeat={stepsPerBeat}
+                beatsPerBar={beatsPerBar}
+                stepW={stepW}
+                rowH={rowH}
+                paintModeRef={paintModeRef}
+                onAddNote={onAddNote}
+                onRemoveNote={onRemoveNote}
+                onPreviewDrum={onPreviewDrum}
+              />
+            : <MelodicGrid
+                track={track}
+                totalSteps={totalSteps}
+                stepsPerBeat={stepsPerBeat}
+                beatsPerBar={beatsPerBar}
+                stepW={stepW}
+                rowH={rowH}
+                paintModeRef={paintModeRef}
+                onAddNote={onAddNote}
+                onRemoveNote={onRemoveNote}
+                onStartResize={onStartResize}
+                onPreviewPitch={onPreviewPitch}
+              />
+          }
         </div>
-      </div>
+      )}
     </div>
   );
 }
 
 // ── Main component ─────────────────────────────────────────────────────────────
 
-interface MidiEditorProps {
-  onQuit?: () => void;
-}
+interface MidiEditorProps { onQuit?: () => void }
 
 export default function MidiEditor({ onQuit }: MidiEditorProps) {
-  const [pattern, setPattern]           = useState<Pattern>(createInitialPattern);
-  const [isPlaying, setIsPlaying]       = useState(false);
-  const [activeTrackIdx, setActiveTrackIdx] = useState(0);
+  const [pattern,     setPattern]     = useState<Pattern>(loadPattern);
+  const [isPlaying,   setIsPlaying]   = useState(false);
+  const [zoomIdx,     setZoomIdx]     = useState(loadZoomIdx);
+  const [modalTid,    setModalTid]    = useState<string | null>(null);
+  const [showSave,    setShowSave]    = useState(false);
+  const [showLoad,    setShowLoad]    = useState(false);
 
-  const patternRef    = useRef(pattern);
-  patternRef.current  = pattern;
+  const { stepW, rowH } = ZOOM_PRESETS[zoomIdx];
 
-  const isPlayingRef  = useRef(false);
-  const stepRef       = useRef(0);
-  const timerRef      = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playheadRef   = useRef<HTMLDivElement | null>(null);
+  const patternRef     = useRef(pattern);
+  patternRef.current   = pattern;
+  const stepWRef       = useRef(stepW);
+  stepWRef.current     = stepW;
 
-  const paintModeRef   = useRef(null) as React.MutableRefObject<PaintState>;
+  const isPlayingRef   = useRef(false);
+  const stepRef        = useRef(0);
+  const timerRef       = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playheadRef    = useRef<HTMLDivElement | null>(null);
+
+  const paintModeRef   = useRef<PaintState>(null);
   const resizeModeRef  = useRef(false);
-  const resizeStateRef = useRef<{
-    noteId: string; trackId: string;
-    startX: number; origDuration: number; noteStartStep: number;
-  } | null>(null);
-
-  const activeTrackRef = useRef<Track | null>(null);
-
-  const melodicTracks = useMemo(() => pattern.tracks.filter(t => !t.isDrum), [pattern.tracks]);
-  const drumTrack     = useMemo(() => pattern.tracks.find(t => t.isDrum)!,   [pattern.tracks]);
-
-  const clampedIdx  = Math.min(activeTrackIdx, melodicTracks.length - 1);
-  const activeTrack = melodicTracks[clampedIdx] ?? melodicTracks[0];
-  activeTrackRef.current = activeTrack;
+  const resizeStateRef = useRef<ResizeState | null>(null);
 
   const totalSteps = useMemo(
     () => pattern.bars * pattern.beatsPerBar * pattern.stepsPerBeat,
     [pattern.bars, pattern.beatsPerBar, pattern.stepsPerBeat],
   );
+  const gridW = totalSteps * stepW;
+
+  // ── Auto-save to localStorage ────────────────────────────────────────────────
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_AUTO, JSON.stringify(pattern)); } catch { /* ignore */ }
+  }, [pattern]);
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_ZOOM, String(zoomIdx)); } catch { /* ignore */ }
+  }, [zoomIdx]);
 
   // ── Playback ──────────────────────────────────────────────────────────────────
 
   function movePlayhead(step: number) {
     if (playheadRef.current) {
-      playheadRef.current.style.display   = 'block';
-      playheadRef.current.style.transform = `translateX(${step * STEP_W}px)`;
+      playheadRef.current.style.display    = 'block';
+      playheadRef.current.style.transform  = `translateX(${LEFT_W + step * stepWRef.current}px)`;
     }
   }
 
@@ -537,20 +762,16 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     const pat   = patternRef.current;
     const total = pat.bars * pat.beatsPerBar * pat.stepsPerBeat;
     const step  = stepRef.current;
-
     movePlayhead(step);
-
-    const stepDurSec = 60 / pat.bpm / pat.stepsPerBeat;
+    const stepDur = 60 / pat.bpm / pat.stepsPerBeat;
     pat.tracks.forEach(track => {
       if (track.muted) return;
       track.notes.forEach((note: Note) => {
         if (note.startStep !== step || note.startStep >= total) return;
-        const dur = note.durationSteps * stepDurSec * 0.85;
         if (track.isDrum) playDrum(note.pitch, note.velocity);
-        else playNote(note.pitch, note.velocity, dur, track.waveform);
+        else playNote(note.pitch, note.velocity, note.durationSteps * stepDur * 0.85, track.waveform, undefined, track.volume);
       });
     });
-
     stepRef.current = (step + 1) % total;
     timerRef.current = setTimeout(tick, (60_000 / pat.bpm) / pat.stepsPerBeat);
   }, []);
@@ -565,50 +786,118 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   useEffect(() => () => { stopPlayback(); }, [stopPlayback]);
 
-  // ── Global mouse + keyboard events ────────────────────────────────────────────
+  // ── Global pointer events (resize + drag-paint for touch) ─────────────────────
 
-  useEffect(() => {
-    function handleMouseMove(e: MouseEvent) {
-      if (!resizeModeRef.current || !resizeStateRef.current) return;
+  // Stable ref-based handlers so the effect only runs once
+  const pointerMoveHandlerRef = useRef<(e: PointerEvent) => void>(() => {});
+  const pointerUpHandlerRef   = useRef<(e: PointerEvent) => void>(() => {});
+
+  pointerMoveHandlerRef.current = (e: PointerEvent) => {
+    // Resize takes priority
+    if (resizeModeRef.current && resizeStateRef.current) {
       const { noteId, trackId, startX, origDuration, noteStartStep } = resizeStateRef.current;
       const pat    = patternRef.current;
       const maxDur = pat.bars * pat.beatsPerBar * pat.stepsPerBeat - noteStartStep;
-      const newDur = Math.max(1, Math.min(maxDur, origDuration + Math.round((e.clientX - startX) / STEP_W)));
+      const newDur = Math.max(1, Math.min(maxDur, origDuration + Math.round((e.clientX - startX) / stepWRef.current)));
       setPattern(prev => ({
         ...prev,
         tracks: prev.tracks.map(t => t.id !== trackId ? t : {
           ...t, notes: t.notes.map(n => n.id !== noteId ? n : { ...n, durationSteps: newDur }),
         }),
       }));
+      return;
     }
 
-    function handleMouseUp() {
-      paintModeRef.current   = null;
-      resizeModeRef.current  = false;
-      resizeStateRef.current = null;
-    }
+    // Touch drag-paint: use elementFromPoint to find target cell
+    const pm = paintModeRef.current;
+    if (!pm) return;
 
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup',   handleMouseUp);
+    const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+    if (!el) return;
+
+    if (pm.action === 'add') {
+      // Melodic background cell
+      const bgCell = el.closest('[data-pitch][data-step]') as HTMLElement | null;
+      if (bgCell && bgCell.dataset.trackId === pm.trackId && !bgCell.classList.contains('me-note-rect')) {
+        const pitch = parseInt(bgCell.dataset.pitch ?? '');
+        const step  = parseInt(bgCell.dataset.step  ?? '');
+        if (!isNaN(pitch) && !isNaN(step)) {
+          setPattern(prev => ({
+            ...prev,
+            tracks: prev.tracks.map(t => {
+              if (t.id !== pm.trackId) return t;
+              if (t.notes.some(n => n.startStep === step && n.pitch === pitch)) return t;
+              return { ...t, notes: [...t.notes, { id: makeNoteId(), pitch, startStep: step, durationSteps: 1, velocity: 100 }] };
+            }),
+          }));
+        }
+        return;
+      }
+      // Drum cell
+      const drumCell = el.closest('[data-drum-pitch]') as HTMLElement | null;
+      if (drumCell && drumCell.dataset.trackId === pm.trackId && !drumCell.classList.contains('me-drum-cell--on')) {
+        const pitch = parseInt(drumCell.dataset.drumPitch ?? '');
+        const step  = parseInt(drumCell.dataset.step      ?? '');
+        if (!isNaN(pitch) && !isNaN(step)) {
+          setPattern(prev => ({
+            ...prev,
+            tracks: prev.tracks.map(t => {
+              if (t.id !== pm.trackId) return t;
+              if (t.notes.some(n => n.startStep === step && n.pitch === pitch)) return t;
+              return { ...t, notes: [...t.notes, { id: makeNoteId(), pitch, startStep: step, durationSteps: 1, velocity: 100 }] };
+            }),
+          }));
+        }
+      }
+    } else {
+      // Remove: note rect
+      const noteRect = el.closest('[data-note-id]') as HTMLElement | null;
+      if (noteRect && noteRect.dataset.trackId === pm.trackId) {
+        const noteId = noteRect.dataset.noteId ?? '';
+        if (noteId) {
+          setPattern(prev => ({
+            ...prev,
+            tracks: prev.tracks.map(t =>
+              t.id !== pm.trackId ? t : { ...t, notes: t.notes.filter(n => n.id !== noteId) }
+            ),
+          }));
+        }
+      }
+    }
+  };
+
+  pointerUpHandlerRef.current = (_e: PointerEvent) => {
+    paintModeRef.current   = null;
+    resizeModeRef.current  = false;
+    resizeStateRef.current = null;
+  };
+
+  useEffect(() => {
+    const mv = (e: PointerEvent) => pointerMoveHandlerRef.current(e);
+    const up = (e: PointerEvent) => pointerUpHandlerRef.current(e);
+    document.addEventListener('pointermove', mv);
+    document.addEventListener('pointerup',   up);
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup',   handleMouseUp);
+      document.removeEventListener('pointermove', mv);
+      document.removeEventListener('pointerup',   up);
     };
   }, []);
 
+  // ── Spacebar play/pause ────────────────────────────────────────────────────────
+
   useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
+    function onKey(e: KeyboardEvent) {
       if (e.code !== 'Space') return;
       const tag = (e.target as HTMLElement).tagName;
       if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
       e.preventDefault();
       if (isPlayingRef.current) stopPlayback(); else startPlayback();
     }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
   }, [startPlayback, stopPlayback]);
 
-  // ── Note editing ──────────────────────────────────────────────────────────────
+  // ── Note / track callbacks ─────────────────────────────────────────────────────
 
   const addNote = useCallback((trackId: string, pitch: number, step: number) => {
     setPattern(prev => ({
@@ -616,8 +905,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       tracks: prev.tracks.map(t => {
         if (t.id !== trackId) return t;
         if (t.notes.some(n => n.startStep === step && n.pitch === pitch)) return t;
-        const newNote: Note = { id: makeNoteId(), pitch, startStep: step, durationSteps: 1, velocity: 100 };
-        return { ...t, notes: [...t.notes, newNote] };
+        return { ...t, notes: [...t.notes, { id: makeNoteId(), pitch, startStep: step, durationSteps: 1, velocity: 100 }] };
       }),
     }));
   }, []);
@@ -631,16 +919,20 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     }));
   }, []);
 
-  const startResizeNote = useCallback((noteId: string, startX: number, origDuration: number, noteStartStep: number) => {
+  const startResize = useCallback((noteId: string, trackId: string, startX: number, origDuration: number, noteStartStep: number) => {
     resizeModeRef.current  = true;
-    resizeStateRef.current = {
-      noteId,
-      trackId: activeTrackRef.current?.id ?? '',
-      startX, origDuration, noteStartStep,
-    };
+    resizeStateRef.current = { noteId, trackId, startX, origDuration, noteStartStep };
   }, []);
 
-  // ── Track management ──────────────────────────────────────────────────────────
+  const previewPitch = useCallback((track: Track, pitch: number) => {
+    resumeAudio();
+    playNote(pitch, 100, 0.35, track.waveform, undefined, track.volume);
+  }, []);
+
+  const previewDrum = useCallback((pitch: number) => {
+    resumeAudio();
+    playDrum(pitch, 100);
+  }, []);
 
   const muteTrack = useCallback((trackId: string) => {
     setPattern(prev => ({
@@ -649,132 +941,203 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     }));
   }, []);
 
-  const changeWaveform = useCallback((trackId: string, waveform: OscWaveform) => {
+  const toggleCollapse = useCallback((trackId: string) => {
     setPattern(prev => ({
       ...prev,
-      tracks: prev.tracks.map(t => t.id === trackId ? { ...t, waveform } : t),
+      tracks: prev.tracks.map(t => t.id === trackId ? { ...t, collapsed: !t.collapsed } : t),
     }));
   }, []);
 
-  const addTrack = useCallback(() => {
+  const deleteTrack = useCallback((trackId: string) => {
+    setPattern(prev => ({ ...prev, tracks: prev.tracks.filter(t => t.id !== trackId) }));
+  }, []);
+
+  const updateTrack = useCallback((trackId: string, updates: Partial<Track>) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t => t.id === trackId ? { ...t, ...updates } : t),
+    }));
+  }, []);
+
+  const addMelodicTrack = useCallback(() => {
     setPattern(prev => {
-      const melodic = prev.tracks.filter(t => !t.isDrum);
-      if (melodic.length >= 10) return prev;
-      const idx = melodic.length;
+      if (prev.tracks.filter(t => !t.isDrum).length >= 10) return prev;
+      const idx = prev.tracks.length;
       const newTrack: Track = {
-        id: `t${makeNoteId()}`,
-        name: `Trk ${idx + 1}`,
+        id: `t${makeNoteId()}`, name: `Track ${prev.tracks.filter(t=>!t.isDrum).length + 1}`,
         color: TRACK_COLORS[idx % TRACK_COLORS.length],
-        waveform: 'sine',
-        notes: [], muted: false, isDrum: false,
+        waveform: 'sine', notes: [], muted: false, isDrum: false,
+        volume: 1, attack: 0.01, release: 0.3, collapsed: false,
       };
-      return {
-        ...prev,
-        tracks: [...prev.tracks.filter(t => !t.isDrum), newTrack, ...prev.tracks.filter(t => t.isDrum)],
-      };
+      return { ...prev, tracks: [...prev.tracks, newTrack] };
     });
   }, []);
 
-  const removeActiveTrack = useCallback(() => {
+  const addDrumTrack = useCallback(() => {
     setPattern(prev => {
-      const melodic = prev.tracks.filter(t => !t.isDrum);
-      if (melodic.length <= 1) return prev;
-      const toRemove = melodic[Math.min(activeTrackIdx, melodic.length - 1)];
-      return { ...prev, tracks: prev.tracks.filter(t => t.id !== toRemove.id) };
+      const drumCount  = prev.tracks.filter(t => t.isDrum).length;
+      const lastDrumIdx = prev.tracks.reduce((acc, t, i) => t.isDrum ? i : acc, -1);
+      const newTrack: Track = {
+        id: `d${makeNoteId()}`, name: `Drums ${drumCount + 1}`,
+        color: TRACK_COLORS[(drumCount + 3) % TRACK_COLORS.length],
+        waveform: 'sine', notes: [], muted: false, isDrum: true,
+        volume: 1, attack: 0.01, release: 0.3, collapsed: false,
+      };
+      const tracks = [...prev.tracks];
+      tracks.splice(lastDrumIdx + 1, 0, newTrack);
+      return { ...prev, tracks };
     });
-    setActiveTrackIdx(prev => Math.max(0, prev - 1));
-  }, [activeTrackIdx]);
+  }, []);
 
   const newPattern = useCallback(() => {
     stopPlayback();
     setPattern(createInitialPattern());
-    setActiveTrackIdx(0);
   }, [stopPlayback]);
 
-  const previewPitch = useCallback((pitch: number) => {
-    resumeAudio();
-    playNote(pitch, 100, 0.35, activeTrackRef.current?.waveform ?? 'sine');
-  }, []);
-
-  const previewDrum = useCallback((pitch: number) => {
-    resumeAudio();
-    playDrum(pitch, 100);
-  }, []);
-
-  // ── Window menus ──────────────────────────────────────────────────────────────
+  // ── Window menus ───────────────────────────────────────────────────────────────
 
   const menus = useMemo<MenuBarMenu[]>(() => [
     {
       label: 'File',
       items: [
-        { label: 'New Pattern', onClick: newPattern },
+        { label: 'New Pattern',       onClick: newPattern },
+        { label: 'Save to Library…',  onClick: () => setShowSave(true) },
+        { label: 'Load from Library…',onClick: () => setShowLoad(true) },
+        { label: 'Download JSON',     onClick: () => downloadJson(patternRef.current) },
         ...(onQuit ? [{ separator: true as const }, { label: 'Close', onClick: onQuit }] : []),
       ],
     },
     {
       label: 'Playback',
       items: [
-        { label: isPlaying ? 'Stop  ■' : 'Play  ▶', onClick: isPlaying ? stopPlayback : startPlayback },
+        { label: isPlaying ? 'Stop ■' : 'Play ▶', onClick: isPlaying ? stopPlayback : startPlayback },
         { separator: true },
         { label: 'BPM 80',  onClick: () => setPattern(p => ({ ...p, bpm: 80  })) },
         { label: 'BPM 120', onClick: () => setPattern(p => ({ ...p, bpm: 120 })) },
         { label: 'BPM 160', onClick: () => setPattern(p => ({ ...p, bpm: 160 })) },
       ],
     },
-    {
-      label: 'Track',
-      items: melodicTracks.map((t, i) => ({
-        label: t.name,
-        checked: i === clampedIdx,
-        onClick: () => setActiveTrackIdx(i),
-      })),
-    },
-  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit, melodicTracks, clampedIdx]);
+  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit]);
 
   useWindowMenus(menus);
 
-  // ── Render ────────────────────────────────────────────────────────────────────
+  // ── Render ─────────────────────────────────────────────────────────────────────
+
+  const rulerSteps: { s: number; isBar: boolean; label: string }[] = useMemo(() =>
+    Array.from({ length: totalSteps }, (_, s) => {
+      const isBar  = s % (pattern.stepsPerBeat * pattern.beatsPerBar) === 0;
+      const isBeat = !isBar && s % pattern.stepsPerBeat === 0;
+      if (!isBar && !isBeat) return null;
+      return { s, isBar, label: isBar ? String(s / (pattern.stepsPerBeat * pattern.beatsPerBar) + 1) : '' };
+    }).filter((x): x is { s: number; isBar: boolean; label: string } => x !== null),
+    [totalSteps, pattern.stepsPerBeat, pattern.beatsPerBar],
+  );
+
+  const modalTrack = modalTid ? pattern.tracks.find(t => t.id === modalTid) : null;
 
   return (
     <div className="me-root">
       <Transport
         pattern={pattern}
         isPlaying={isPlaying}
-        activeTrackIdx={clampedIdx}
-        activeTrack={activeTrack}
-        melodicTrackCount={melodicTracks.length}
+        zoomIdx={zoomIdx}
         onPlay={startPlayback}
         onStop={stopPlayback}
         onBpmChange={bpm => setPattern(p => ({ ...p, bpm: Math.max(40, Math.min(240, bpm)) }))}
         onBarsChange={bars => { stopPlayback(); setPattern(p => ({ ...p, bars })); }}
         onStepsPerBeatChange={spb => { stopPlayback(); setPattern(p => ({ ...p, stepsPerBeat: spb })); }}
-        onActiveTrackChange={setActiveTrackIdx}
-        onMuteTrack={muteTrack}
-        onChangeWaveform={changeWaveform}
-        onAddTrack={addTrack}
-        onRemoveTrack={removeActiveTrack}
-        onNewPattern={newPattern}
+        onZoomIn={() => setZoomIdx(i => Math.min(i + 1, ZOOM_PRESETS.length - 1))}
+        onZoomOut={() => setZoomIdx(i => Math.max(i - 1, 0))}
+        onNew={newPattern}
+        onSave={() => setShowSave(true)}
+        onLoad={() => setShowLoad(true)}
+        onDownload={() => downloadJson(patternRef.current)}
       />
 
-      <div className="me-body">
-        <div className="me-section-label">PIANO ROLL — {activeTrack.name.toUpperCase()}</div>
-        <div className="me-piano-roll-wrap">
-          <PianoRoll
-            melodicTrack={activeTrack}
-            drumTrack={drumTrack}
-            totalSteps={totalSteps}
-            stepsPerBeat={pattern.stepsPerBeat}
-            beatsPerBar={pattern.beatsPerBar}
-            playheadRef={playheadRef}
-            paintModeRef={paintModeRef}
-            onAddNote={addNote}
-            onRemoveNote={removeNote}
-            onStartResize={startResizeNote}
-            onPreviewPitch={previewPitch}
-            onPreviewDrum={previewDrum}
+      {/* Main grid: single overflow:auto container */}
+      <div className="me-outer">
+        <div className="me-inner" style={{ minWidth: LEFT_W + gridW }}>
+
+          {/* Time ruler — sticky top */}
+          <div className="me-ruler" style={{ height: RULER_H }}>
+            <div className="me-ruler-corner" style={{ width: LEFT_W }} />
+            <div className="me-ruler-steps" style={{ width: gridW, height: RULER_H }}>
+              {rulerSteps.map(({ s, isBar, label }) => (
+                <div
+                  key={s}
+                  className={`me-ruler-mark${isBar ? ' me-ruler-mark--bar' : ' me-ruler-mark--beat'}`}
+                  style={{ left: s * stepW }}
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Track list */}
+          {pattern.tracks.map(track => (
+            <TrackSection
+              key={track.id}
+              track={track}
+              totalSteps={totalSteps}
+              stepsPerBeat={pattern.stepsPerBeat}
+              beatsPerBar={pattern.beatsPerBar}
+              stepW={stepW}
+              rowH={rowH}
+              canDelete={pattern.tracks.length > 1}
+              paintModeRef={paintModeRef}
+              onToggleCollapse={() => toggleCollapse(track.id)}
+              onGear={() => setModalTid(track.id)}
+              onDelete={() => deleteTrack(track.id)}
+              onMute={() => muteTrack(track.id)}
+              onAddNote={(pitch, step) => addNote(track.id, pitch, step)}
+              onRemoveNote={noteId => removeNote(track.id, noteId)}
+              onStartResize={(noteId, startX, origDur, noteStart) =>
+                startResize(noteId, track.id, startX, origDur, noteStart)
+              }
+              onPreviewPitch={pitch => previewPitch(track, pitch)}
+              onPreviewDrum={previewDrum}
+            />
+          ))}
+
+          {/* Add track row */}
+          <div className="me-add-track-row" style={{ height: HDR_H }}>
+            <div className="me-add-track-left" style={{ width: LEFT_W }}>
+              <button className="me-btn me-btn--sm" onPointerDown={addDrumTrack}>+ Drums</button>
+              <button className="me-btn me-btn--sm" onPointerDown={addMelodicTrack}>+ Melody</button>
+            </div>
+            <div className="me-add-track-fill" style={{ width: gridW }} />
+          </div>
+
+          {/* Playhead — positioned in content space */}
+          <div
+            className="me-playhead"
+            ref={playheadRef}
+            style={{ top: RULER_H, display: 'none' }}
           />
         </div>
       </div>
+
+      {/* Overlays */}
+      {modalTrack && (
+        <InstrumentModal
+          track={modalTrack}
+          onSave={updates => { updateTrack(modalTrack.id, updates); setModalTid(null); }}
+          onClose={() => setModalTid(null)}
+        />
+      )}
+      {showSave && (
+        <SaveDialog
+          onSave={name => { persistSave(name, patternRef.current); setShowSave(false); }}
+          onClose={() => setShowSave(false)}
+        />
+      )}
+      {showLoad && (
+        <LoadDialog
+          onLoad={p => { stopPlayback(); setPattern(p); setShowLoad(false); }}
+          onClose={() => setShowLoad(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -412,8 +412,8 @@ function MelodicGrid({
 
   return (
     <div
-      className="me-note-grid"
-      style={{ width: gridW, height: gridH, touchAction: editMode ? 'none' : 'auto' }}
+      className={`me-note-grid${editMode ? ' me-note-grid--edit' : ''}`}
+      style={{ width: gridW, height: gridH }}
     >
       {/* Step column markers */}
       {Array.from({ length: totalSteps }, (_, s) => {
@@ -530,7 +530,7 @@ function DrumGrid({
   }
 
   return (
-    <div className="me-drum-grid" style={{ width: gridW, height: gridH, touchAction: editMode ? 'none' : 'auto' }}>
+    <div className={`me-drum-grid${editMode ? ' me-drum-grid--edit' : ''}`} style={{ width: gridW, height: gridH }}>
       {/* Step columns */}
       {Array.from({ length: totalSteps }, (_, s) => {
         const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
@@ -719,7 +719,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const [pattern,     setPattern]     = useState<Pattern>(loadPattern);
   const [isPlaying,   setIsPlaying]   = useState(false);
   const [zoomIdx,     setZoomIdx]     = useState(loadZoomIdx);
-  const [editMode,    setEditMode]    = useState(false);
+  const [editMode,    setEditMode]    = useState(true);
   const [modalTid,    setModalTid]    = useState<string | null>(null);
   const [showSave,    setShowSave]    = useState(false);
   const [showLoad,    setShowLoad]    = useState(false);

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -1,0 +1,576 @@
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useWindowMenus } from '../../components/Window/useWindowMenus';
+import type { MenuBarMenu } from '../../components/MenuBar/MenuBar';
+import {
+  type Pattern,
+  type Track,
+  type Note,
+  type DrumType,
+  DRUM_TYPES,
+  DRUM_LABELS,
+  DRUM_PITCHES,
+  PIANO_MIN,
+  PIANO_MAX,
+  STEP_W,
+  ROW_H,
+  SEQ_BTN_W,
+  SEQ_BTN_H,
+  isBlackPitch,
+  pitchName,
+  makeNoteId,
+  createInitialPattern,
+} from './types';
+import { resumeAudio, playNote, playDrum } from './audio';
+import './MidiEditor.css';
+
+const PITCH_RANGE: number[] = [];
+for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
+
+function buildNoteSet(track: Track): Set<string> {
+  const s = new Set<string>();
+  track.notes.forEach(n => {
+    for (let d = 0; d < n.durationSteps; d++) {
+      s.add(`${n.pitch},${n.startStep + d}`);
+    }
+  });
+  return s;
+}
+
+// ── Transport ──────────────────────────────────────────────────────────────────
+
+interface TransportProps {
+  pattern: Pattern;
+  isPlaying: boolean;
+  activeTrackIdx: number;
+  onPlay: () => void;
+  onStop: () => void;
+  onBpmChange: (bpm: number) => void;
+  onBarsChange: (bars: number) => void;
+  onStepsPerBeatChange: (spb: number) => void;
+  onActiveTrackChange: (idx: number) => void;
+  onMuteTrack: (trackId: string) => void;
+  onNewPattern: () => void;
+}
+
+function Transport({
+  pattern,
+  isPlaying,
+  activeTrackIdx,
+  onPlay,
+  onStop,
+  onBpmChange,
+  onBarsChange,
+  onStepsPerBeatChange,
+  onActiveTrackChange,
+  onMuteTrack,
+  onNewPattern,
+}: TransportProps) {
+  const melodicTracks = pattern.tracks.filter(t => !t.isDrum);
+
+  function nudgeBpm(delta: number) {
+    onBpmChange(Math.max(40, Math.min(240, pattern.bpm + delta)));
+  }
+
+  return (
+    <div className="me-transport">
+      <div className="me-transport__row">
+        <button
+          className={`me-btn me-btn--play ${isPlaying ? 'me-btn--stop' : ''}`}
+          onMouseDown={isPlaying ? onStop : onPlay}
+        >
+          {isPlaying ? '■' : '▶'}
+        </button>
+
+        <div className="me-transport__group">
+          <span className="me-label">BPM</span>
+          <button className="me-btn me-btn--sm" onMouseDown={() => nudgeBpm(-5)}>-</button>
+          <input
+            className="me-num-input"
+            type="number"
+            min={40}
+            max={240}
+            value={pattern.bpm}
+            onChange={e => onBpmChange(Number(e.target.value))}
+          />
+          <button className="me-btn me-btn--sm" onMouseDown={() => nudgeBpm(5)}>+</button>
+        </div>
+
+        <div className="me-transport__group">
+          <span className="me-label">BARS</span>
+          <select
+            className="me-select"
+            value={pattern.bars}
+            onChange={e => onBarsChange(Number(e.target.value))}
+          >
+            {[1, 2, 4, 8].map(n => <option key={n} value={n}>{n}</option>)}
+          </select>
+        </div>
+
+        <div className="me-transport__group">
+          <span className="me-label">GRID</span>
+          <select
+            className="me-select"
+            value={pattern.stepsPerBeat}
+            onChange={e => onStepsPerBeatChange(Number(e.target.value))}
+          >
+            <option value={2}>1/8</option>
+            <option value={4}>1/16</option>
+          </select>
+        </div>
+
+        <div className="me-transport__sep" />
+
+        <button className="me-btn me-btn--new" onMouseDown={onNewPattern}>NEW</button>
+      </div>
+
+      <div className="me-transport__row">
+        <span className="me-label me-label--dim">PIANO ROLL:</span>
+        {melodicTracks.map((t, i) => (
+          <button
+            key={t.id}
+            className={`me-track-btn ${i === activeTrackIdx ? 'me-track-btn--active' : ''}`}
+            style={{ '--track-color': t.color } as React.CSSProperties}
+            onMouseDown={() => onActiveTrackChange(i)}
+          >
+            {t.name}
+          </button>
+        ))}
+
+        <div className="me-transport__sep" />
+
+        <span className="me-label me-label--dim">MUTE:</span>
+        {pattern.tracks.map(t => (
+          <button
+            key={t.id}
+            className={`me-mute-btn ${t.muted ? 'me-mute-btn--muted' : ''}`}
+            style={{ '--track-color': t.color } as React.CSSProperties}
+            onMouseDown={() => onMuteTrack(t.id)}
+            title={`${t.muted ? 'Unmute' : 'Mute'} ${t.name}`}
+          >
+            {t.name[0]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Piano Roll ─────────────────────────────────────────────────────────────────
+
+interface PianoRollProps {
+  track: Track;
+  totalSteps: number;
+  stepsPerBeat: number;
+  beatsPerBar: number;
+  playheadRef: React.RefObject<HTMLDivElement | null>;
+  onToggleNote: (pitch: number, step: number) => void;
+  onPreviewPitch: (pitch: number) => void;
+}
+
+function PianoRoll({
+  track,
+  totalSteps,
+  stepsPerBeat,
+  beatsPerBar,
+  playheadRef,
+  onToggleNote,
+  onPreviewPitch,
+}: PianoRollProps) {
+  const noteSet = useMemo(() => buildNoteSet(track), [track]);
+
+  const gridWidth = totalSteps * STEP_W;
+  const gridHeight = PITCH_RANGE.length * ROW_H;
+
+  return (
+    <div className="me-piano-roll">
+      {/* Piano keys column */}
+      <div className="me-piano-keys" style={{ height: gridHeight }}>
+        {PITCH_RANGE.map(pitch => {
+          const isBlack = isBlackPitch(pitch);
+          const isC = pitch % 12 === 0;
+          return (
+            <div
+              key={pitch}
+              className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
+              style={{ height: ROW_H }}
+              onMouseDown={() => onPreviewPitch(pitch)}
+            >
+              {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Note grid */}
+      <div className="me-note-grid-wrap">
+        <div
+          className="me-note-grid"
+          style={{ width: gridWidth, height: gridHeight }}
+        >
+          {/* Beat / bar dividers */}
+          {Array.from({ length: totalSteps }, (_, s) => s).map(step => (
+            <div
+              key={`div-${step}`}
+              className={`me-step-col ${step % (stepsPerBeat * beatsPerBar) === 0 ? 'me-step-col--bar' : step % stepsPerBeat === 0 ? 'me-step-col--beat' : ''}`}
+              style={{ left: step * STEP_W, width: STEP_W, height: gridHeight }}
+            />
+          ))}
+
+          {/* Note cells */}
+          {PITCH_RANGE.map((pitch, rowIdx) => {
+            const isBlack = isBlackPitch(pitch);
+            return Array.from({ length: totalSteps }, (_, step) => {
+              const hasNote = noteSet.has(`${pitch},${step}`);
+              return (
+                <div
+                  key={`${pitch}-${step}`}
+                  className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'} ${hasNote ? 'me-cell--note' : ''}`}
+                  style={{
+                    left: step * STEP_W,
+                    top: rowIdx * ROW_H,
+                    width: STEP_W,
+                    height: ROW_H,
+                    ...(hasNote ? { background: track.color } : {}),
+                  }}
+                  onMouseDown={() => onToggleNote(pitch, step)}
+                />
+              );
+            });
+          })}
+
+          {/* Horizontal dividers (pitch rows) */}
+          {PITCH_RANGE.map((pitch, rowIdx) =>
+            pitch % 12 === 0 ? (
+              <div
+                key={`row-div-${pitch}`}
+                className="me-row-divider"
+                style={{ top: rowIdx * ROW_H, width: gridWidth }}
+              />
+            ) : null
+          )}
+
+          {/* Playhead */}
+          <div
+            className="me-playhead"
+            ref={playheadRef as React.RefObject<HTMLDivElement>}
+            style={{ height: gridHeight, display: 'none' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Step Sequencer ─────────────────────────────────────────────────────────────
+
+interface StepSeqProps {
+  track: Track;
+  totalSteps: number;
+  stepsPerBeat: number;
+  beatsPerBar: number;
+  seqPlayheadRef: React.RefObject<HTMLDivElement | null>;
+  onToggleNote: (pitch: number, step: number) => void;
+}
+
+function StepSeq({
+  track,
+  totalSteps,
+  stepsPerBeat,
+  beatsPerBar,
+  seqPlayheadRef,
+  onToggleNote,
+}: StepSeqProps) {
+  const drumNoteSet = useMemo(() => buildNoteSet(track), [track]);
+
+  const gridWidth = totalSteps * SEQ_BTN_W;
+  const gridHeight = DRUM_TYPES.length * SEQ_BTN_H;
+
+  return (
+    <div className="me-step-seq">
+      <div className="me-step-seq__labels">
+        <div className="me-step-seq__corner" />
+        {DRUM_TYPES.map(dt => (
+          <div key={dt} className="me-drum-label" style={{ height: SEQ_BTN_H }}>
+            {DRUM_LABELS[dt]}
+          </div>
+        ))}
+      </div>
+
+      <div className="me-step-seq__grid-wrap">
+        <div className="me-step-seq__grid" style={{ width: gridWidth, height: gridHeight + SEQ_BTN_H }}>
+          {/* Step indicator row */}
+          <div className="me-seq-indicator-row" style={{ width: gridWidth }}>
+            {Array.from({ length: totalSteps }, (_, s) => s).map(step => (
+              <div
+                key={step}
+                className={`me-seq-step-num ${step % (stepsPerBeat * beatsPerBar) === 0 ? 'me-seq-step-num--bar' : step % stepsPerBeat === 0 ? 'me-seq-step-num--beat' : ''}`}
+                style={{ width: SEQ_BTN_W }}
+              />
+            ))}
+          </div>
+
+          {/* Button rows */}
+          {DRUM_TYPES.map((dt: DrumType, rowIdx) => {
+            const pitch = DRUM_PITCHES[dt];
+            return (
+              <div key={dt} className="me-seq-row" style={{ height: SEQ_BTN_H }}>
+                {Array.from({ length: totalSteps }, (_, step) => {
+                  const isOn = drumNoteSet.has(`${pitch},${step}`);
+                  const isBeat = step % stepsPerBeat === 0;
+                  const isBar = step % (stepsPerBeat * beatsPerBar) === 0;
+                  return (
+                    <button
+                      key={step}
+                      className={`me-seq-btn ${isOn ? 'me-seq-btn--on' : 'me-seq-btn--off'} ${isBeat ? 'me-seq-btn--beat' : ''} ${isBar ? 'me-seq-btn--bar' : ''}`}
+                      style={{ width: SEQ_BTN_W, height: SEQ_BTN_H, ...(isOn ? { background: track.color } : {}) }}
+                      onMouseDown={() => onToggleNote(pitch, step)}
+                      data-row={rowIdx}
+                      data-step={step}
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
+
+          {/* Playhead overlay */}
+          <div
+            className="me-seq-playhead"
+            ref={seqPlayheadRef as React.RefObject<HTMLDivElement>}
+            style={{ height: gridHeight, top: SEQ_BTN_H, display: 'none' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+interface MidiEditorProps {
+  onQuit?: () => void;
+}
+
+export default function MidiEditor({ onQuit }: MidiEditorProps) {
+  const [pattern, setPattern] = useState<Pattern>(createInitialPattern);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [activeTrackIdx, setActiveTrackIdx] = useState(0);
+
+  const patternRef = useRef(pattern);
+  patternRef.current = pattern;
+
+  const isPlayingRef = useRef(false);
+  const stepRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playheadRef = useRef<HTMLDivElement | null>(null);
+  const seqPlayheadRef = useRef<HTMLDivElement | null>(null);
+
+  const melodicTracks = useMemo(
+    () => pattern.tracks.filter(t => !t.isDrum),
+    [pattern.tracks],
+  );
+  const drumTrack = useMemo(
+    () => pattern.tracks.find(t => t.isDrum)!,
+    [pattern.tracks],
+  );
+  const activeTrack = melodicTracks[activeTrackIdx] ?? melodicTracks[0];
+
+  const totalSteps = useMemo(
+    () => pattern.bars * pattern.beatsPerBar * pattern.stepsPerBeat,
+    [pattern.bars, pattern.beatsPerBar, pattern.stepsPerBeat],
+  );
+
+  // Move playhead refs — called from timer, no React state change
+  function movePlayhead(step: number) {
+    const x = step * STEP_W;
+    if (playheadRef.current) {
+      playheadRef.current.style.display = 'block';
+      playheadRef.current.style.transform = `translateX(${x}px)`;
+    }
+    const sx = step * SEQ_BTN_W;
+    if (seqPlayheadRef.current) {
+      seqPlayheadRef.current.style.display = 'block';
+      seqPlayheadRef.current.style.transform = `translateX(${sx}px)`;
+    }
+  }
+
+  function hidePlayhead() {
+    if (playheadRef.current) playheadRef.current.style.display = 'none';
+    if (seqPlayheadRef.current) seqPlayheadRef.current.style.display = 'none';
+  }
+
+  const stopPlayback = useCallback(() => {
+    isPlayingRef.current = false;
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    stepRef.current = 0;
+    setIsPlaying(false);
+    hidePlayhead();
+  }, []);
+
+  const tick = useCallback(() => {
+    if (!isPlayingRef.current) return;
+    const pat = patternRef.current;
+    const total = pat.bars * pat.beatsPerBar * pat.stepsPerBeat;
+    const step = stepRef.current;
+
+    movePlayhead(step);
+
+    const stepDurSec = 60 / pat.bpm / pat.stepsPerBeat;
+    pat.tracks.forEach(track => {
+      if (track.muted) return;
+      track.notes.forEach((note: Note) => {
+        if (note.startStep !== step) return;
+        if (note.startStep >= total) return;
+        const dur = note.durationSteps * stepDurSec * 0.85;
+        if (track.isDrum) {
+          playDrum(note.pitch, note.velocity);
+        } else {
+          playNote(note.pitch, note.velocity, dur, track.waveform);
+        }
+      });
+    });
+
+    stepRef.current = (step + 1) % total;
+    const ms = (60_000 / pat.bpm) / pat.stepsPerBeat;
+    timerRef.current = setTimeout(tick, ms);
+  }, []);
+
+  const startPlayback = useCallback(() => {
+    resumeAudio();
+    isPlayingRef.current = true;
+    stepRef.current = 0;
+    setIsPlaying(true);
+    const ms = (60_000 / patternRef.current.bpm) / patternRef.current.stepsPerBeat;
+    timerRef.current = setTimeout(tick, ms);
+  }, [tick]);
+
+  // Clean up on unmount
+  useEffect(() => () => { stopPlayback(); }, [stopPlayback]);
+
+  const toggleNote = useCallback((trackId: string, pitch: number, step: number) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(track => {
+        if (track.id !== trackId) return track;
+        const existing = track.notes.find(n => n.startStep === step && n.pitch === pitch);
+        if (existing) {
+          return { ...track, notes: track.notes.filter(n => n.id !== existing.id) };
+        }
+        const newNote: Note = {
+          id: makeNoteId(),
+          pitch,
+          startStep: step,
+          durationSteps: 1,
+          velocity: 100,
+        };
+        return { ...track, notes: [...track.notes, newNote] };
+      }),
+    }));
+  }, []);
+
+  const muteTrack = useCallback((trackId: string) => {
+    setPattern(prev => ({
+      ...prev,
+      tracks: prev.tracks.map(t =>
+        t.id === trackId ? { ...t, muted: !t.muted } : t
+      ),
+    }));
+  }, []);
+
+  const newPattern = useCallback(() => {
+    stopPlayback();
+    setPattern(createInitialPattern());
+    setActiveTrackIdx(0);
+  }, [stopPlayback]);
+
+  const previewPitch = useCallback((pitch: number) => {
+    resumeAudio();
+    playNote(pitch, 100, 0.4, activeTrack.waveform);
+  }, [activeTrack]);
+
+  // ── Window menus ─────────────────────────────────────────────────────────────
+
+  const menus = useMemo<MenuBarMenu[]>(() => [
+    {
+      label: 'File',
+      items: [
+        { label: 'New Pattern', onClick: newPattern },
+        ...(onQuit ? [{ separator: true as const }, { label: 'Close', onClick: onQuit }] : []),
+      ],
+    },
+    {
+      label: 'Playback',
+      items: [
+        { label: isPlaying ? 'Stop  ■' : 'Play  ▶', onClick: isPlaying ? stopPlayback : startPlayback },
+        { separator: true },
+        { label: 'BPM 80',  onClick: () => setPattern(p => ({ ...p, bpm: 80  })) },
+        { label: 'BPM 120', onClick: () => setPattern(p => ({ ...p, bpm: 120 })) },
+        { label: 'BPM 160', onClick: () => setPattern(p => ({ ...p, bpm: 160 })) },
+      ],
+    },
+    {
+      label: 'Track',
+      items: melodicTracks.map((t, i) => ({
+        label: t.name,
+        checked: i === activeTrackIdx,
+        onClick: () => setActiveTrackIdx(i),
+      })),
+    },
+  ], [isPlaying, startPlayback, stopPlayback, newPattern, onQuit, melodicTracks, activeTrackIdx]);
+
+  useWindowMenus(menus);
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="me-root">
+      <Transport
+        pattern={pattern}
+        isPlaying={isPlaying}
+        activeTrackIdx={activeTrackIdx}
+        onPlay={startPlayback}
+        onStop={stopPlayback}
+        onBpmChange={bpm => setPattern(p => ({ ...p, bpm: Math.max(40, Math.min(240, bpm)) }))}
+        onBarsChange={bars => { stopPlayback(); setPattern(p => ({ ...p, bars })); }}
+        onStepsPerBeatChange={stepsPerBeat => { stopPlayback(); setPattern(p => ({ ...p, stepsPerBeat })); }}
+        onActiveTrackChange={setActiveTrackIdx}
+        onMuteTrack={muteTrack}
+        onNewPattern={newPattern}
+      />
+
+      <div className="me-body">
+        <div className="me-piano-section">
+          <div className="me-section-label">PIANO ROLL — {activeTrack.name.toUpperCase()}</div>
+          <div className="me-piano-roll-wrap">
+            <PianoRoll
+              track={activeTrack}
+              totalSteps={totalSteps}
+              stepsPerBeat={pattern.stepsPerBeat}
+              beatsPerBar={pattern.beatsPerBar}
+              playheadRef={playheadRef}
+              onToggleNote={(pitch, step) => toggleNote(activeTrack.id, pitch, step)}
+              onPreviewPitch={previewPitch}
+            />
+          </div>
+        </div>
+
+        <div className="me-divider" />
+
+        <div className="me-seq-section">
+          <div className="me-section-label">STEP SEQUENCER — DRUMS</div>
+          <StepSeq
+            track={drumTrack}
+            totalSteps={totalSteps}
+            stepsPerBeat={pattern.stepsPerBeat}
+            beatsPerBar={pattern.beatsPerBar}
+            seqPlayheadRef={seqPlayheadRef}
+            onToggleNote={(pitch, step) => toggleNote(drumTrack.id, pitch, step)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -281,6 +281,7 @@ interface TransportProps {
   pattern: Pattern;
   isPlaying: boolean;
   zoomIdx: number;
+  editMode: boolean;
   onPlay: () => void;
   onStop: () => void;
   onBpmChange: (bpm: number) => void;
@@ -292,12 +293,13 @@ interface TransportProps {
   onSave: () => void;
   onLoad: () => void;
   onDownload: () => void;
+  onToggleEditMode: () => void;
 }
 
 function Transport({
-  pattern, isPlaying, zoomIdx,
+  pattern, isPlaying, zoomIdx, editMode,
   onPlay, onStop, onBpmChange, onBarsChange, onStepsPerBeatChange,
-  onZoomIn, onZoomOut, onNew, onSave, onLoad, onDownload,
+  onZoomIn, onZoomOut, onNew, onSave, onLoad, onDownload, onToggleEditMode,
 }: TransportProps) {
   function nudge(delta: number) {
     onBpmChange(Math.max(40, Math.min(240, pattern.bpm + delta)));
@@ -309,6 +311,16 @@ function Transport({
         <button className={`me-btn me-btn--play${isPlaying ? ' me-btn--stop' : ''}`} onPointerDown={isPlaying ? onStop : onPlay}>
           {isPlaying ? '■' : '▶'}
         </button>
+
+        <button
+          className={`me-btn me-btn--sm${editMode ? ' me-btn--primary' : ''}`}
+          onPointerDown={onToggleEditMode}
+          title={editMode ? 'Draw mode active — tap to switch to scroll' : 'Scroll mode — tap to draw notes'}
+        >
+          {editMode ? 'DRAW' : 'SCROLL'}
+        </button>
+
+        <div className="me-transport__sep" />
 
         <div className="me-transport__group">
           <span className="me-label">BPM</span>
@@ -365,6 +377,7 @@ interface MelodicGridProps {
   beatsPerBar: number;
   stepW: number;
   rowH: number;
+  editMode: boolean;
   paintModeRef: React.MutableRefObject<PaintState>;
   onAddNote: (pitch: number, step: number) => void;
   onRemoveNote: (noteId: string) => void;
@@ -373,7 +386,7 @@ interface MelodicGridProps {
 }
 
 function MelodicGrid({
-  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH,
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, editMode,
   paintModeRef, onAddNote, onRemoveNote, onStartResize, onPreviewPitch,
 }: MelodicGridProps) {
   const noteMap  = useMemo(() => buildNoteMap(track), [track]);
@@ -400,7 +413,7 @@ function MelodicGrid({
   return (
     <div
       className="me-note-grid"
-      style={{ width: gridW, height: gridH }}
+      style={{ width: gridW, height: gridH, touchAction: editMode ? 'none' : 'auto' }}
     >
       {/* Step column markers */}
       {Array.from({ length: totalSteps }, (_, s) => {
@@ -429,7 +442,7 @@ function MelodicGrid({
               data-pitch={pitch}
               data-step={step}
               data-track-id={track.id}
-              onPointerDown={e => { e.preventDefault(); cellDown(pitch, step); }}
+              {...(editMode ? { onPointerDown: (e: React.PointerEvent) => { e.preventDefault(); cellDown(pitch, step); } } : {})}
             />
           );
         });
@@ -451,11 +464,13 @@ function MelodicGrid({
             }}
             data-note-id={note.id}
             data-track-id={track.id}
-            onPointerDown={e => {
-              e.preventDefault(); e.stopPropagation();
-              paintModeRef.current = { action: 'remove', trackId: track.id };
-              onRemoveNote(note.id);
-            }}
+            {...(editMode ? {
+              onPointerDown: (e: React.PointerEvent) => {
+                e.preventDefault(); e.stopPropagation();
+                paintModeRef.current = { action: 'remove', trackId: track.id };
+                onRemoveNote(note.id);
+              },
+            } : {})}
           >
             <div
               className="me-note-resize-handle"
@@ -488,6 +503,7 @@ interface DrumGridProps {
   beatsPerBar: number;
   stepW: number;
   rowH: number;
+  editMode: boolean;
   paintModeRef: React.MutableRefObject<PaintState>;
   onAddNote: (pitch: number, step: number) => void;
   onRemoveNote: (noteId: string) => void;
@@ -495,7 +511,7 @@ interface DrumGridProps {
 }
 
 function DrumGrid({
-  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH,
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, editMode,
   paintModeRef, onAddNote, onRemoveNote, onPreviewDrum,
 }: DrumGridProps) {
   const drumNoteMap = useMemo(() => buildNoteMap(track), [track]);
@@ -514,7 +530,7 @@ function DrumGrid({
   }
 
   return (
-    <div className="me-drum-grid" style={{ width: gridW, height: gridH }}>
+    <div className="me-drum-grid" style={{ width: gridW, height: gridH, touchAction: editMode ? 'none' : 'auto' }}>
       {/* Step columns */}
       {Array.from({ length: totalSteps }, (_, s) => {
         const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
@@ -549,7 +565,7 @@ function DrumGrid({
               data-step={step}
               data-track-id={track.id}
               data-note-id={existingId ?? ''}
-              onPointerDown={e => { e.preventDefault(); cellDown(pitch, step, existingId); }}
+              {...(editMode ? { onPointerDown: (e: React.PointerEvent) => { e.preventDefault(); cellDown(pitch, step, existingId); } } : {})}
             />
           );
         });
@@ -568,6 +584,7 @@ interface TrackSectionProps {
   stepW: number;
   rowH: number;
   canDelete: boolean;
+  editMode: boolean;
   paintModeRef: React.MutableRefObject<PaintState>;
   onToggleCollapse: () => void;
   onGear: () => void;
@@ -581,7 +598,7 @@ interface TrackSectionProps {
 }
 
 function TrackSection({
-  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, canDelete,
+  track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, canDelete, editMode,
   paintModeRef, onToggleCollapse, onGear, onDelete, onMute,
   onAddNote, onRemoveNote, onStartResize, onPreviewPitch, onPreviewDrum,
 }: TrackSectionProps) {
@@ -667,6 +684,7 @@ function TrackSection({
                 beatsPerBar={beatsPerBar}
                 stepW={stepW}
                 rowH={rowH}
+                editMode={editMode}
                 paintModeRef={paintModeRef}
                 onAddNote={onAddNote}
                 onRemoveNote={onRemoveNote}
@@ -679,6 +697,7 @@ function TrackSection({
                 beatsPerBar={beatsPerBar}
                 stepW={stepW}
                 rowH={rowH}
+                editMode={editMode}
                 paintModeRef={paintModeRef}
                 onAddNote={onAddNote}
                 onRemoveNote={onRemoveNote}
@@ -700,6 +719,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const [pattern,     setPattern]     = useState<Pattern>(loadPattern);
   const [isPlaying,   setIsPlaying]   = useState(false);
   const [zoomIdx,     setZoomIdx]     = useState(loadZoomIdx);
+  const [editMode,    setEditMode]    = useState(false);
   const [modalTid,    setModalTid]    = useState<string | null>(null);
   const [showSave,    setShowSave]    = useState(false);
   const [showLoad,    setShowLoad]    = useState(false);
@@ -1041,6 +1061,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         pattern={pattern}
         isPlaying={isPlaying}
         zoomIdx={zoomIdx}
+        editMode={editMode}
         onPlay={startPlayback}
         onStop={stopPlayback}
         onBpmChange={bpm => setPattern(p => ({ ...p, bpm: Math.max(40, Math.min(240, bpm)) }))}
@@ -1052,6 +1073,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         onSave={() => setShowSave(true)}
         onLoad={() => setShowLoad(true)}
         onDownload={() => downloadJson(patternRef.current)}
+        onToggleEditMode={() => setEditMode(m => !m)}
       />
 
       {/* Main grid: single overflow:auto container */}
@@ -1085,6 +1107,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
               stepW={stepW}
               rowH={rowH}
               canDelete={pattern.tracks.length > 1}
+              editMode={editMode}
               paintModeRef={paintModeRef}
               onToggleCollapse={() => toggleCollapse(track.id)}
               onGear={() => setModalTid(track.id)}

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -31,11 +31,10 @@ for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
 const PITCH_TO_ROW = new Map<number, number>();
 PITCH_RANGE.forEach((p, i) => PITCH_TO_ROW.set(p, i));
 
-const DRUM_SEP_H = 5; // visual separator between melodic rows and drum rows
-const MELODIC_H = PITCH_RANGE.length * ROW_H;
-const DRUM_H = DRUM_TYPES.length * ROW_H;
+const DRUM_SEP_H = 5;
+const MELODIC_H  = PITCH_RANGE.length * ROW_H;
+const DRUM_H     = DRUM_TYPES.length * ROW_H;
 
-// Paint state: section prevents cross-contamination between melodic and drum drag
 type PaintState = { action: 'add' | 'remove'; section: 'melodic' | 'drum' } | null;
 
 function buildNoteMap(track: Track): Map<string, string> {
@@ -70,22 +69,9 @@ interface TransportProps {
 }
 
 function Transport({
-  pattern,
-  isPlaying,
-  activeTrackIdx,
-  activeTrack,
-  melodicTrackCount,
-  onPlay,
-  onStop,
-  onBpmChange,
-  onBarsChange,
-  onStepsPerBeatChange,
-  onActiveTrackChange,
-  onMuteTrack,
-  onChangeWaveform,
-  onAddTrack,
-  onRemoveTrack,
-  onNewPattern,
+  pattern, isPlaying, activeTrackIdx, activeTrack, melodicTrackCount,
+  onPlay, onStop, onBpmChange, onBarsChange, onStepsPerBeatChange,
+  onActiveTrackChange, onMuteTrack, onChangeWaveform, onAddTrack, onRemoveTrack, onNewPattern,
 }: TransportProps) {
   const melodicTracks = pattern.tracks.filter(t => !t.isDrum);
 
@@ -184,7 +170,10 @@ function Transport({
   );
 }
 
-// ── Unified Piano Roll + Drums grid ───────────────────────────────────────────
+// ── Piano Roll ─────────────────────────────────────────────────────────────────
+// Layout: left sidebar (keys + drum labels, always visible) + right grid area
+// (horizontal scroll). Inside the grid area: melodic grid scrolls vertically;
+// drum grid is pinned at the bottom so it's always reachable without scrolling.
 
 interface PianoRollProps {
   melodicTrack: Track;
@@ -202,18 +191,9 @@ interface PianoRollProps {
 }
 
 function PianoRoll({
-  melodicTrack,
-  drumTrack,
-  totalSteps,
-  stepsPerBeat,
-  beatsPerBar,
-  playheadRef,
-  paintModeRef,
-  onAddNote,
-  onRemoveNote,
-  onStartResize,
-  onPreviewPitch,
-  onPreviewDrum,
+  melodicTrack, drumTrack, totalSteps, stepsPerBeat, beatsPerBar,
+  playheadRef, paintModeRef, onAddNote, onRemoveNote, onStartResize,
+  onPreviewPitch, onPreviewDrum,
 }: PianoRollProps) {
   const noteMap     = useMemo(() => buildNoteMap(melodicTrack), [melodicTrack]);
   const drumNoteMap = useMemo(() => buildNoteMap(drumTrack),    [drumTrack]);
@@ -221,13 +201,25 @@ function PianoRoll({
   const lastPaintedRef      = useRef('');
   const lastPreviewPitchRef = useRef(-1);
 
-  const gridWidth  = totalSteps * STEP_W;
-  const gridHeight = MELODIC_H + DRUM_SEP_H + DRUM_H;
+  // Scroll sync: piano keys track the melodic grid's vertical scroll position
+  const keysScrollRef    = useRef<HTMLDivElement>(null);
+  const melodicScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mel  = melodicScrollRef.current;
+    const keys = keysScrollRef.current;
+    if (!mel || !keys) return;
+    function sync() { if (keys) keys.scrollTop = mel!.scrollTop; }
+    mel.addEventListener('scroll', sync, { passive: true });
+    return () => mel.removeEventListener('scroll', sync);
+  }, []);
+
+  const gridWidth = totalSteps * STEP_W;
 
   // ── Melodic cell handlers ──────────────────────────────────────────────────
 
   function handleCellDown(pitch: number, step: number) {
-    paintModeRef.current = { action: 'add', section: 'melodic' };
+    paintModeRef.current        = { action: 'add', section: 'melodic' };
     lastPaintedRef.current      = `m:${pitch},${step}`;
     lastPreviewPitchRef.current = pitch;
     onAddNote(melodicTrack.id, pitch, step);
@@ -254,8 +246,8 @@ function PianoRoll({
       paintModeRef.current = null;
       onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
     } else {
-      paintModeRef.current = { action: 'remove', section: 'melodic' };
-      lastPaintedRef.current = note.id;
+      paintModeRef.current    = { action: 'remove', section: 'melodic' };
+      lastPaintedRef.current  = note.id;
       onRemoveNote(melodicTrack.id, note.id);
     }
   }
@@ -272,11 +264,11 @@ function PianoRoll({
 
   function handleDrumDown(pitch: number, step: number, existingId: string | undefined) {
     if (existingId) {
-      paintModeRef.current = { action: 'remove', section: 'drum' };
+      paintModeRef.current   = { action: 'remove', section: 'drum' };
       lastPaintedRef.current = existingId;
       onRemoveNote(drumTrack.id, existingId);
     } else {
-      paintModeRef.current = { action: 'add', section: 'drum' };
+      paintModeRef.current   = { action: 'add', section: 'drum' };
       lastPaintedRef.current = `d:${pitch},${step}`;
       onAddNote(drumTrack.id, pitch, step);
       onPreviewDrum(pitch);
@@ -304,31 +296,52 @@ function PianoRoll({
     [melodicTrack.notes, totalSteps],
   );
 
+  // Step column elements reused in both grids
+  function renderStepCols(height: number, prefix: string) {
+    return Array.from({ length: totalSteps }, (_, s) => {
+      const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
+      const isBeat = !isBar && s % stepsPerBeat === 0;
+      const isQ4   = !isBar && !isBeat && s % 4 === 0;
+      const cls = isBar ? ' me-step-col--bar' : isBeat ? ' me-step-col--beat' : isQ4 ? ' me-step-col--q4' : '';
+      return (
+        <div
+          key={`${prefix}-${s}`}
+          className={`me-step-col${cls}`}
+          style={{ left: s * STEP_W, width: STEP_W, height }}
+        />
+      );
+    });
+  }
+
   return (
     <div className="me-piano-roll">
-      {/* ── Left sidebar: piano keys + drum labels ─────────────────────── */}
-      <div className="me-piano-keys" style={{ height: gridHeight }}>
-        {/* Melodic piano keys */}
-        {PITCH_RANGE.map(pitch => {
-          const isBlack = isBlackPitch(pitch);
-          const isC = pitch % 12 === 0;
-          return (
-            <div
-              key={pitch}
-              className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
-              style={{ height: ROW_H }}
-              onMouseDown={() => { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }}
-              onMouseEnter={e => { if (e.buttons === 1) { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; } }}
-            >
-              {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
-            </div>
-          );
-        })}
 
-        {/* Separator */}
+      {/* ── Left sidebar: always visible regardless of scroll ─────────────── */}
+      <div className="me-keys-col">
+
+        {/* Piano keys — overflow hidden; scrollTop synced from melodic grid */}
+        <div className="me-keys-scroll" ref={keysScrollRef}>
+          {PITCH_RANGE.map(pitch => {
+            const isBlack = isBlackPitch(pitch);
+            const isC     = pitch % 12 === 0;
+            return (
+              <div
+                key={pitch}
+                className={`me-key ${isBlack ? 'me-key--black' : 'me-key--white'}`}
+                style={{ height: ROW_H }}
+                onMouseDown={() => { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }}
+                onMouseEnter={e => {
+                  if (e.buttons === 1) { onPreviewPitch(pitch); lastPreviewPitchRef.current = pitch; }
+                }}
+              >
+                {isC && <span className="me-key__label">{pitchName(pitch)}</span>}
+              </div>
+            );
+          })}
+        </div>
+
         <div className="me-drum-key-sep" style={{ height: DRUM_SEP_H }} />
 
-        {/* Drum row labels */}
         {DRUM_TYPES.map((dt: DrumType) => (
           <div
             key={dt}
@@ -342,119 +355,115 @@ function PianoRoll({
         ))}
       </div>
 
-      {/* ── Note grid ─────────────────────────────────────────────────────── */}
-      <div className="me-note-grid-wrap">
-        <div className="me-note-grid" style={{ width: gridWidth, height: gridHeight }}>
+      {/* ── Grid area: horizontal scroll; melodic scrolls vertically inside ── */}
+      <div className="me-grid-h-scroll">
+        <div className="me-grid-content" style={{ minWidth: gridWidth }}>
 
-          {/* Step column markers */}
-          {Array.from({ length: totalSteps }, (_, s) => s).map(step => {
-            const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
-            const isBeat = !isBar && step % stepsPerBeat === 0;
-            const isQ4   = !isBar && !isBeat && step % 4 === 0;
-            return (
-              <div
-                key={`col-${step}`}
-                className={`me-step-col${isBar ? ' me-step-col--bar' : isBeat ? ' me-step-col--beat' : isQ4 ? ' me-step-col--q4' : ''}`}
-                style={{ left: step * STEP_W, width: STEP_W, height: gridHeight }}
-              />
-            );
-          })}
+          {/* Melodic grid — vertically scrollable */}
+          <div className="me-melodic-scroll" ref={melodicScrollRef}>
+            <div className="me-note-grid" style={{ width: gridWidth, height: MELODIC_H }}>
 
-          {/* Melodic background cells (empty spots only) */}
-          {PITCH_RANGE.map((pitch, rowIdx) => {
-            const isBlack = isBlackPitch(pitch);
-            return Array.from({ length: totalSteps }, (_, step) => {
-              if (noteMap.has(`${pitch},${step}`)) return null;
-              return (
-                <div
-                  key={`bg-${pitch}-${step}`}
-                  className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
-                  style={{ left: step * STEP_W, top: rowIdx * ROW_H, width: STEP_W, height: ROW_H }}
-                  onMouseDown={e => { e.preventDefault(); handleCellDown(pitch, step); }}
-                  onMouseEnter={() => handleCellEnter(pitch, step)}
-                />
-              );
-            });
-          })}
+              {renderStepCols(MELODIC_H, 'mc')}
 
-          {/* Melodic note rectangles */}
-          {noteRects.map(note => {
-            const rowIdx = PITCH_TO_ROW.get(note.pitch);
-            if (rowIdx === undefined) return null;
-            const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
-            const noteW = displayDur * STEP_W;
-            return (
-              <div
-                key={note.id}
-                className="me-note-rect"
-                style={{
-                  left: note.startStep * STEP_W,
-                  top: rowIdx * ROW_H,
-                  width: noteW,
-                  height: ROW_H,
-                  background: melodicTrack.color,
-                }}
-                onMouseDown={e => handleNoteDown(e, note, noteW)}
-                onMouseEnter={() => handleNoteEnter(note)}
-              >
-                <div
-                  className="me-note-resize-handle"
-                  onMouseDown={e => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    paintModeRef.current = null;
-                    onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
-                  }}
-                />
-              </div>
-            );
-          })}
+              {/* Melodic background cells */}
+              {PITCH_RANGE.map((pitch, rowIdx) => {
+                const isBlack = isBlackPitch(pitch);
+                return Array.from({ length: totalSteps }, (_, step) => {
+                  if (noteMap.has(`${pitch},${step}`)) return null;
+                  return (
+                    <div
+                      key={`bg-${pitch}-${step}`}
+                      className={`me-cell ${isBlack ? 'me-cell--black' : 'me-cell--white'}`}
+                      style={{ left: step * STEP_W, top: rowIdx * ROW_H, width: STEP_W, height: ROW_H }}
+                      onMouseDown={e => { e.preventDefault(); handleCellDown(pitch, step); }}
+                      onMouseEnter={() => handleCellEnter(pitch, step)}
+                    />
+                  );
+                });
+              })}
 
-          {/* Octave dividers */}
-          {PITCH_RANGE.map((pitch, rowIdx) =>
-            pitch % 12 === 0 ? (
-              <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * ROW_H, width: gridWidth }} />
-            ) : null
-          )}
+              {/* Note rectangles */}
+              {noteRects.map(note => {
+                const rowIdx = PITCH_TO_ROW.get(note.pitch);
+                if (rowIdx === undefined) return null;
+                const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
+                const noteW = displayDur * STEP_W;
+                return (
+                  <div
+                    key={note.id}
+                    className="me-note-rect"
+                    style={{
+                      left: note.startStep * STEP_W,
+                      top: rowIdx * ROW_H,
+                      width: noteW,
+                      height: ROW_H,
+                      background: melodicTrack.color,
+                    }}
+                    onMouseDown={e => handleNoteDown(e, note, noteW)}
+                    onMouseEnter={() => handleNoteEnter(note)}
+                  >
+                    <div
+                      className="me-note-resize-handle"
+                      onMouseDown={e => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        paintModeRef.current = null;
+                        onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
+                      }}
+                    />
+                  </div>
+                );
+              })}
 
-          {/* Drum section separator */}
-          <div
-            className="me-drum-section-sep"
-            style={{ top: MELODIC_H, width: gridWidth, height: DRUM_SEP_H }}
-          />
+              {/* Octave dividers */}
+              {PITCH_RANGE.map((pitch, rowIdx) =>
+                pitch % 12 === 0 ? (
+                  <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * ROW_H, width: gridWidth }} />
+                ) : null
+              )}
+            </div>
+          </div>
 
-          {/* Drum cells */}
-          {DRUM_TYPES.map((dt: DrumType, drumRowIdx) => {
-            const pitch  = DRUM_PITCHES[dt];
-            const rowTop = MELODIC_H + DRUM_SEP_H + drumRowIdx * ROW_H;
-            return Array.from({ length: totalSteps }, (_, step) => {
-              const cellKey    = `${pitch},${step}`;
-              const existingId = drumNoteMap.get(cellKey);
-              const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
-              const isBeat = !isBar && step % stepsPerBeat === 0;
-              return (
-                <div
-                  key={`drum-${dt}-${step}`}
-                  className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
-                  style={{
-                    left: step * STEP_W,
-                    top: rowTop,
-                    width: STEP_W,
-                    height: ROW_H,
-                    ...((existingId ? { '--drum-color': drumTrack.color } : {}) as React.CSSProperties),
-                  }}
-                  onMouseDown={e => { e.preventDefault(); handleDrumDown(pitch, step, existingId); }}
-                  onMouseEnter={() => handleDrumEnter(pitch, step, existingId)}
-                />
-              );
-            });
-          })}
+          {/* Drum section separator — always visible */}
+          <div className="me-drum-section-sep" style={{ height: DRUM_SEP_H }} />
 
-          {/* Playhead — spans full height including drum rows */}
+          {/* Drum grid — always visible at bottom, no vertical scroll needed */}
+          <div className="me-drum-grid" style={{ width: gridWidth, height: DRUM_H }}>
+
+            {renderStepCols(DRUM_H, 'dc')}
+
+            {DRUM_TYPES.map((dt: DrumType, drumRowIdx) => {
+              const pitch  = DRUM_PITCHES[dt];
+              const rowTop = drumRowIdx * ROW_H;
+              return Array.from({ length: totalSteps }, (_, step) => {
+                const cellKey    = `${pitch},${step}`;
+                const existingId = drumNoteMap.get(cellKey);
+                const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+                const isBeat = !isBar && step % stepsPerBeat === 0;
+                return (
+                  <div
+                    key={`drum-${dt}-${step}`}
+                    className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
+                    style={{
+                      left: step * STEP_W,
+                      top: rowTop,
+                      width: STEP_W,
+                      height: ROW_H,
+                      ...((existingId ? { '--drum-color': drumTrack.color } : {}) as React.CSSProperties),
+                    }}
+                    onMouseDown={e => { e.preventDefault(); handleDrumDown(pitch, step, existingId); }}
+                    onMouseEnter={() => handleDrumEnter(pitch, step, existingId)}
+                  />
+                );
+              });
+            })}
+          </div>
+
+          {/* Playhead — absolutely positioned over the full grid content area */}
           <div
             className="me-playhead"
             ref={playheadRef as React.RefObject<HTMLDivElement>}
-            style={{ height: gridHeight, display: 'none' }}
+            style={{ display: 'none' }}
           />
         </div>
       </div>
@@ -469,20 +478,20 @@ interface MidiEditorProps {
 }
 
 export default function MidiEditor({ onQuit }: MidiEditorProps) {
-  const [pattern, setPattern] = useState<Pattern>(createInitialPattern);
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [pattern, setPattern]           = useState<Pattern>(createInitialPattern);
+  const [isPlaying, setIsPlaying]       = useState(false);
   const [activeTrackIdx, setActiveTrackIdx] = useState(0);
 
-  const patternRef = useRef(pattern);
-  patternRef.current = pattern;
+  const patternRef    = useRef(pattern);
+  patternRef.current  = pattern;
 
-  const isPlayingRef = useRef(false);
-  const stepRef      = useRef(0);
-  const timerRef     = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playheadRef  = useRef<HTMLDivElement | null>(null);
+  const isPlayingRef  = useRef(false);
+  const stepRef       = useRef(0);
+  const timerRef      = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playheadRef   = useRef<HTMLDivElement | null>(null);
 
-  const paintModeRef  = useRef(null) as React.MutableRefObject<PaintState>;
-  const resizeModeRef = useRef(false);
+  const paintModeRef   = useRef(null) as React.MutableRefObject<PaintState>;
+  const resizeModeRef  = useRef(false);
   const resizeStateRef = useRef<{
     noteId: string; trackId: string;
     startX: number; origDuration: number; noteStartStep: number;
@@ -491,9 +500,9 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const activeTrackRef = useRef<Track | null>(null);
 
   const melodicTracks = useMemo(() => pattern.tracks.filter(t => !t.isDrum), [pattern.tracks]);
-  const drumTrack     = useMemo(() => pattern.tracks.find(t => t.isDrum)!,  [pattern.tracks]);
+  const drumTrack     = useMemo(() => pattern.tracks.find(t => t.isDrum)!,   [pattern.tracks]);
 
-  const clampedIdx = Math.min(activeTrackIdx, melodicTracks.length - 1);
+  const clampedIdx  = Math.min(activeTrackIdx, melodicTracks.length - 1);
   const activeTrack = melodicTracks[clampedIdx] ?? melodicTracks[0];
   activeTrackRef.current = activeTrack;
 
@@ -502,11 +511,11 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     [pattern.bars, pattern.beatsPerBar, pattern.stepsPerBeat],
   );
 
-  // ── Playback ─────────────────────────────────────────────────────────────────
+  // ── Playback ──────────────────────────────────────────────────────────────────
 
   function movePlayhead(step: number) {
     if (playheadRef.current) {
-      playheadRef.current.style.display = 'block';
+      playheadRef.current.style.display   = 'block';
       playheadRef.current.style.transform = `translateX(${step * STEP_W}px)`;
     }
   }
@@ -556,13 +565,13 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   useEffect(() => () => { stopPlayback(); }, [stopPlayback]);
 
-  // ── Global mouse events ───────────────────────────────────────────────────────
+  // ── Global mouse + keyboard events ────────────────────────────────────────────
 
   useEffect(() => {
     function handleMouseMove(e: MouseEvent) {
       if (!resizeModeRef.current || !resizeStateRef.current) return;
       const { noteId, trackId, startX, origDuration, noteStartStep } = resizeStateRef.current;
-      const pat = patternRef.current;
+      const pat    = patternRef.current;
       const maxDur = pat.bars * pat.beatsPerBar * pat.stepsPerBeat - noteStartStep;
       const newDur = Math.max(1, Math.min(maxDur, origDuration + Math.round((e.clientX - startX) / STEP_W)));
       setPattern(prev => ({
@@ -574,20 +583,18 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     }
 
     function handleMouseUp() {
-      paintModeRef.current  = null;
-      resizeModeRef.current = false;
+      paintModeRef.current   = null;
+      resizeModeRef.current  = false;
       resizeStateRef.current = null;
     }
 
     document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('mouseup',   handleMouseUp);
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('mouseup',   handleMouseUp);
     };
   }, []);
-
-  // ── Spacebar ──────────────────────────────────────────────────────────────────
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -625,7 +632,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   }, []);
 
   const startResizeNote = useCallback((noteId: string, startX: number, origDuration: number, noteStartStep: number) => {
-    resizeModeRef.current = true;
+    resizeModeRef.current  = true;
     resizeStateRef.current = {
       noteId,
       trackId: activeTrackRef.current?.id ?? '',

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -14,8 +14,6 @@ import {
   PIANO_MAX,
   STEP_W,
   ROW_H,
-  SEQ_BTN_W,
-  SEQ_BTN_H,
   isBlackPitch,
   pitchName,
   makeNoteId,
@@ -33,7 +31,13 @@ for (let p = PIANO_MAX; p >= PIANO_MIN; p--) PITCH_RANGE.push(p);
 const PITCH_TO_ROW = new Map<number, number>();
 PITCH_RANGE.forEach((p, i) => PITCH_TO_ROW.set(p, i));
 
-// Maps `${pitch},${step}` → noteId (including all cells spanned by the note)
+const DRUM_SEP_H = 5; // visual separator between melodic rows and drum rows
+const MELODIC_H = PITCH_RANGE.length * ROW_H;
+const DRUM_H = DRUM_TYPES.length * ROW_H;
+
+// Paint state: section prevents cross-contamination between melodic and drum drag
+type PaintState = { action: 'add' | 'remove'; section: 'melodic' | 'drum' } | null;
+
 function buildNoteMap(track: Track): Map<string, string> {
   const m = new Map<string, string>();
   track.notes.forEach(n => {
@@ -145,18 +149,8 @@ function Transport({
             {t.name}
           </button>
         ))}
-        <button
-          className="me-btn me-btn--sm"
-          onMouseDown={onAddTrack}
-          disabled={melodicTrackCount >= 10}
-          title="Add melodic track"
-        >+TRK</button>
-        <button
-          className="me-btn me-btn--sm"
-          onMouseDown={onRemoveTrack}
-          disabled={melodicTrackCount <= 1}
-          title="Remove active track"
-        >-TRK</button>
+        <button className="me-btn me-btn--sm" onMouseDown={onAddTrack} disabled={melodicTrackCount >= 10} title="Add track">+TRK</button>
+        <button className="me-btn me-btn--sm" onMouseDown={onRemoveTrack} disabled={melodicTrackCount <= 1} title="Remove active track">-TRK</button>
 
         <div className="me-transport__sep" />
 
@@ -173,7 +167,6 @@ function Transport({
         </select>
 
         <div className="me-transport__sep" />
-
         <span className="me-label me-label--dim">MUTE:</span>
         {pattern.tracks.map(t => (
           <button
@@ -191,23 +184,26 @@ function Transport({
   );
 }
 
-// ── Piano Roll ─────────────────────────────────────────────────────────────────
+// ── Unified Piano Roll + Drums grid ───────────────────────────────────────────
 
 interface PianoRollProps {
-  track: Track;
+  melodicTrack: Track;
+  drumTrack: Track;
   totalSteps: number;
   stepsPerBeat: number;
   beatsPerBar: number;
   playheadRef: React.RefObject<HTMLDivElement | null>;
-  paintModeRef: React.MutableRefObject<'add' | 'remove' | null>;
-  onAddNote: (pitch: number, step: number) => void;
-  onRemoveNote: (noteId: string) => void;
+  paintModeRef: React.MutableRefObject<PaintState>;
+  onAddNote: (trackId: string, pitch: number, step: number) => void;
+  onRemoveNote: (trackId: string, noteId: string) => void;
   onStartResize: (noteId: string, startX: number, origDuration: number, noteStartStep: number) => void;
   onPreviewPitch: (pitch: number) => void;
+  onPreviewDrum: (pitch: number) => void;
 }
 
 function PianoRoll({
-  track,
+  melodicTrack,
+  drumTrack,
   totalSteps,
   stepsPerBeat,
   beatsPerBar,
@@ -217,28 +213,34 @@ function PianoRoll({
   onRemoveNote,
   onStartResize,
   onPreviewPitch,
+  onPreviewDrum,
 }: PianoRollProps) {
-  const noteMap = useMemo(() => buildNoteMap(track), [track]);
-  const lastPaintedRef = useRef('');
+  const noteMap     = useMemo(() => buildNoteMap(melodicTrack), [melodicTrack]);
+  const drumNoteMap = useMemo(() => buildNoteMap(drumTrack),    [drumTrack]);
+
+  const lastPaintedRef      = useRef('');
   const lastPreviewPitchRef = useRef(-1);
 
-  const gridWidth = totalSteps * STEP_W;
-  const gridHeight = PITCH_RANGE.length * ROW_H;
+  const gridWidth  = totalSteps * STEP_W;
+  const gridHeight = MELODIC_H + DRUM_SEP_H + DRUM_H;
+
+  // ── Melodic cell handlers ──────────────────────────────────────────────────
 
   function handleCellDown(pitch: number, step: number) {
-    paintModeRef.current = 'add';
-    lastPaintedRef.current = `${pitch},${step}`;
+    paintModeRef.current = { action: 'add', section: 'melodic' };
+    lastPaintedRef.current      = `m:${pitch},${step}`;
     lastPreviewPitchRef.current = pitch;
-    onAddNote(pitch, step);
+    onAddNote(melodicTrack.id, pitch, step);
     onPreviewPitch(pitch);
   }
 
   function handleCellEnter(pitch: number, step: number) {
-    if (paintModeRef.current !== 'add') return;
-    const key = `${pitch},${step}`;
-    if (key === lastPaintedRef.current) return;
+    const pm = paintModeRef.current;
+    if (!pm || pm.section !== 'melodic' || pm.action !== 'add') return;
+    const key = `m:${pitch},${step}`;
+    if (key === lastPaintedRef.current || noteMap.has(`${pitch},${step}`)) return;
     lastPaintedRef.current = key;
-    onAddNote(pitch, step);
+    onAddNote(melodicTrack.id, pitch, step);
     if (pitch !== lastPreviewPitchRef.current) {
       lastPreviewPitchRef.current = pitch;
       onPreviewPitch(pitch);
@@ -248,34 +250,65 @@ function PianoRoll({
   function handleNoteDown(e: React.MouseEvent, note: Note, noteW: number) {
     e.stopPropagation();
     e.preventDefault();
-    const localX = e.nativeEvent.offsetX;
-    if (localX >= noteW - 6) {
-      // Resize handle
+    if (e.nativeEvent.offsetX >= noteW - 6) {
       paintModeRef.current = null;
       onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
     } else {
-      paintModeRef.current = 'remove';
+      paintModeRef.current = { action: 'remove', section: 'melodic' };
       lastPaintedRef.current = note.id;
-      onRemoveNote(note.id);
+      onRemoveNote(melodicTrack.id, note.id);
     }
   }
 
   function handleNoteEnter(note: Note) {
-    if (paintModeRef.current !== 'remove') return;
+    const pm = paintModeRef.current;
+    if (!pm || pm.section !== 'melodic' || pm.action !== 'remove') return;
     if (note.id === lastPaintedRef.current) return;
     lastPaintedRef.current = note.id;
-    onRemoveNote(note.id);
+    onRemoveNote(melodicTrack.id, note.id);
   }
 
-  const noteRects = useMemo(() =>
-    track.notes.filter(n => n.startStep < totalSteps),
-    [track.notes, totalSteps],
+  // ── Drum cell handlers ─────────────────────────────────────────────────────
+
+  function handleDrumDown(pitch: number, step: number, existingId: string | undefined) {
+    if (existingId) {
+      paintModeRef.current = { action: 'remove', section: 'drum' };
+      lastPaintedRef.current = existingId;
+      onRemoveNote(drumTrack.id, existingId);
+    } else {
+      paintModeRef.current = { action: 'add', section: 'drum' };
+      lastPaintedRef.current = `d:${pitch},${step}`;
+      onAddNote(drumTrack.id, pitch, step);
+      onPreviewDrum(pitch);
+    }
+  }
+
+  function handleDrumEnter(pitch: number, step: number, existingId: string | undefined) {
+    const pm = paintModeRef.current;
+    if (!pm || pm.section !== 'drum') return;
+    if (pm.action === 'add') {
+      const key = `d:${pitch},${step}`;
+      if (key === lastPaintedRef.current || existingId) return;
+      lastPaintedRef.current = key;
+      onAddNote(drumTrack.id, pitch, step);
+      onPreviewDrum(pitch);
+    } else {
+      if (!existingId || existingId === lastPaintedRef.current) return;
+      lastPaintedRef.current = existingId;
+      onRemoveNote(drumTrack.id, existingId);
+    }
+  }
+
+  const noteRects = useMemo(
+    () => melodicTrack.notes.filter(n => n.startStep < totalSteps),
+    [melodicTrack.notes, totalSteps],
   );
 
   return (
     <div className="me-piano-roll">
-      {/* Piano keys column */}
+      {/* ── Left sidebar: piano keys + drum labels ─────────────────────── */}
       <div className="me-piano-keys" style={{ height: gridHeight }}>
+        {/* Melodic piano keys */}
         {PITCH_RANGE.map(pitch => {
           const isBlack = isBlackPitch(pitch);
           const isC = pitch % 12 === 0;
@@ -291,13 +324,29 @@ function PianoRoll({
             </div>
           );
         })}
+
+        {/* Separator */}
+        <div className="me-drum-key-sep" style={{ height: DRUM_SEP_H }} />
+
+        {/* Drum row labels */}
+        {DRUM_TYPES.map((dt: DrumType) => (
+          <div
+            key={dt}
+            className="me-drum-key"
+            style={{ height: ROW_H }}
+            onMouseDown={() => onPreviewDrum(DRUM_PITCHES[dt])}
+            onMouseEnter={e => { if (e.buttons === 1) onPreviewDrum(DRUM_PITCHES[dt]); }}
+          >
+            {DRUM_LABELS[dt]}
+          </div>
+        ))}
       </div>
 
-      {/* Note grid */}
+      {/* ── Note grid ─────────────────────────────────────────────────────── */}
       <div className="me-note-grid-wrap">
         <div className="me-note-grid" style={{ width: gridWidth, height: gridHeight }}>
 
-          {/* Step column markers (beat / bar lines) */}
+          {/* Step column markers */}
           {Array.from({ length: totalSteps }, (_, s) => s).map(step => {
             const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
             const isBeat = !isBar && step % stepsPerBeat === 0;
@@ -311,7 +360,7 @@ function PianoRoll({
             );
           })}
 
-          {/* Background cells (only where no note occupies) */}
+          {/* Melodic background cells (empty spots only) */}
           {PITCH_RANGE.map((pitch, rowIdx) => {
             const isBlack = isBlackPitch(pitch);
             return Array.from({ length: totalSteps }, (_, step) => {
@@ -328,7 +377,7 @@ function PianoRoll({
             });
           })}
 
-          {/* Note rectangles */}
+          {/* Melodic note rectangles */}
           {noteRects.map(note => {
             const rowIdx = PITCH_TO_ROW.get(note.pitch);
             if (rowIdx === undefined) return null;
@@ -343,7 +392,7 @@ function PianoRoll({
                   top: rowIdx * ROW_H,
                   width: noteW,
                   height: ROW_H,
-                  background: track.color,
+                  background: melodicTrack.color,
                 }}
                 onMouseDown={e => handleNoteDown(e, note, noteW)}
                 onMouseEnter={() => handleNoteEnter(note)}
@@ -361,145 +410,51 @@ function PianoRoll({
             );
           })}
 
-          {/* Octave dividers (at each C) */}
+          {/* Octave dividers */}
           {PITCH_RANGE.map((pitch, rowIdx) =>
             pitch % 12 === 0 ? (
               <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * ROW_H, width: gridWidth }} />
             ) : null
           )}
 
-          {/* Playhead */}
+          {/* Drum section separator */}
+          <div
+            className="me-drum-section-sep"
+            style={{ top: MELODIC_H, width: gridWidth, height: DRUM_SEP_H }}
+          />
+
+          {/* Drum cells */}
+          {DRUM_TYPES.map((dt: DrumType, drumRowIdx) => {
+            const pitch  = DRUM_PITCHES[dt];
+            const rowTop = MELODIC_H + DRUM_SEP_H + drumRowIdx * ROW_H;
+            return Array.from({ length: totalSteps }, (_, step) => {
+              const cellKey    = `${pitch},${step}`;
+              const existingId = drumNoteMap.get(cellKey);
+              const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
+              const isBeat = !isBar && step % stepsPerBeat === 0;
+              return (
+                <div
+                  key={`drum-${dt}-${step}`}
+                  className={`me-drum-cell${existingId ? ' me-drum-cell--on' : ''}${isBar ? ' me-drum-cell--bar' : isBeat ? ' me-drum-cell--beat' : ''}`}
+                  style={{
+                    left: step * STEP_W,
+                    top: rowTop,
+                    width: STEP_W,
+                    height: ROW_H,
+                    ...((existingId ? { '--drum-color': drumTrack.color } : {}) as React.CSSProperties),
+                  }}
+                  onMouseDown={e => { e.preventDefault(); handleDrumDown(pitch, step, existingId); }}
+                  onMouseEnter={() => handleDrumEnter(pitch, step, existingId)}
+                />
+              );
+            });
+          })}
+
+          {/* Playhead — spans full height including drum rows */}
           <div
             className="me-playhead"
             ref={playheadRef as React.RefObject<HTMLDivElement>}
             style={{ height: gridHeight, display: 'none' }}
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Step Sequencer ─────────────────────────────────────────────────────────────
-
-interface StepSeqProps {
-  track: Track;
-  totalSteps: number;
-  stepsPerBeat: number;
-  beatsPerBar: number;
-  seqPlayheadRef: React.RefObject<HTMLDivElement | null>;
-  seqPaintModeRef: React.MutableRefObject<'add' | 'remove' | null>;
-  onAddDrumNote: (pitch: number, step: number) => void;
-  onRemoveDrumNote: (noteId: string) => void;
-  onPreviewDrum: (pitch: number) => void;
-}
-
-function StepSeq({
-  track,
-  totalSteps,
-  stepsPerBeat,
-  beatsPerBar,
-  seqPlayheadRef,
-  seqPaintModeRef,
-  onAddDrumNote,
-  onRemoveDrumNote,
-  onPreviewDrum,
-}: StepSeqProps) {
-  const drumNoteMap = useMemo(() => buildNoteMap(track), [track]);
-  const lastPaintedRef = useRef('');
-
-  const gridWidth = totalSteps * SEQ_BTN_W;
-  const gridHeight = DRUM_TYPES.length * SEQ_BTN_H;
-
-  function handleBtnDown(pitch: number, step: number) {
-    const key = `${pitch},${step}`;
-    const existingId = drumNoteMap.get(key);
-    if (existingId) {
-      seqPaintModeRef.current = 'remove';
-      lastPaintedRef.current = existingId;
-      onRemoveDrumNote(existingId);
-    } else {
-      seqPaintModeRef.current = 'add';
-      lastPaintedRef.current = key;
-      onAddDrumNote(pitch, step);
-      onPreviewDrum(pitch);
-    }
-  }
-
-  function handleBtnEnter(pitch: number, step: number) {
-    const key = `${pitch},${step}`;
-    if (seqPaintModeRef.current === 'add') {
-      if (key === lastPaintedRef.current || drumNoteMap.has(key)) return;
-      lastPaintedRef.current = key;
-      onAddDrumNote(pitch, step);
-      onPreviewDrum(pitch);
-    } else if (seqPaintModeRef.current === 'remove') {
-      const existingId = drumNoteMap.get(key);
-      if (!existingId || existingId === lastPaintedRef.current) return;
-      lastPaintedRef.current = existingId;
-      onRemoveDrumNote(existingId);
-    }
-  }
-
-  return (
-    <div className="me-step-seq">
-      <div className="me-step-seq__labels">
-        <div className="me-step-seq__corner" />
-        {DRUM_TYPES.map(dt => (
-          <div key={dt} className="me-drum-label" style={{ height: SEQ_BTN_H }}>
-            {DRUM_LABELS[dt]}
-          </div>
-        ))}
-      </div>
-
-      <div className="me-step-seq__grid-wrap">
-        <div className="me-step-seq__grid" style={{ width: gridWidth, height: gridHeight + SEQ_BTN_H }}>
-
-          {/* Step indicator row */}
-          <div className="me-seq-indicator-row" style={{ width: gridWidth }}>
-            {Array.from({ length: totalSteps }, (_, s) => s).map(step => {
-              const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
-              const isBeat = !isBar && step % stepsPerBeat === 0;
-              const isQ4   = !isBar && !isBeat && step % 4 === 0;
-              return (
-                <div
-                  key={step}
-                  className={`me-seq-step-num${isBar ? ' me-seq-step-num--bar' : isBeat ? ' me-seq-step-num--beat' : isQ4 ? ' me-seq-step-num--q4' : ''}`}
-                  style={{ width: SEQ_BTN_W }}
-                />
-              );
-            })}
-          </div>
-
-          {/* Button rows */}
-          {DRUM_TYPES.map((dt: DrumType) => {
-            const pitch = DRUM_PITCHES[dt];
-            return (
-              <div key={dt} className="me-seq-row" style={{ height: SEQ_BTN_H }}>
-                {Array.from({ length: totalSteps }, (_, step) => {
-                  const isOn   = drumNoteMap.has(`${pitch},${step}`);
-                  const isBar  = step % (stepsPerBeat * beatsPerBar) === 0;
-                  const isBeat = !isBar && step % stepsPerBeat === 0;
-                  const isQ4   = !isBar && !isBeat && step % 4 === 0;
-                  return (
-                    <button
-                      key={step}
-                      className={`me-seq-btn${isOn ? ' me-seq-btn--on' : ' me-seq-btn--off'}${isBar ? ' me-seq-btn--bar' : isBeat ? ' me-seq-btn--beat' : isQ4 ? ' me-seq-btn--q4' : ''}`}
-                      style={{ width: SEQ_BTN_W, height: SEQ_BTN_H, ...(isOn ? { background: track.color } : {}) }}
-                      onMouseDown={e => { e.preventDefault(); handleBtnDown(pitch, step); }}
-                      onMouseEnter={() => handleBtnEnter(pitch, step)}
-                    />
-                  );
-                })}
-              </div>
-            );
-          })}
-
-          {/* Playhead overlay */}
-          <div
-            className="me-seq-playhead"
-            ref={seqPlayheadRef as React.RefObject<HTMLDivElement>}
-            style={{ height: gridHeight, top: SEQ_BTN_H, display: 'none' }}
           />
         </div>
       </div>
@@ -522,16 +477,11 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   patternRef.current = pattern;
 
   const isPlayingRef = useRef(false);
-  const stepRef = useRef(0);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playheadRef = useRef<HTMLDivElement | null>(null);
-  const seqPlayheadRef = useRef<HTMLDivElement | null>(null);
+  const stepRef      = useRef(0);
+  const timerRef     = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playheadRef  = useRef<HTMLDivElement | null>(null);
 
-  // Paint drag refs (cleared on global mouseup)
-  const paintModeRef = useRef(null) as React.MutableRefObject<'add' | 'remove' | null>;
-  const seqPaintModeRef = useRef(null) as React.MutableRefObject<'add' | 'remove' | null>;
-
-  // Resize drag refs
+  const paintModeRef  = useRef(null) as React.MutableRefObject<PaintState>;
   const resizeModeRef = useRef(false);
   const resizeStateRef = useRef<{
     noteId: string; trackId: string;
@@ -541,7 +491,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const activeTrackRef = useRef<Track | null>(null);
 
   const melodicTracks = useMemo(() => pattern.tracks.filter(t => !t.isDrum), [pattern.tracks]);
-  const drumTrack = useMemo(() => pattern.tracks.find(t => t.isDrum)!, [pattern.tracks]);
+  const drumTrack     = useMemo(() => pattern.tracks.find(t => t.isDrum)!,  [pattern.tracks]);
 
   const clampedIdx = Math.min(activeTrackIdx, melodicTracks.length - 1);
   const activeTrack = melodicTracks[clampedIdx] ?? melodicTracks[0];
@@ -559,15 +509,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       playheadRef.current.style.display = 'block';
       playheadRef.current.style.transform = `translateX(${step * STEP_W}px)`;
     }
-    if (seqPlayheadRef.current) {
-      seqPlayheadRef.current.style.display = 'block';
-      seqPlayheadRef.current.style.transform = `translateX(${step * SEQ_BTN_W}px)`;
-    }
   }
 
   function hidePlayhead() {
     if (playheadRef.current) playheadRef.current.style.display = 'none';
-    if (seqPlayheadRef.current) seqPlayheadRef.current.style.display = 'none';
   }
 
   const stopPlayback = useCallback(() => {
@@ -580,9 +525,9 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const tick = useCallback(() => {
     if (!isPlayingRef.current) return;
-    const pat = patternRef.current;
+    const pat   = patternRef.current;
     const total = pat.bars * pat.beatsPerBar * pat.stepsPerBeat;
-    const step = stepRef.current;
+    const step  = stepRef.current;
 
     movePlayhead(step);
 
@@ -611,28 +556,25 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   useEffect(() => () => { stopPlayback(); }, [stopPlayback]);
 
-  // ── Global mouse events (resize + clear paint mode) ───────────────────────────
+  // ── Global mouse events ───────────────────────────────────────────────────────
 
   useEffect(() => {
     function handleMouseMove(e: MouseEvent) {
       if (!resizeModeRef.current || !resizeStateRef.current) return;
       const { noteId, trackId, startX, origDuration, noteStartStep } = resizeStateRef.current;
-      const deltaSteps = Math.round((e.clientX - startX) / STEP_W);
       const pat = patternRef.current;
       const maxDur = pat.bars * pat.beatsPerBar * pat.stepsPerBeat - noteStartStep;
-      const newDur = Math.max(1, Math.min(maxDur, origDuration + deltaSteps));
+      const newDur = Math.max(1, Math.min(maxDur, origDuration + Math.round((e.clientX - startX) / STEP_W)));
       setPattern(prev => ({
         ...prev,
         tracks: prev.tracks.map(t => t.id !== trackId ? t : {
-          ...t,
-          notes: t.notes.map(n => n.id !== noteId ? n : { ...n, durationSteps: newDur }),
+          ...t, notes: t.notes.map(n => n.id !== noteId ? n : { ...n, durationSteps: newDur }),
         }),
       }));
     }
 
     function handleMouseUp() {
-      paintModeRef.current = null;
-      seqPaintModeRef.current = null;
+      paintModeRef.current  = null;
       resizeModeRef.current = false;
       resizeStateRef.current = null;
     }
@@ -645,7 +587,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     };
   }, []);
 
-  // ── Spacebar play/pause ───────────────────────────────────────────────────────
+  // ── Spacebar ──────────────────────────────────────────────────────────────────
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -687,9 +629,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     resizeStateRef.current = {
       noteId,
       trackId: activeTrackRef.current?.id ?? '',
-      startX,
-      origDuration,
-      noteStartStep,
+      startX, origDuration, noteStartStep,
     };
   }, []);
 
@@ -719,9 +659,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         name: `Trk ${idx + 1}`,
         color: TRACK_COLORS[idx % TRACK_COLORS.length],
         waveform: 'sine',
-        notes: [],
-        muted: false,
-        isDrum: false,
+        notes: [], muted: false, isDrum: false,
       };
       return {
         ...prev,
@@ -745,8 +683,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     setPattern(createInitialPattern());
     setActiveTrackIdx(0);
   }, [stopPlayback]);
-
-  // ── Preview ───────────────────────────────────────────────────────────────────
 
   const previewPitch = useCallback((pitch: number) => {
     resumeAudio();
@@ -814,37 +750,20 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       />
 
       <div className="me-body">
-        <div className="me-piano-section">
-          <div className="me-section-label">PIANO ROLL — {activeTrack.name.toUpperCase()}</div>
-          <div className="me-piano-roll-wrap">
-            <PianoRoll
-              track={activeTrack}
-              totalSteps={totalSteps}
-              stepsPerBeat={pattern.stepsPerBeat}
-              beatsPerBar={pattern.beatsPerBar}
-              playheadRef={playheadRef}
-              paintModeRef={paintModeRef}
-              onAddNote={(pitch, step) => addNote(activeTrack.id, pitch, step)}
-              onRemoveNote={noteId => removeNote(activeTrack.id, noteId)}
-              onStartResize={startResizeNote}
-              onPreviewPitch={previewPitch}
-            />
-          </div>
-        </div>
-
-        <div className="me-divider" />
-
-        <div className="me-seq-section">
-          <div className="me-section-label">STEP SEQUENCER — DRUMS</div>
-          <StepSeq
-            track={drumTrack}
+        <div className="me-section-label">PIANO ROLL — {activeTrack.name.toUpperCase()}</div>
+        <div className="me-piano-roll-wrap">
+          <PianoRoll
+            melodicTrack={activeTrack}
+            drumTrack={drumTrack}
             totalSteps={totalSteps}
             stepsPerBeat={pattern.stepsPerBeat}
             beatsPerBar={pattern.beatsPerBar}
-            seqPlayheadRef={seqPlayheadRef}
-            seqPaintModeRef={seqPaintModeRef}
-            onAddDrumNote={(pitch, step) => addNote(drumTrack.id, pitch, step)}
-            onRemoveDrumNote={noteId => removeNote(drumTrack.id, noteId)}
+            playheadRef={playheadRef}
+            paintModeRef={paintModeRef}
+            onAddNote={addNote}
+            onRemoveNote={removeNote}
+            onStartResize={startResizeNote}
+            onPreviewPitch={previewPitch}
             onPreviewDrum={previewDrum}
           />
         </div>

--- a/src/experiences/MidiEditor/audio.ts
+++ b/src/experiences/MidiEditor/audio.ts
@@ -19,6 +19,7 @@ export function midiToHz(midi: number): number {
   return 440 * Math.pow(2, (midi - 69) / 12);
 }
 
+// Proper ADSR: attack → sustain at full vol → release at end of note
 export function playNote(
   pitch: number,
   velocity: number,
@@ -26,21 +27,33 @@ export function playNote(
   waveform: OscWaveform,
   when?: number,
   gain = 1,
+  attack = 0.01,
+  release = 0.1,
 ): void {
-  const c = getCtx();
-  const t = when ?? c.currentTime;
+  const c   = getCtx();
+  const t   = when ?? c.currentTime;
   const vol = (velocity / 127) * 0.22 * Math.max(0, Math.min(1, gain));
+
+  const atkDur   = Math.min(attack, durationSec * 0.4);
+  const relDur   = Math.min(release, durationSec * 0.4);
+  const atkEnd   = t + atkDur;
+  const relStart = t + Math.max(atkDur, durationSec - relDur);
+  const relEnd   = relStart + relDur;
 
   const osc = c.createOscillator();
   const env = c.createGain();
   osc.type = waveform as OscillatorType;
   osc.frequency.value = midiToHz(pitch);
-  env.gain.setValueAtTime(vol, t);
-  env.gain.exponentialRampToValueAtTime(0.001, t + durationSec);
+
+  env.gain.setValueAtTime(0, t);
+  env.gain.linearRampToValueAtTime(vol, atkEnd);
+  env.gain.setValueAtTime(vol, relStart);
+  env.gain.exponentialRampToValueAtTime(0.001, relEnd + 0.005);
+
   osc.connect(env);
   env.connect(c.destination);
   osc.start(t);
-  osc.stop(t + durationSec + 0.01);
+  osc.stop(relEnd + 0.01);
 }
 
 function makeNoiseBuf(c: AudioContext, dur: number): AudioBuffer {
@@ -61,10 +74,8 @@ function playKick(velocity: number, when: number): void {
   osc.frequency.exponentialRampToValueAtTime(40, when + 0.08);
   env.gain.setValueAtTime(vol, when);
   env.gain.exponentialRampToValueAtTime(0.001, when + 0.25);
-  osc.connect(env);
-  env.connect(c.destination);
-  osc.start(when);
-  osc.stop(when + 0.26);
+  osc.connect(env); env.connect(c.destination);
+  osc.start(when); osc.stop(when + 0.26);
 }
 
 function playSnare(velocity: number, when: number): void {
@@ -75,27 +86,20 @@ function playSnare(velocity: number, when: number): void {
   const noise = c.createBufferSource();
   noise.buffer = makeNoiseBuf(c, dur);
   const filt = c.createBiquadFilter();
-  filt.type = 'bandpass';
-  filt.frequency.value = 1800;
+  filt.type = 'bandpass'; filt.frequency.value = 1800;
   const env = c.createGain();
   env.gain.setValueAtTime(vol, when);
   env.gain.exponentialRampToValueAtTime(0.001, when + dur);
-  noise.connect(filt);
-  filt.connect(env);
-  env.connect(c.destination);
-  noise.start(when);
-  noise.stop(when + dur);
+  noise.connect(filt); filt.connect(env); env.connect(c.destination);
+  noise.start(when); noise.stop(when + dur);
 
   const osc = c.createOscillator();
   const oenv = c.createGain();
-  osc.type = 'triangle';
-  osc.frequency.value = 200;
+  osc.type = 'triangle'; osc.frequency.value = 200;
   oenv.gain.setValueAtTime(vol * 0.7, when);
   oenv.gain.exponentialRampToValueAtTime(0.001, when + 0.08);
-  osc.connect(oenv);
-  oenv.connect(c.destination);
-  osc.start(when);
-  osc.stop(when + 0.09);
+  osc.connect(oenv); oenv.connect(c.destination);
+  osc.start(when); osc.stop(when + 0.09);
 }
 
 function playHihat(open: boolean, velocity: number, when: number): void {
@@ -106,16 +110,73 @@ function playHihat(open: boolean, velocity: number, when: number): void {
   const noise = c.createBufferSource();
   noise.buffer = makeNoiseBuf(c, dur);
   const hp = c.createBiquadFilter();
-  hp.type = 'highpass';
-  hp.frequency.value = 8000;
+  hp.type = 'highpass'; hp.frequency.value = 8000;
   const env = c.createGain();
   env.gain.setValueAtTime(vol, when);
   env.gain.exponentialRampToValueAtTime(0.001, when + dur);
-  noise.connect(hp);
-  hp.connect(env);
-  env.connect(c.destination);
-  noise.start(when);
-  noise.stop(when + dur);
+  noise.connect(hp); hp.connect(env); env.connect(c.destination);
+  noise.start(when); noise.stop(when + dur);
+}
+
+function playTom(freq: number, velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.55;
+  const osc = c.createOscillator();
+  const env = c.createGain();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(freq, when);
+  osc.frequency.exponentialRampToValueAtTime(freq * 0.45, when + 0.14);
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + 0.22);
+  osc.connect(env); env.connect(c.destination);
+  osc.start(when); osc.stop(when + 0.23);
+}
+
+function playClap(velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.35;
+  for (let i = 0; i < 2; i++) {
+    const d = i * 0.014;
+    const noise = c.createBufferSource();
+    noise.buffer = makeNoiseBuf(c, 0.06);
+    const filt = c.createBiquadFilter();
+    filt.type = 'bandpass'; filt.frequency.value = 1200; filt.Q.value = 0.8;
+    const env = c.createGain();
+    env.gain.setValueAtTime(vol, when + d);
+    env.gain.exponentialRampToValueAtTime(0.001, when + d + 0.09);
+    noise.connect(filt); filt.connect(env); env.connect(c.destination);
+    noise.start(when + d); noise.stop(when + d + 0.1);
+  }
+}
+
+function playCrash(velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.2;
+  const dur = 0.8;
+  const noise = c.createBufferSource();
+  noise.buffer = makeNoiseBuf(c, dur);
+  const hp = c.createBiquadFilter();
+  hp.type = 'highpass'; hp.frequency.value = 6000;
+  const env = c.createGain();
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + dur);
+  noise.connect(hp); hp.connect(env); env.connect(c.destination);
+  noise.start(when); noise.stop(when + dur);
+}
+
+function playRide(velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.15;
+  const dur = 0.35;
+  const noise = c.createBufferSource();
+  noise.buffer = makeNoiseBuf(c, dur);
+  const bp = c.createBiquadFilter();
+  bp.type = 'bandpass'; bp.frequency.value = 10000; bp.Q.value = 2;
+  const env = c.createGain();
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + dur);
+  noise.connect(bp); bp.connect(env); env.connect(c.destination);
+  noise.start(when); noise.stop(when + dur);
 }
 
 export function playDrum(pitch: number, velocity: number, when?: number): void {
@@ -124,7 +185,13 @@ export function playDrum(pitch: number, velocity: number, when?: number): void {
   switch (pitch) {
     case 36: playKick(velocity, t); break;
     case 38: playSnare(velocity, t); break;
+    case 39: playClap(velocity, t); break;
+    case 41: playTom(90,  velocity, t); break;
     case 42: playHihat(false, velocity, t); break;
-    case 46: playHihat(true, velocity, t); break;
+    case 46: playHihat(true,  velocity, t); break;
+    case 47: playTom(150, velocity, t); break;
+    case 49: playCrash(velocity, t); break;
+    case 50: playTom(220, velocity, t); break;
+    case 51: playRide(velocity, t); break;
   }
 }

--- a/src/experiences/MidiEditor/audio.ts
+++ b/src/experiences/MidiEditor/audio.ts
@@ -25,10 +25,11 @@ export function playNote(
   durationSec: number,
   waveform: OscWaveform,
   when?: number,
+  gain = 1,
 ): void {
   const c = getCtx();
   const t = when ?? c.currentTime;
-  const vol = (velocity / 127) * 0.22;
+  const vol = (velocity / 127) * 0.22 * Math.max(0, Math.min(1, gain));
 
   const osc = c.createOscillator();
   const env = c.createGain();

--- a/src/experiences/MidiEditor/audio.ts
+++ b/src/experiences/MidiEditor/audio.ts
@@ -1,0 +1,129 @@
+import type { OscWaveform } from './types';
+
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext {
+  if (!ctx) ctx = new AudioContext();
+  return ctx;
+}
+
+export function resumeAudio(): void {
+  if (ctx && ctx.state === 'suspended') void ctx.resume();
+}
+
+export function audioCurrentTime(): number {
+  return getCtx().currentTime;
+}
+
+export function midiToHz(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+export function playNote(
+  pitch: number,
+  velocity: number,
+  durationSec: number,
+  waveform: OscWaveform,
+  when?: number,
+): void {
+  const c = getCtx();
+  const t = when ?? c.currentTime;
+  const vol = (velocity / 127) * 0.22;
+
+  const osc = c.createOscillator();
+  const env = c.createGain();
+  osc.type = waveform as OscillatorType;
+  osc.frequency.value = midiToHz(pitch);
+  env.gain.setValueAtTime(vol, t);
+  env.gain.exponentialRampToValueAtTime(0.001, t + durationSec);
+  osc.connect(env);
+  env.connect(c.destination);
+  osc.start(t);
+  osc.stop(t + durationSec + 0.01);
+}
+
+function makeNoiseBuf(c: AudioContext, dur: number): AudioBuffer {
+  const len = Math.ceil(c.sampleRate * dur);
+  const buf = c.createBuffer(1, len, c.sampleRate);
+  const d = buf.getChannelData(0);
+  for (let i = 0; i < len; i++) d[i] = Math.random() * 2 - 1;
+  return buf;
+}
+
+function playKick(velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.7;
+  const osc = c.createOscillator();
+  const env = c.createGain();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(150, when);
+  osc.frequency.exponentialRampToValueAtTime(40, when + 0.08);
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + 0.25);
+  osc.connect(env);
+  env.connect(c.destination);
+  osc.start(when);
+  osc.stop(when + 0.26);
+}
+
+function playSnare(velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.4;
+  const dur = 0.18;
+
+  const noise = c.createBufferSource();
+  noise.buffer = makeNoiseBuf(c, dur);
+  const filt = c.createBiquadFilter();
+  filt.type = 'bandpass';
+  filt.frequency.value = 1800;
+  const env = c.createGain();
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + dur);
+  noise.connect(filt);
+  filt.connect(env);
+  env.connect(c.destination);
+  noise.start(when);
+  noise.stop(when + dur);
+
+  const osc = c.createOscillator();
+  const oenv = c.createGain();
+  osc.type = 'triangle';
+  osc.frequency.value = 200;
+  oenv.gain.setValueAtTime(vol * 0.7, when);
+  oenv.gain.exponentialRampToValueAtTime(0.001, when + 0.08);
+  osc.connect(oenv);
+  oenv.connect(c.destination);
+  osc.start(when);
+  osc.stop(when + 0.09);
+}
+
+function playHihat(open: boolean, velocity: number, when: number): void {
+  const c = getCtx();
+  const vol = (velocity / 127) * 0.25;
+  const dur = open ? 0.28 : 0.045;
+
+  const noise = c.createBufferSource();
+  noise.buffer = makeNoiseBuf(c, dur);
+  const hp = c.createBiquadFilter();
+  hp.type = 'highpass';
+  hp.frequency.value = 8000;
+  const env = c.createGain();
+  env.gain.setValueAtTime(vol, when);
+  env.gain.exponentialRampToValueAtTime(0.001, when + dur);
+  noise.connect(hp);
+  hp.connect(env);
+  env.connect(c.destination);
+  noise.start(when);
+  noise.stop(when + dur);
+}
+
+export function playDrum(pitch: number, velocity: number, when?: number): void {
+  const c = getCtx();
+  const t = when ?? c.currentTime;
+  switch (pitch) {
+    case 36: playKick(velocity, t); break;
+    case 38: playSnare(velocity, t); break;
+    case 42: playHihat(false, velocity, t); break;
+    case 46: playHihat(true, velocity, t); break;
+  }
+}

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -53,9 +53,6 @@ export const PIANO_MAX = 83;
 export const STEP_W = 22;
 export const ROW_H = 14;
 export const KEY_W = 42;
-export const SEQ_BTN_W = 22;
-export const SEQ_BTN_H = 28;
-export const DRUM_LABEL_W = 60;
 
 let noteCounter = 0;
 export function makeNoteId(): string {

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -1,0 +1,84 @@
+export type OscWaveform = 'sine' | 'square' | 'sawtooth' | 'triangle';
+
+export interface Note {
+  id: string;
+  pitch: number;
+  startStep: number;
+  durationSteps: number;
+  velocity: number;
+}
+
+export interface Track {
+  id: string;
+  name: string;
+  color: string;
+  waveform: OscWaveform;
+  notes: Note[];
+  muted: boolean;
+  isDrum: boolean;
+}
+
+export interface Pattern {
+  bpm: number;
+  bars: number;
+  beatsPerBar: number;
+  stepsPerBeat: number;
+  tracks: Track[];
+}
+
+export const DRUM_PITCHES = {
+  kick: 36,
+  snare: 38,
+  'hihat-c': 42,
+  'hihat-o': 46,
+} as const;
+
+export type DrumType = keyof typeof DRUM_PITCHES;
+export const DRUM_TYPES: DrumType[] = ['kick', 'snare', 'hihat-c', 'hihat-o'];
+export const DRUM_LABELS: Record<DrumType, string> = {
+  kick: 'Kick',
+  snare: 'Snare',
+  'hihat-c': 'HiHat C',
+  'hihat-o': 'HiHat O',
+};
+
+export const PIANO_MIN = 36;
+export const PIANO_MAX = 83;
+
+export const STEP_W = 22;
+export const ROW_H = 14;
+export const KEY_W = 42;
+export const SEQ_BTN_W = 22;
+export const SEQ_BTN_H = 28;
+export const DRUM_LABEL_W = 60;
+
+let noteCounter = 0;
+export function makeNoteId(): string {
+  return `n${++noteCounter}`;
+}
+
+export function isBlackPitch(pitch: number): boolean {
+  const semitone = pitch % 12;
+  return [1, 3, 6, 8, 10].includes(semitone);
+}
+
+export function pitchName(pitch: number): string {
+  const names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const octave = Math.floor(pitch / 12) - 1;
+  return `${names[pitch % 12]}${octave}`;
+}
+
+export function createInitialPattern(): Pattern {
+  return {
+    bpm: 120,
+    bars: 2,
+    beatsPerBar: 4,
+    stepsPerBeat: 4,
+    tracks: [
+      { id: 'lead',  name: 'Lead',  color: '#cc4400', waveform: 'sine',     notes: [], muted: false, isDrum: false },
+      { id: 'pad',   name: 'Pad',   color: '#5b2d8e', waveform: 'triangle', notes: [], muted: false, isDrum: false },
+      { id: 'bass',  name: 'Bass',  color: '#228833', waveform: 'sawtooth', notes: [], muted: false, isDrum: false },
+      { id: 'drums', name: 'Drums', color: '#c89000', waveform: 'sine',     notes: [], muted: false, isDrum: true  },
+    ],
+  };
+}

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -1,5 +1,10 @@
 export type OscWaveform = 'sine' | 'square' | 'sawtooth' | 'triangle';
 
+export const TRACK_COLORS = [
+  '#cc4400', '#5b2d8e', '#228833', '#c89000',
+  '#1a5fa8', '#a82080', '#607000', '#005a5a', '#804020', '#3a4080',
+] as const;
+
 export interface Note {
   id: string;
   pitch: number;

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -25,6 +25,7 @@ export interface Track {
   attack: number;     // seconds
   release: number;    // seconds
   collapsed: boolean;
+  drumRows?: number[]; // ordered MIDI pitches; only meaningful for drum tracks
 }
 
 export interface Pattern {
@@ -36,20 +37,46 @@ export interface Pattern {
 }
 
 export const DRUM_PITCHES = {
-  kick:     36,
-  snare:    38,
+  kick:      36,
+  snare:     38,
+  clap:      39,
+  'tom-l':   41,
   'hihat-c': 42,
   'hihat-o': 46,
+  'tom-m':   47,
+  crash:     49,
+  'tom-h':   50,
+  ride:      51,
 } as const;
 
 export type DrumType = keyof typeof DRUM_PITCHES;
-export const DRUM_TYPES: DrumType[] = ['kick', 'snare', 'hihat-c', 'hihat-o'];
+
+export const DRUM_TYPES: DrumType[] = [
+  'kick', 'snare', 'clap', 'tom-l', 'hihat-c', 'hihat-o', 'tom-m', 'crash', 'tom-h', 'ride',
+];
+
 export const DRUM_LABELS: Record<DrumType, string> = {
   kick:      'Kick',
   snare:     'Snare',
-  'hihat-c': 'HiHat C',
-  'hihat-o': 'HiHat O',
+  clap:      'Clap',
+  'tom-l':   'Tom L',
+  'hihat-c': 'HH Cl',
+  'hihat-o': 'HH Op',
+  'tom-m':   'Tom M',
+  crash:     'Crash',
+  'tom-h':   'Tom H',
+  ride:      'Ride',
 };
+
+const PITCH_LABEL_MAP: Record<number, string> = {};
+(Object.keys(DRUM_PITCHES) as DrumType[]).forEach(k => {
+  PITCH_LABEL_MAP[DRUM_PITCHES[k]] = DRUM_LABELS[k];
+});
+export function drumPitchLabel(pitch: number): string {
+  return PITCH_LABEL_MAP[pitch] ?? `D${pitch}`;
+}
+
+export const DEFAULT_DRUM_ROWS = [36, 38, 42, 46]; // kick, snare, hihat-c, hihat-o
 
 export const PIANO_MIN = 36;  // C2
 export const PIANO_MAX = 83;  // B5
@@ -76,7 +103,7 @@ export function createInitialPattern(): Pattern {
   return {
     bpm: 120, bars: 2, beatsPerBar: 4, stepsPerBeat: 4,
     tracks: [
-      makeTrack({ id: 'drums', name: 'Drums', color: '#c89000', waveform: 'sine',     notes: [], muted: false, isDrum: true  }),
+      makeTrack({ id: 'drums', name: 'Drums', color: '#c89000', waveform: 'sine',     notes: [], muted: false, isDrum: true,  drumRows: [...DEFAULT_DRUM_ROWS] }),
       makeTrack({ id: 'lead',  name: 'Lead',  color: '#cc4400', waveform: 'sine',     notes: [], muted: false, isDrum: false }),
       makeTrack({ id: 'pad',   name: 'Pad',   color: '#5b2d8e', waveform: 'triangle', notes: [], muted: false, isDrum: false }),
       makeTrack({ id: 'bass',  name: 'Bass',  color: '#228833', waveform: 'sawtooth', notes: [], muted: false, isDrum: false }),

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -21,6 +21,10 @@ export interface Track {
   notes: Note[];
   muted: boolean;
   isDrum: boolean;
+  volume: number;     // 0–1
+  attack: number;     // seconds
+  release: number;    // seconds
+  collapsed: boolean;
 }
 
 export interface Pattern {
@@ -32,8 +36,8 @@ export interface Pattern {
 }
 
 export const DRUM_PITCHES = {
-  kick: 36,
-  snare: 38,
+  kick:     36,
+  snare:    38,
   'hihat-c': 42,
   'hihat-o': 46,
 } as const;
@@ -41,18 +45,14 @@ export const DRUM_PITCHES = {
 export type DrumType = keyof typeof DRUM_PITCHES;
 export const DRUM_TYPES: DrumType[] = ['kick', 'snare', 'hihat-c', 'hihat-o'];
 export const DRUM_LABELS: Record<DrumType, string> = {
-  kick: 'Kick',
-  snare: 'Snare',
+  kick:      'Kick',
+  snare:     'Snare',
   'hihat-c': 'HiHat C',
   'hihat-o': 'HiHat O',
 };
 
-export const PIANO_MIN = 36;
-export const PIANO_MAX = 83;
-
-export const STEP_W = 22;
-export const ROW_H = 14;
-export const KEY_W = 42;
+export const PIANO_MIN = 36;  // C2
+export const PIANO_MAX = 83;  // B5
 
 let noteCounter = 0;
 export function makeNoteId(): string {
@@ -60,27 +60,26 @@ export function makeNoteId(): string {
 }
 
 export function isBlackPitch(pitch: number): boolean {
-  const semitone = pitch % 12;
-  return [1, 3, 6, 8, 10].includes(semitone);
+  return [1, 3, 6, 8, 10].includes(pitch % 12);
 }
 
 export function pitchName(pitch: number): string {
-  const names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-  const octave = Math.floor(pitch / 12) - 1;
-  return `${names[pitch % 12]}${octave}`;
+  const names = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+  return `${names[pitch % 12]}${Math.floor(pitch / 12) - 1}`;
+}
+
+function makeTrack(partial: Omit<Track, 'volume'|'attack'|'release'|'collapsed'>): Track {
+  return { ...partial, volume: 1, attack: 0.01, release: 0.3, collapsed: false };
 }
 
 export function createInitialPattern(): Pattern {
   return {
-    bpm: 120,
-    bars: 2,
-    beatsPerBar: 4,
-    stepsPerBeat: 4,
+    bpm: 120, bars: 2, beatsPerBar: 4, stepsPerBeat: 4,
     tracks: [
-      { id: 'lead',  name: 'Lead',  color: '#cc4400', waveform: 'sine',     notes: [], muted: false, isDrum: false },
-      { id: 'pad',   name: 'Pad',   color: '#5b2d8e', waveform: 'triangle', notes: [], muted: false, isDrum: false },
-      { id: 'bass',  name: 'Bass',  color: '#228833', waveform: 'sawtooth', notes: [], muted: false, isDrum: false },
-      { id: 'drums', name: 'Drums', color: '#c89000', waveform: 'sine',     notes: [], muted: false, isDrum: true  },
+      makeTrack({ id: 'drums', name: 'Drums', color: '#c89000', waveform: 'sine',     notes: [], muted: false, isDrum: true  }),
+      makeTrack({ id: 'lead',  name: 'Lead',  color: '#cc4400', waveform: 'sine',     notes: [], muted: false, isDrum: false }),
+      makeTrack({ id: 'pad',   name: 'Pad',   color: '#5b2d8e', waveform: 'triangle', notes: [], muted: false, isDrum: false }),
+      makeTrack({ id: 'bass',  name: 'Bass',  color: '#228833', waveform: 'sawtooth', notes: [], muted: false, isDrum: false }),
     ],
   };
 }

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -27,6 +27,7 @@ import Pool from "../Pool/Pool";
 import DuckHunt from "../DuckHunt/DuckHunt";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
 import SoundRecorder, { lsGetSoundNames } from "./SoundRecorder";
+import MidiEditor from "../MidiEditor/MidiEditor";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import CardsLauncher from "../Cards/CardsLauncher";
 import War from "../Cards/War";
@@ -64,7 +65,8 @@ type AppAction =
   | "nsart"
   | "art-backup"
   | "readme"
-  | "sound-recorder";
+  | "sound-recorder"
+  | "midi-editor";
 
 interface AppDef {
   title: string;
@@ -90,6 +92,7 @@ const APP_REGISTRY: Record<string, AppDef> = {
   "duck-hunt":      { title: "Duck & Learn",       icon: "🎯", action: "duckhunt"        },
   "typing-racer":   { title: "Type 'Em Up",        icon: "⌨️", action: "experience"      },
   "sound-recorder": { title: "Sound Recorder",     icon: "🎙️", action: "sound-recorder"  },
+  "midi-editor":    { title: "MIDI Editor",         icon: "🎹", action: "midi-editor"     },
 };
 
 // ── Desktop icon entries (subset actually shown on desktop) ───────────────────
@@ -181,7 +184,8 @@ type WindowContent =
   | { type: "desktop-display" }
   | { type: "nsart" }
   | { type: "nsart-backup" }
-  | { type: "sound-recorder"; fileName?: string };
+  | { type: "sound-recorder"; fileName?: string }
+  | { type: "midi-editor" };
 
 interface OpenWindow {
   id: string;
@@ -538,6 +542,7 @@ export default function NsDoors97() {
         case "duckhunt":     content = { type: "duckhunt" };             width = 740; break;
         case "cards":          content = { type: "cards-launcher" };                           width = 320; break;
         case "sound-recorder": content = { type: "sound-recorder" as const };                  width = 420; break;
+        case "midi-editor":    content = { type: "midi-editor" as const };                     width = 860; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -869,6 +874,9 @@ export default function NsDoors97() {
               onQuit={() => closeWindow(win.id)}
               onFileSaved={handleSoundFileSaved}
             />
+          )}
+          {win.content.type === "midi-editor" && (
+            <MidiEditor onQuit={() => closeWindow(win.id)} />
           )}
           {win.content.type === "desktop-display" && (
             <DisplayApp

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -113,6 +113,7 @@ const TOOLS_ITEMS = [
   { id: "notebook",       icon: "📝", label: "Notebook"       },
   { id: "ns-art",         icon: "🎨", label: "NS Art"          },
   { id: "sound-recorder", icon: "🎙️", label: "Sound Recorder" },
+  { id: "midi-editor",    icon: "🎹", label: "MIDI Editor"    },
 ] as const;
 
 type OpenSubmenu = "games" | "tools" | "settings" | null;

--- a/src/experiences/NsDoors97/fileSystem.ts
+++ b/src/experiences/NsDoors97/fileSystem.ts
@@ -321,10 +321,11 @@ export const ROOT: FsFolder = {
           kind: "folder",
           name: "Accessories",
           children: [
-            { kind: "file", name: "Notebook.exe",    type: "exe", action: "notebook"   },
-            { kind: "file", name: "Paint.exe",       type: "exe", action: "noop"       },
-            { kind: "file", name: "Calculator.exe",  type: "exe", action: "noop"       },
-            { kind: "file", name: "Clock.exe",       type: "exe", action: "noop"       },
+            { kind: "file", name: "Notebook.exe",     type: "exe", action: "notebook"      },
+            { kind: "file", name: "MIDI Editor.exe",  type: "exe", action: "midi-editor"  },
+            { kind: "file", name: "Paint.exe",        type: "exe", action: "noop"          },
+            { kind: "file", name: "Calculator.exe",   type: "exe", action: "noop"          },
+            { kind: "file", name: "Clock.exe",        type: "exe", action: "noop"          },
           ],
         },
         {

--- a/src/pages/MidiEditorPage.tsx
+++ b/src/pages/MidiEditorPage.tsx
@@ -1,0 +1,23 @@
+import MidiEditor from '../experiences/MidiEditor/MidiEditor';
+import StandaloneWindow from '../components/StandaloneWindow/StandaloneWindow';
+
+export default function MidiEditorPage() {
+  return (
+    <StandaloneWindow
+      title="MIDI Editor"
+      icon="🎹"
+      helpContent={
+        <ul>
+          <li>Click piano roll cells to add/remove notes</li>
+          <li>Click piano keys to preview a pitch</li>
+          <li>Toggle step sequencer buttons for drums</li>
+          <li>Use the transport bar to play/stop</li>
+          <li>Select a track to edit in the piano roll</li>
+          <li>Mute individual tracks with the M buttons</li>
+        </ul>
+      }
+    >
+      <MidiEditor />
+    </StandaloneWindow>
+  );
+}


### PR DESCRIPTION
Piano roll (3 melodic tracks, C2–B5) and step sequencer (4 drum sounds)
side by side. Web Audio oscillator synthesis with architecture open for
future sampled instruments. Configurable BPM (40–240), bars (1/2/4/8),
and step grid (1/8 or 1/16). Playhead updates via DOM ref to avoid
React re-renders during playback. Integrated into NS Doors 97 and
accessible at /midi-editor.

https://claude.ai/code/session_01Hpv7DgWExZSG944ewRHsyt