### PR TITLE
Fix pool 8-ball win/loss, scratch inhand, add strictness settings, CPU vs CPU mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@vitejs/plugin-react": "^4.3.1",
         "jimp": "^0.22.12",
         "typescript": "^5.5.3",
-        "vite": "^5.4.2"
+        "vite": "^5.4.2",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1712,6 +1713,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1731,6 +1845,16 @@
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1842,6 +1966,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001778",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
@@ -1871,6 +2005,33 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clsx": {
@@ -1914,6 +2075,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -1926,6 +2097,13 @@
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1976,6 +2154,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -2001,6 +2189,16 @@
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==",
       "dev": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/file-type": {
       "version": "16.5.4",
@@ -2225,6 +2423,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2233,6 +2438,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mime": {
@@ -2366,6 +2581,23 @@
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -2780,6 +3012,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2789,6 +3028,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2825,12 +3078,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/token-types": {
       "version": "4.2.1",
@@ -2981,6 +3278,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3004,6 +3390,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xhr": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "playwright test",
-    "test:update": "playwright test --update-snapshots"
+    "test:update": "playwright test --update-snapshots",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@noahwright/design": "^1.1.0",
@@ -24,6 +25,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "jimp": "^0.22.12",
     "typescript": "^5.5.3",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/experiences/Pool/Pool.css
+++ b/src/experiences/Pool/Pool.css
@@ -308,3 +308,74 @@
   line-height: 1.6;
   min-height: 10px;
 }
+
+/* ── Ball-in-hand confirm bar ────────────────────────────────────────────── */
+.pool-inhand-bar {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+}
+
+.pool-btn--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Settings modal ───────────────────────────────────────────────────────── */
+.pool-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.pool-modal {
+  background: #c0c0c0;
+  border: 3px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 20px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  min-width: 260px;
+}
+
+.pool-modal__title {
+  font-size: 10px;
+  color: #cc4400;
+  letter-spacing: 1px;
+}
+
+.pool-modal__section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.pool-modal__label {
+  font-size: 7px;
+  color: #333;
+  align-self: flex-start;
+}
+
+.pool-modal__options {
+  display: flex;
+  gap: 6px;
+}
+
+.pool-modal__desc {
+  font-size: 5px;
+  color: #555;
+  text-align: center;
+  line-height: 1.8;
+  min-height: 18px;
+}

--- a/src/experiences/Pool/Pool.tsx
+++ b/src/experiences/Pool/Pool.tsx
@@ -35,7 +35,7 @@ const MIN_SPEED  = 0.012;
 // ── Controls ──────────────────────────────────────────────────────────────────
 const MAX_VEL       = 22;
 const AIM_LERP_MAX  = 0.18;
-const AIM_LERP_RAMP = 0.008;
+const AIM_LERP_RAMP = 0.004;
 const ENG_LERP_MAX  = 0.15;
 const ENG_LERP_RAMP = 0.007;
 const ENG_DOT_SCALE = 30;
@@ -1049,6 +1049,14 @@ export default function Pool({ onQuit }: PoolProps) {
     );
   })();
 
+  // ── Shared label maps (used on both setup screen and settings modal) ─────
+  const strictnessLabel: Record<Strictness, string> = {
+    strict: 'Strict', loose: 'Loose', generous: 'Generous',
+  };
+  const hintLabel: Record<HintLevel, string> = {
+    minimal: 'Minimal', normal: 'Normal', extra: 'Extra',
+  };
+
   // ── Setup screen ──────────────────────────────────────────────────────────
   if (gamePhase === 'setup') {
     const isAI0 = mode === 'aiai';
@@ -1100,6 +1108,26 @@ export default function Pool({ onQuit }: PoolProps) {
               </>
           }
         </div>
+        <div className="pool-setup__fields">
+          <label className="pool-setup__label">Pocket Size</label>
+          <div className="pool-setup__row">
+            {(['strict', 'loose', 'generous'] as Strictness[]).map(s => (
+              <button key={s} className={`pool-btn${strictness === s ? ' pool-btn--on' : ''}`}
+                onClick={() => setStrictness(s)}>
+                {strictnessLabel[s]}
+              </button>
+            ))}
+          </div>
+          <label className="pool-setup__label">Aim Hints</label>
+          <div className="pool-setup__row">
+            {(['minimal', 'normal', 'extra'] as HintLevel[]).map(h => (
+              <button key={h} className={`pool-btn${hintLevel === h ? ' pool-btn--on' : ''}`}
+                onClick={() => setHintLevel(h)}>
+                {hintLabel[h]}
+              </button>
+            ))}
+          </div>
+        </div>
         <div className="pool-setup__actions">
           <button
             className="pool-btn pool-btn--primary"
@@ -1125,13 +1153,6 @@ export default function Pool({ onQuit }: PoolProps) {
     : uiPhase === 'aiming' && isHumanTurn
     ? 'Tap/hold to aim · drag cue down to shoot'
     : uiMsg;
-
-  const strictnessLabel: Record<Strictness, string> = {
-    strict: 'Strict', loose: 'Loose', generous: 'Generous',
-  };
-  const hintLabel: Record<HintLevel, string> = {
-    minimal: 'Minimal', normal: 'Normal', extra: 'Extra',
-  };
 
   return (
     <div className="pool-game">

--- a/src/experiences/Pool/Pool.tsx
+++ b/src/experiences/Pool/Pool.tsx
@@ -89,6 +89,9 @@ const STRICTNESS_MULT: Record<Strictness, { my: number; opp: number }> = {
   generous: { my: 1.15, opp: 0.95 },
 };
 
+// ── Aim hint level ────────────────────────────────────────────────────────────
+type HintLevel = 'minimal' | 'normal' | 'extra';
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 type Mode   = 'hvh' | 'hvai' | 'aiai';
 type AIDiff = 'easy' | 'normal' | 'hard';
@@ -320,9 +323,10 @@ function liftColor(hex: string, amt: number): string {
   return `rgb(${Math.min(255, (n >> 16) + amt)},${Math.min(255, ((n >> 8) & 0xff) + amt)},${Math.min(255, (n & 0xff) + amt)})`;
 }
 
-function ghostBallDist(balls: Ball[], cue: Ball, angle: number): number {
+function ghostBallInfo(balls: Ball[], cue: Ball, angle: number): { dist: number; target: Ball | null } {
   const dx = Math.cos(angle), dy = Math.sin(angle);
   let minD = Infinity;
+  let target: Ball | null = null;
   for (const b of balls) {
     if (b.pocketed || b.num === 0) continue;
     const t = (b.x - cue.x) * dx + (b.y - cue.y) * dy;
@@ -331,10 +335,10 @@ function ghostBallDist(balls: Ball[], cue: Ball, angle: number): number {
     const perp = Math.hypot(b.x - px, b.y - py);
     if (perp < BR * 2) {
       const hit = t - Math.sqrt(Math.max(0, (BR * 2) ** 2 - perp * perp));
-      if (hit < minD) minD = hit;
+      if (hit < minD) { minD = hit; target = b; }
     }
   }
-  return minD === Infinity ? 0 : minD;
+  return minD === Infinity ? { dist: 0, target: null } : { dist: minD, target };
 }
 
 function drawBallScaled(
@@ -430,7 +434,7 @@ function drawStick(
   ctx.lineTo(tx + Math.cos(backAng) * 10, ty + Math.sin(backAng) * 10); ctx.stroke();
 }
 
-function renderFrame(ctx: CanvasRenderingContext2D, gs: GState, shotPower: number): void {
+function renderFrame(ctx: CanvasRenderingContext2D, gs: GState, shotPower: number, hintLevel: HintLevel): void {
   ctx.clearRect(0, 0, CW, CH);
 
   ctx.fillStyle = '#7a4010';
@@ -464,12 +468,45 @@ function renderFrame(ctx: CanvasRenderingContext2D, gs: GState, shotPower: numbe
 
   if (showAiming && cue) {
     const angle = gs.aimAngle;
-    const gd    = ghostBallDist(gs.balls, cue, angle);
-    if (gd > 0) {
+    const { dist: gd, target: hitBall } = ghostBallInfo(gs.balls, cue, angle);
+
+    // Ghost ball at impact point (normal + extra only)
+    if (hintLevel !== 'minimal' && gd > 0) {
       const gx = cue.x + Math.cos(angle) * gd, gy = cue.y + Math.sin(angle) * gd;
       ctx.strokeStyle = 'rgba(255,255,255,0.22)'; ctx.lineWidth = 1; ctx.setLineDash([]);
       ctx.beginPath(); ctx.arc(gx, gy, BR, 0, Math.PI * 2); ctx.stroke();
+
+      // Extra: projected paths for the hit ball and cue ball after collision
+      if (hintLevel === 'extra' && hitBall) {
+        // Collision normal: from ghost center toward hit ball center
+        const nx = (hitBall.x - gx) / (BR * 2);
+        const ny = (hitBall.y - gy) / (BR * 2);
+
+        // Target ball travels along the collision normal
+        const tLen = 90;
+        ctx.strokeStyle = 'rgba(255,200,80,0.55)'; ctx.lineWidth = 1.5; ctx.setLineDash([]);
+        ctx.beginPath();
+        ctx.moveTo(hitBall.x, hitBall.y);
+        ctx.lineTo(hitBall.x + nx * tLen, hitBall.y + ny * tLen);
+        ctx.stroke();
+
+        // Cue ball deflects perpendicular to collision normal (elastic equal-mass)
+        const cdx = Math.cos(angle), cdy = Math.sin(angle);
+        const dot = cdx * nx + cdy * ny;
+        const dflX = cdx - dot * nx, dflY = cdy - dot * ny;
+        const dflMag = Math.hypot(dflX, dflY);
+        if (dflMag > 0.01) {
+          const cLen = 65;
+          ctx.strokeStyle = 'rgba(120,200,255,0.45)'; ctx.lineWidth = 1.5; ctx.setLineDash([4, 5]);
+          ctx.beginPath();
+          ctx.moveTo(gx, gy);
+          ctx.lineTo(gx + (dflX / dflMag) * cLen, gy + (dflY / dflMag) * cLen);
+          ctx.stroke(); ctx.setLineDash([]);
+        }
+      }
     }
+
+    // Aim line from cue ball to impact (or full length if no target)
     ctx.strokeStyle = 'rgba(255,255,255,0.28)'; ctx.lineWidth = 1; ctx.setLineDash([6, 8]);
     ctx.beginPath();
     ctx.moveTo(cue.x, cue.y);
@@ -529,6 +566,7 @@ export default function Pool({ onQuit }: PoolProps) {
   const aimLerpRef   = useRef(0);
   const invertAimRef = useRef(false);
   const strictnessRef = useRef<Strictness>('strict');
+  const hintLevelRef  = useRef<HintLevel>('normal');
 
   const engBallRef   = useRef<HTMLDivElement>(null);
   const engDotRef    = useRef<HTMLDivElement>(null);
@@ -552,6 +590,7 @@ export default function Pool({ onQuit }: PoolProps) {
   const [invertAim,    setInvertAim]    = useState(false);
   const [cuePower,     setCuePower]     = useState(0);
   const [strictness,   setStrictness]   = useState<Strictness>('strict');
+  const [hintLevel,    setHintLevel]    = useState<HintLevel>('normal');
   const [showSettings, setShowSettings] = useState(false);
 
   const [uiPhase,     setUiPhase]     = useState<Phase>('aiming');
@@ -566,6 +605,7 @@ export default function Pool({ onQuit }: PoolProps) {
   useEffect(() => { diffRef.current = diff; }, [diff]);
   useEffect(() => { invertAimRef.current = invertAim; }, [invertAim]);
   useEffect(() => { strictnessRef.current = strictness; }, [strictness]);
+  useEffect(() => { hintLevelRef.current  = hintLevel;  }, [hintLevel]);
 
   const syncUi = useCallback((gs: GState) => {
     setUiPhase(gs.phase);
@@ -877,7 +917,7 @@ export default function Pool({ onQuit }: PoolProps) {
           }
         }
 
-        renderFrame(ctx, gsRef.current!, cuePowerRef.current);
+        renderFrame(ctx, gsRef.current!, cuePowerRef.current, hintLevelRef.current);
       }
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -1089,6 +1129,9 @@ export default function Pool({ onQuit }: PoolProps) {
   const strictnessLabel: Record<Strictness, string> = {
     strict: 'Strict', loose: 'Loose', generous: 'Generous',
   };
+  const hintLabel: Record<HintLevel, string> = {
+    minimal: 'Minimal', normal: 'Normal', extra: 'Extra',
+  };
 
   return (
     <div className="pool-game">
@@ -1115,6 +1158,25 @@ export default function Pool({ onQuit }: PoolProps) {
                 {strictness === 'strict'   && 'Standard hitboxes for all balls.'}
                 {strictness === 'loose'    && 'Slightly larger pockets for your balls.'}
                 {strictness === 'generous' && 'Bigger pockets for your balls, tighter for opponent\'s.'}
+              </div>
+            </div>
+            <div className="pool-modal__section">
+              <div className="pool-modal__label">Aim Hints</div>
+              <div className="pool-modal__options">
+                {(['minimal', 'normal', 'extra'] as HintLevel[]).map(h => (
+                  <button
+                    key={h}
+                    className={`pool-btn${hintLevel === h ? ' pool-btn--on' : ''}`}
+                    onClick={() => setHintLevel(h)}
+                  >
+                    {hintLabel[h]}
+                  </button>
+                ))}
+              </div>
+              <div className="pool-modal__desc">
+                {hintLevel === 'minimal' && 'Aim line only — no impact indicator.'}
+                {hintLevel === 'normal'  && 'Aim line + ghost ball at impact point.'}
+                {hintLevel === 'extra'   && 'Ghost ball + projected paths after collision.'}
               </div>
             </div>
             <button className="pool-btn pool-btn--primary" onClick={() => setShowSettings(false)}>OK</button>

--- a/src/experiences/Pool/Pool.tsx
+++ b/src/experiences/Pool/Pool.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useWindowMenus } from '../../components/Window/useWindowMenus';
 import type { MenuBarMenu } from '../../components/MenuBar/MenuBar';
+import type { Ball, Group, Phase, GState } from './poolLogic';
+import { groupBalls, processTurnEnd, DEFAULT_INHAND_POS } from './poolLogic';
 import './Pool.css';
 
 // ── Canvas dimensions ─────────────────────────────────────────────────────────
@@ -36,7 +38,6 @@ const AIM_LERP_MAX  = 0.18;
 const AIM_LERP_RAMP = 0.008;
 const ENG_LERP_MAX  = 0.15;
 const ENG_LERP_RAMP = 0.007;
-// English dot travel radius (px) for the 80px ball
 const ENG_DOT_SCALE = 30;
 
 // ── Key positions ─────────────────────────────────────────────────────────────
@@ -76,52 +77,27 @@ const STICK_COLORS = [
   '#e8dfc0', // Ivory
 ];
 
+// ── Pocket-size strictness ────────────────────────────────────────────────────
+type Strictness = 'strict' | 'loose' | 'generous';
+
+// Multipliers applied to the catch radius for player's own balls vs opponent's.
+// "Generous" gives the current player a bigger pocket and makes opponent balls
+// slightly smaller so they're harder to accidentally sink.
+const STRICTNESS_MULT: Record<Strictness, { my: number; opp: number }> = {
+  strict:   { my: 1.00, opp: 1.00 },
+  loose:    { my: 1.10, opp: 1.00 },
+  generous: { my: 1.15, opp: 0.95 },
+};
+
 // ── Types ─────────────────────────────────────────────────────────────────────
-interface Ball {
-  num: number;
-  x: number; y: number;
-  vx: number; vy: number;
-  spinX: number; spinY: number;
-  pocketed: boolean;
-  rotAngle: number;  // visual rolling angle, accumulated each frame
-}
-
-type Group  = 'solids' | 'stripes';
-type Phase  = 'aiming' | 'moving' | 'inhand' | 'over';
-type Mode   = 'hvh' | 'hvai';
+type Mode   = 'hvh' | 'hvai' | 'aiai';
 type AIDiff = 'easy' | 'normal' | 'hard';
-
-interface Player {
-  name: string;
-  group: Group | null;
-  isAI: boolean;
-  color: string;
-}
-
-interface GState {
-  balls: Ball[];
-  phase: Phase;
-  turn: 0 | 1;
-  players: [Player, Player];
-  foul: boolean;
-  isBreak: boolean;
-  pocketedThisTurn: number[];
-  sunkBalls: number[];
-  winner: 0 | 1 | null;
-  msg: string;
-  aimAngle: number;
-  englishX: number;
-  englishY: number;
-  inHandPos: { x: number; y: number };
-  firstBallHit: number | null;
-}
 
 interface MouseSt {
   x: number; y: number;
   down: boolean;
 }
 
-// State machine for the AI thinking/aiming/shooting animation
 interface AIThink {
   stage: 'thinking' | 'aiming' | 'cocking';
   targetAngle: number;
@@ -160,7 +136,13 @@ function createBalls(): Ball[] {
 }
 
 // ── Physics step ──────────────────────────────────────────────────────────────
-function stepBalls(balls: Ball[], firstHit: { value: number | null }): number[] {
+function stepBalls(
+  balls: Ball[],
+  firstHit: { value: number | null },
+  myMult: number,
+  oppMult: number,
+  playerGroup: Group | null,
+): number[] {
   const pocketed: number[] = [];
 
   for (const b of balls) {
@@ -221,7 +203,16 @@ function stepBalls(balls: Ball[], firstHit: { value: number | null }): number[] 
     let sunk = false;
     for (const p of POCKETS) {
       const dx = b.x - p.x, dy = b.y - p.y;
-      if (dx * dx + dy * dy < (PR + BR * 0.4) * (PR + BR * 0.4)) {
+      // Per-ball hitbox multiplier: aids player's own balls, neutral/tighter for opponent's
+      let catchMult = 1.0;
+      if (b.num !== 0 && b.num !== 8) {
+        const isMine = playerGroup === 'solids' ? (b.num >= 1 && b.num <= 7)
+                     : playerGroup === 'stripes' ? (b.num >= 9 && b.num <= 15)
+                     : false;
+        catchMult = isMine ? myMult : oppMult;
+      }
+      const catchR = (PR + BR * 0.4) * catchMult;
+      if (dx * dx + dy * dy < catchR * catchR) {
         b.pocketed = true; b.vx = 0; b.vy = 0; b.spinX = 0; b.spinY = 0;
         pocketed.push(b.num); sunk = true; break;
       }
@@ -253,104 +244,9 @@ function anyMoving(balls: Ball[]): boolean {
   return balls.some(b => !b.pocketed && (Math.abs(b.vx) > MIN_SPEED || Math.abs(b.vy) > MIN_SPEED));
 }
 
-// ── Game logic ────────────────────────────────────────────────────────────────
-function groupBalls(balls: Ball[], group: Group | null): Ball[] {
-  if (!group) return balls.filter(b => b.num !== 0 && b.num !== 8);
-  if (group === 'solids') return balls.filter(b => b.num >= 1 && b.num <= 7);
-  return balls.filter(b => b.num >= 9 && b.num <= 15);
-}
-
-function processTurnEnd(gs: GState): GState {
-  const { turn, players, balls, pocketedThisTurn, firstBallHit, isBreak } = gs;
-  const newPlayers: [Player, Player] = [{ ...players[0] }, { ...players[1] }];
-  let nextTurn: 0 | 1 = turn;
-  let foul = false;
-  let msg = '';
-
-  const scratch      = pocketedThisTurn.includes(0);
-  const eight        = pocketedThisTurn.includes(8);
-  const currentGroup = players[turn].group;
-  const oppTurn      = (1 - turn) as 0 | 1;
-
-  const newlySunk = pocketedThisTurn.filter(n => n !== 0 && n !== 8);
-  const sunkBalls = [...gs.sunkBalls, ...newlySunk];
-
-  if (!isBreak && !scratch && firstBallHit !== null) {
-    const hitSolid  = firstBallHit >= 1 && firstBallHit <= 7;
-    const hitStripe = firstBallHit >= 9 && firstBallHit <= 15;
-    if (currentGroup === 'solids'  && !hitSolid)  foul = true;
-    if (currentGroup === 'stripes' && !hitStripe) foul = true;
-  }
-  if (firstBallHit === null && !isBreak) foul = true;
-
-  if (eight) {
-    const activeMine = groupBalls(balls.filter(b => !b.pocketed), currentGroup);
-    if (foul || scratch || activeMine.length > 0) {
-      return { ...gs, sunkBalls, players: newPlayers, winner: oppTurn, phase: 'over',
-        msg: `${newPlayers[oppTurn].name} wins — ${newPlayers[turn].name} sank the 8-ball illegally!` };
-    }
-    return { ...gs, sunkBalls, players: newPlayers, winner: turn, phase: 'over',
-      msg: `${newPlayers[turn].name} wins! 🎱` };
-  }
-
-  if (newPlayers[0].group === null && !isBreak) {
-    const solidsIn  = pocketedThisTurn.some(n => n >= 1 && n <= 7);
-    const stripesIn = pocketedThisTurn.some(n => n >= 9 && n <= 15);
-    if (solidsIn && !stripesIn) {
-      newPlayers[turn].group = 'solids';
-      newPlayers[oppTurn].group = 'stripes';
-      msg = `${newPlayers[turn].name}: solids · ${newPlayers[oppTurn].name}: stripes`;
-    } else if (stripesIn && !solidsIn) {
-      newPlayers[turn].group = 'stripes';
-      newPlayers[oppTurn].group = 'solids';
-      msg = `${newPlayers[turn].name}: stripes · ${newPlayers[oppTurn].name}: solids`;
-    }
-  }
-
-  if (scratch) {
-    nextTurn = oppTurn;
-    const cb = balls.find(b => b.num === 0);
-    if (cb) { cb.pocketed = false; cb.x = CUE_HOME.x; cb.y = CUE_HOME.y; cb.vx = 0; cb.vy = 0; }
-    return {
-      ...gs, sunkBalls, players: newPlayers, turn: nextTurn, isBreak: false,
-      phase: 'inhand', inHandPos: { ...CUE_HOME },
-      pocketedThisTurn: [], firstBallHit: null, foul: false,
-      msg: `Scratch! ${newPlayers[nextTurn].name} has ball in hand.`,
-    };
-  }
-
-  const myGroup      = newPlayers[turn].group;
-  const pocketedOwn  = pocketedThisTurn.some(n => {
-    if (n === 0 || n === 8) return false;
-    if (!myGroup) return true;
-    return myGroup === 'solids' ? n >= 1 && n <= 7 : n >= 9 && n <= 15;
-  });
-  const pocketedOpp  = pocketedThisTurn.some(n => {
-    if (n === 0 || n === 8 || !myGroup) return false;
-    return myGroup === 'solids' ? n >= 9 && n <= 15 : n >= 1 && n <= 7;
-  });
-
-  if (foul || pocketedOpp) {
-    nextTurn = oppTurn;
-    if (!msg) msg = `Foul! ${newPlayers[nextTurn].name}'s turn.`;
-  } else if (!pocketedOwn) {
-    nextTurn = oppTurn;
-  }
-  if (!msg) {
-    msg = nextTurn === turn
-      ? `Nice! ${newPlayers[turn].name} shoots again.`
-      : `${newPlayers[nextTurn].name}'s turn.`;
-  }
-
-  return {
-    ...gs, sunkBalls, players: newPlayers, turn: nextTurn, isBreak: false,
-    phase: 'aiming', pocketedThisTurn: [], firstBallHit: null, foul: false, msg,
-  };
-}
-
 // ── AI ────────────────────────────────────────────────────────────────────────
 function getAIShot(
-  balls: Ball[], turn: 0 | 1, players: [Player, Player], difficulty: AIDiff,
+  balls: Ball[], turn: 0 | 1, players: [{ name: string; group: Group | null; isAI: boolean; color: string }, { name: string; group: Group | null; isAI: boolean; color: string }], difficulty: AIDiff,
 ): { angle: number; power: number; englishX: number; englishY: number } {
   const cue = balls.find(b => b.num === 0 && !b.pocketed);
   if (!cue) return { angle: 0, power: 0.5, englishX: 0, englishY: 0 };
@@ -441,7 +337,6 @@ function ghostBallDist(balls: Ball[], cue: Ball, angle: number): number {
   return minD === Infinity ? 0 : minD;
 }
 
-// General ball drawing at arbitrary position/radius with rolling rotation
 function drawBallScaled(
   ctx: CanvasRenderingContext2D,
   x: number, y: number, r: number,
@@ -478,7 +373,6 @@ function drawBallScaled(
   ctx.strokeStyle = 'rgba(0,0,0,0.45)'; ctx.lineWidth = r * 0.07;
   ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.stroke();
 
-  // Rotating shine dot (gives rolling feel)
   const sx = x + Math.cos(rotAngle) * r * 0.5;
   const sy = y + Math.sin(rotAngle) * r * 0.5;
   const sg = ctx.createRadialGradient(sx, sy, 0, sx, sy, r * 0.25);
@@ -487,7 +381,6 @@ function drawBallScaled(
   ctx.fillStyle = sg;
   ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
 
-  // Number (stays upright)
   ctx.fillStyle = '#fff';
   ctx.beginPath(); ctx.arc(x, y, r * 0.40, 0, Math.PI * 2); ctx.fill();
   ctx.fillStyle = '#111';
@@ -500,7 +393,6 @@ function drawBall(ctx: CanvasRenderingContext2D, b: Ball): void {
   drawBallScaled(ctx, b.x, b.y, BR, b.num, b.rotAngle);
 }
 
-// ── Mini ball icon for sunk-balls tray ────────────────────────────────────────
 function BallIcon({ num, size }: { num: number; size: number }) {
   const ref = useRef<HTMLCanvasElement>(null);
   useEffect(() => {
@@ -587,10 +479,16 @@ function renderFrame(ctx: CanvasRenderingContext2D, gs: GState, shotPower: numbe
   }
 
   if (gs.phase === 'inhand') {
-    ctx.fillStyle = 'rgba(255,255,255,0.15)';
-    ctx.beginPath(); ctx.arc(gs.inHandPos.x, gs.inHandPos.y, BR, 0, Math.PI * 2); ctx.fill();
-    ctx.strokeStyle = 'rgba(255,255,255,0.65)'; ctx.lineWidth = 1.5;
-    ctx.beginPath(); ctx.arc(gs.inHandPos.x, gs.inHandPos.y, BR, 0, Math.PI * 2); ctx.stroke();
+    // Ghost ball follows cursor; cue ball stays pocketed until player confirms placement
+    const pos = gs.inHandPos;
+    const blocked = gs.balls.some(
+      b => !b.pocketed && b.num !== 0 && Math.hypot(b.x - pos.x, b.y - pos.y) < BR * 2 + 2,
+    );
+    ctx.fillStyle = blocked ? 'rgba(255,80,80,0.25)' : 'rgba(255,255,255,0.15)';
+    ctx.beginPath(); ctx.arc(pos.x, pos.y, BR, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = blocked ? 'rgba(255,80,80,0.8)' : 'rgba(255,255,255,0.65)';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath(); ctx.arc(pos.x, pos.y, BR, 0, Math.PI * 2); ctx.stroke();
   }
 
   for (const b of gs.balls) {
@@ -630,30 +528,31 @@ export default function Pool({ onQuit }: PoolProps) {
   const diffRef      = useRef<AIDiff>('normal');
   const aimLerpRef   = useRef(0);
   const invertAimRef = useRef(false);
+  const strictnessRef = useRef<Strictness>('strict');
 
-  // English (spin indicator) — imperative DOM updates for smooth RAF-driven lerp
   const engBallRef   = useRef<HTMLDivElement>(null);
   const engDotRef    = useRef<HTMLDivElement>(null);
   const engDownRef   = useRef(false);
   const engTargetRef = useRef({ x: 0, y: 0 });
   const engLerpRef   = useRef(0);
 
-  // Cue shooting drag
   const cuePowerRef    = useRef(0);
   const cueDraggingRef = useRef(false);
   const cueDragStartY  = useRef(0);
   const cueDragAreaH   = useRef(90);
 
   // ── React state ────────────────────────────────────────────────────────────
-  const [gamePhase, setGamePhase] = useState<'setup' | 'playing'>('setup');
-  const [mode,      setMode]      = useState<Mode>('hvh');
-  const [diff,      setDiff]      = useState<AIDiff>('normal');
-  const [p0name,    setP0name]    = useState('Player 1');
-  const [p1name,    setP1name]    = useState('Player 2');
-  const [p0color,   setP0color]   = useState(STICK_COLORS[0]);
-  const [p1color,   setP1color]   = useState(STICK_COLORS[1]);
-  const [invertAim, setInvertAim] = useState(false);
-  const [cuePower,  setCuePower]  = useState(0);
+  const [gamePhase,    setGamePhase]    = useState<'setup' | 'playing'>('setup');
+  const [mode,         setMode]         = useState<Mode>('hvh');
+  const [diff,         setDiff]         = useState<AIDiff>('normal');
+  const [p0name,       setP0name]       = useState('Player 1');
+  const [p1name,       setP1name]       = useState('Player 2');
+  const [p0color,      setP0color]      = useState(STICK_COLORS[0]);
+  const [p1color,      setP1color]      = useState(STICK_COLORS[1]);
+  const [invertAim,    setInvertAim]    = useState(false);
+  const [cuePower,     setCuePower]     = useState(0);
+  const [strictness,   setStrictness]   = useState<Strictness>('strict');
+  const [showSettings, setShowSettings] = useState(false);
 
   const [uiPhase,     setUiPhase]     = useState<Phase>('aiming');
   const [uiTurn,      setUiTurn]      = useState<0 | 1>(0);
@@ -666,6 +565,7 @@ export default function Pool({ onQuit }: PoolProps) {
 
   useEffect(() => { diffRef.current = diff; }, [diff]);
   useEffect(() => { invertAimRef.current = invertAim; }, [invertAim]);
+  useEffect(() => { strictnessRef.current = strictness; }, [strictness]);
 
   const syncUi = useCallback((gs: GState) => {
     setUiPhase(gs.phase);
@@ -705,7 +605,6 @@ export default function Pool({ onQuit }: PoolProps) {
     syncUi(gsRef.current);
   }, [syncUi, resetEngDot]);
 
-  // fireAI: sets up the AIThink animation state machine (no more direct setTimeout fire)
   const fireAI = useCallback(() => {
     if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
     aiTimerRef.current = setTimeout(() => {
@@ -715,7 +614,6 @@ export default function Pool({ onQuit }: PoolProps) {
       const cue  = cur.balls.find(b => b.num === 0 && !b.pocketed);
       if (!cue) return;
 
-      // Pick 2 nearby balls to "look at" before aiming
       const fakeAngles = cur.balls
         .filter(b => !b.pocketed && b.num !== 0)
         .sort(() => Math.random() - 0.5)
@@ -734,18 +632,83 @@ export default function Pool({ onQuit }: PoolProps) {
     }, 300);
   }, []);
 
+  // After a scratch, auto-place the cue ball for an AI player
+  const placeForAI = useCallback(() => {
+    if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+    aiTimerRef.current = setTimeout(() => {
+      const gs = gsRef.current;
+      if (!gs || gs.phase !== 'inhand' || !gs.players[gs.turn].isAI) return;
+
+      const tryPos = (x: number, y: number) => {
+        const cx = Math.max(PF_X1 + BR, Math.min(PF_X2 - BR, x));
+        const cy = Math.max(PF_Y1 + BR, Math.min(PF_Y2 - BR, y));
+        const ok = !gs.balls.some(
+          b => !b.pocketed && b.num !== 0 && Math.hypot(b.x - cx, b.y - cy) < BR * 2 + 2,
+        );
+        return ok ? { x: cx, y: cy } : null;
+      };
+
+      const candidates = [
+        CUE_HOME,
+        { x: CUE_HOME.x, y: CUE_HOME.y - 50 },
+        { x: CUE_HOME.x, y: CUE_HOME.y + 50 },
+        { x: CUE_HOME.x - 50, y: CUE_HOME.y },
+        { x: CUE_HOME.x + 50, y: CUE_HOME.y },
+        { x: PF_X1 + BR + 10, y: PF_Y1 + PF_H * 0.5 },
+      ];
+
+      let placed: { x: number; y: number } | null = null;
+      for (const c of candidates) {
+        placed = tryPos(c.x, c.y);
+        if (placed) break;
+      }
+      // Fallback: force CUE_HOME even if overlapping
+      if (!placed) placed = { x: CUE_HOME.x, y: CUE_HOME.y };
+
+      const cb = gs.balls.find(b => b.num === 0);
+      if (cb) {
+        cb.pocketed = false;
+        cb.x = placed.x; cb.y = placed.y;
+        cb.vx = 0; cb.vy = 0;
+      }
+      const next: GState = { ...gs, phase: 'aiming' };
+      gsRef.current = next;
+      syncUi(next);
+      fireAI();
+    }, 900);
+  }, [syncUi, fireAI]);
+
+  // Confirm ball-in-hand placement (called by the human player's "Set Ball" button)
+  const setBall = useCallback(() => {
+    const gs = gsRef.current;
+    if (!gs || gs.phase !== 'inhand') return;
+    const pos = gs.inHandPos;
+    const ok = !gs.balls.some(
+      b => !b.pocketed && b.num !== 0 && Math.hypot(b.x - pos.x, b.y - pos.y) < BR * 2 + 2,
+    );
+    if (!ok) return;
+    const cb = gs.balls.find(b => b.num === 0);
+    if (cb) {
+      cb.pocketed = false;
+      cb.x = pos.x; cb.y = pos.y;
+      cb.vx = 0; cb.vy = 0;
+    }
+    gsRef.current = { ...gs, phase: 'aiming' };
+    syncUi(gsRef.current);
+  }, [syncUi]);
+
   const startGame = useCallback((m: Mode, n0: string, n1: string, c0: string, c1: string) => {
     if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
     aiThinkRef.current = null;
-    const players: [Player, Player] = [
-      { name: n0, group: null, isAI: false, color: c0 },
-      { name: n1, group: null, isAI: m === 'hvai', color: c1 },
+    const players: [{ name: string; group: Group | null; isAI: boolean; color: string }, { name: string; group: Group | null; isAI: boolean; color: string }] = [
+      { name: n0, group: null, isAI: m === 'aiai', color: c0 },
+      { name: n1, group: null, isAI: m !== 'hvh',  color: c1 },
     ];
     const gs: GState = {
       balls: createBalls(), phase: 'aiming', turn: 0, players,
       isBreak: true, pocketedThisTurn: [], sunkBalls: [], winner: null,
       msg: `${n0}'s break!`, aimAngle: 0,
-      englishX: 0, englishY: 0, inHandPos: { ...CUE_HOME }, firstBallHit: null,
+      englishX: 0, englishY: 0, inHandPos: { ...DEFAULT_INHAND_POS }, firstBallHit: null,
       foul: false,
     };
     gsRef.current = gs;
@@ -759,7 +722,15 @@ export default function Pool({ onQuit }: PoolProps) {
     syncUi(gs);
   }, [syncUi, resetEngDot]);
 
-  // ── Win95 menus via the standard OS window menu bar ───────────────────────
+  // Trigger AI for player 0 when game starts in aiai mode
+  useEffect(() => {
+    if (gamePhase === 'playing') {
+      const gs = gsRef.current;
+      if (gs && gs.players[gs.turn].isAI) fireAI();
+    }
+  }, [gamePhase, fireAI]);
+
+  // ── Win95 menus ───────────────────────────────────────────────────────────
   const menus = useMemo<MenuBarMenu[]>(() => [
     {
       label: 'Game',
@@ -772,6 +743,8 @@ export default function Pool({ onQuit }: PoolProps) {
       label: 'Options',
       items: [
         { label: 'Invert Aim', checked: invertAim, onClick: () => setInvertAim(v => !v) },
+        { separator: true as const },
+        { label: 'Settings...', onClick: () => setShowSettings(true) },
       ],
     },
   ], [invertAim, onQuit]);
@@ -789,13 +762,12 @@ export default function Pool({ onQuit }: PoolProps) {
       const gs = gsRef.current;
       if (gs) {
 
-        // ── AI animation (driven by RAF, not setTimeout) ──────────────────
+        // ── AI animation ──────────────────────────────────────────────────
         if (gs.players[gs.turn].isAI && gs.phase === 'aiming' && aiThinkRef.current) {
           const ai = aiThinkRef.current;
           const elapsed = performance.now() - ai.stageStartTime;
 
           if (ai.stage === 'thinking') {
-            // Lerp toward a fake angle to simulate "looking at" other balls
             const targetA = ai.fakeAngles[ai.fakeIdx] ?? ai.targetAngle;
             let d = targetA - gs.aimAngle;
             while (d > Math.PI)  d -= Math.PI * 2;
@@ -812,7 +784,6 @@ export default function Pool({ onQuit }: PoolProps) {
               }
             }
           } else if (ai.stage === 'aiming') {
-            // Settle on the actual shot angle
             let d = ai.targetAngle - gs.aimAngle;
             while (d > Math.PI)  d -= Math.PI * 2;
             while (d < -Math.PI) d += Math.PI * 2;
@@ -823,7 +794,6 @@ export default function Pool({ onQuit }: PoolProps) {
               ai.stageDuration = 500;
             }
           } else {
-            // Cocking: animate cue pullback, then fire
             const t = Math.min(1, elapsed / ai.stageDuration);
             cuePowerRef.current = t * ai.targetPower;
             setCuePower(cuePowerRef.current);
@@ -867,9 +837,9 @@ export default function Pool({ onQuit }: PoolProps) {
         // ── English lerp ──────────────────────────────────────────────────
         if (gs.phase === 'aiming' && engDownRef.current && !gs.players[gs.turn].isAI) {
           engLerpRef.current = rampedLerp(engLerpRef.current, ENG_LERP_RAMP, ENG_LERP_MAX);
-          const t = engTargetRef.current;
-          gs.englishX += (t.x - gs.englishX) * engLerpRef.current;
-          gs.englishY += (t.y - gs.englishY) * engLerpRef.current;
+          const et = engTargetRef.current;
+          gs.englishX += (et.x - gs.englishX) * engLerpRef.current;
+          gs.englishY += (et.y - gs.englishY) * engLerpRef.current;
           const mag = Math.hypot(gs.englishX, gs.englishY);
           if (mag > 1) { gs.englishX /= mag; gs.englishY /= mag; }
           if (engDotRef.current) {
@@ -880,10 +850,10 @@ export default function Pool({ onQuit }: PoolProps) {
 
         // ── Physics ───────────────────────────────────────────────────────
         if (gs.phase === 'moving') {
-          const sunk = stepBalls(gs.balls, firstHitRef.current);
+          const sm = STRICTNESS_MULT[strictnessRef.current];
+          const sunk = stepBalls(gs.balls, firstHitRef.current, sm.my, sm.opp, gs.players[gs.turn].group);
           if (sunk.length) {
             gs.pocketedThisTurn = [...gs.pocketedThisTurn, ...sunk];
-            // Update sunk-ball display immediately (don't wait for turn end)
             const regular = sunk.filter(n => n !== 0 && n !== 8);
             if (regular.length > 0) setUiSunkBalls(prev => [...prev, ...regular]);
           }
@@ -893,10 +863,11 @@ export default function Pool({ onQuit }: PoolProps) {
             gsRef.current = next;
             syncUi(next);
             if (next.phase === 'aiming' && next.players[next.turn].isAI) fireAI();
+            else if (next.phase === 'inhand' && next.players[next.turn].isAI) placeForAI();
           }
         }
 
-        // ── Rolling rotation (visual only) ────────────────────────────────
+        // ── Rolling rotation ──────────────────────────────────────────────
         for (const b of gs.balls) {
           if (!b.pocketed) {
             const speed = Math.hypot(b.vx, b.vy);
@@ -915,7 +886,7 @@ export default function Pool({ onQuit }: PoolProps) {
       cancelAnimationFrame(rafRef.current);
       if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
     };
-  }, [gamePhase, syncUi, fireAI, resetEngDot]);
+  }, [gamePhase, syncUi, fireAI, placeForAI, resetEngDot]);
 
   // ── Canvas pointer events ─────────────────────────────────────────────────
   const clientToCanvas = useCallback((clientX: number, clientY: number) => {
@@ -930,7 +901,7 @@ export default function Pool({ onQuit }: PoolProps) {
     mouseRef.current.down = true; mouseRef.current.x = x; mouseRef.current.y = y;
     aimLerpRef.current = 0;
     const gs = gsRef.current;
-    if (gs?.phase === 'inhand') {
+    if (gs?.phase === 'inhand' && !gs.players[gs.turn].isAI) {
       gs.inHandPos = {
         x: Math.max(PF_X1 + BR, Math.min(PF_X2 - BR, x)),
         y: Math.max(PF_Y1 + BR, Math.min(PF_Y2 - BR, y)),
@@ -941,7 +912,7 @@ export default function Pool({ onQuit }: PoolProps) {
   const handleCanvasMove = useCallback((x: number, y: number) => {
     mouseRef.current.x = x; mouseRef.current.y = y;
     const gs = gsRef.current;
-    if (gs?.phase === 'inhand') {
+    if (gs?.phase === 'inhand' && !gs.players[gs.turn].isAI) {
       gs.inHandPos = {
         x: Math.max(PF_X1 + BR, Math.min(PF_X2 - BR, x)),
         y: Math.max(PF_Y1 + BR, Math.min(PF_Y2 - BR, y)),
@@ -951,19 +922,8 @@ export default function Pool({ onQuit }: PoolProps) {
 
   const handleCanvasUp = useCallback(() => {
     mouseRef.current.down = false;
-    const gs = gsRef.current;
-    if (!gs || gs.phase !== 'inhand') return;
-    const pos = gs.inHandPos;
-    const ok = !gs.balls.some(
-      b => !b.pocketed && b.num !== 0 && Math.hypot(b.x - pos.x, b.y - pos.y) < BR * 2 + 2,
-    );
-    if (ok) {
-      const cb = gs.balls.find(b => b.num === 0);
-      if (cb) { cb.pocketed = false; cb.x = pos.x; cb.y = pos.y; cb.vx = 0; cb.vy = 0; }
-      gsRef.current = { ...gs, phase: 'aiming' };
-      syncUi(gsRef.current);
-    }
-  }, [syncUi]);
+    // Ball placement is now confirmed via the "Set Ball" button, not on pointer-up
+  }, []);
 
   const onMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const { x, y } = canvasXY(e); handleCanvasDown(x, y);
@@ -1006,7 +966,7 @@ export default function Pool({ onQuit }: PoolProps) {
 
   const onEngPointerUp = useCallback(() => { engDownRef.current = false; }, []);
 
-  // ── Side cue drag (shooting) ──────────────────────────────────────────────
+  // ── Side cue drag ─────────────────────────────────────────────────────────
   const onCuePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const gs = gsRef.current;
     if (!gs || gs.phase !== 'aiming' || gs.players[gs.turn].isAI) return;
@@ -1039,26 +999,43 @@ export default function Pool({ onQuit }: PoolProps) {
   const p0Circles = getCircleNums(uiGroups[0]);
   const p1Circles = getCircleNums(uiGroups[1]);
 
+  // Check if current inhand position is valid (for "Set Ball" button)
+  const inHandValid = (() => {
+    const gs = gsRef.current;
+    if (!gs || gs.phase !== 'inhand') return false;
+    const pos = gs.inHandPos;
+    return !gs.balls.some(
+      b => !b.pocketed && b.num !== 0 && Math.hypot(b.x - pos.x, b.y - pos.y) < BR * 2 + 2,
+    );
+  })();
+
   // ── Setup screen ──────────────────────────────────────────────────────────
   if (gamePhase === 'setup') {
+    const isAI0 = mode === 'aiai';
+    const isAI1 = mode === 'hvai' || mode === 'aiai';
     return (
       <div className="pool-setup">
         <div className="pool-setup__title">8-BALL POOL</div>
         <div className="pool-setup__row">
           <button className={`pool-btn${mode === 'hvh'  ? ' pool-btn--on' : ''}`} onClick={() => setMode('hvh')}>2 Players</button>
-          <button className={`pool-btn${mode === 'hvai' ? ' pool-btn--on' : ''}`} onClick={() => setMode('hvai')}>vs Computer</button>
+          <button className={`pool-btn${mode === 'hvai' ? ' pool-btn--on' : ''}`} onClick={() => setMode('hvai')}>vs CPU</button>
+          <button className={`pool-btn${mode === 'aiai' ? ' pool-btn--on' : ''}`} onClick={() => setMode('aiai')}>CPU vs CPU</button>
         </div>
         <div className="pool-setup__fields">
-          <label className="pool-setup__label">Player 1 name</label>
+          <label className="pool-setup__label">{isAI0 ? 'CPU 1 name' : 'Player 1 name'}</label>
           <input className="pool-setup__inp" value={p0name} maxLength={16} onChange={e => setP0name(e.target.value)} />
-          <div className="pool-setup__swatches">
-            {STICK_COLORS.map(c => (
-              <button key={c} className={`pool-swatch${p0color === c ? ' pool-swatch--on' : ''}`}
-                style={{ background: c }} onClick={() => setP0color(c)} />
-            ))}
-          </div>
+          {!isAI0 && (
+            <div className="pool-setup__swatches">
+              {STICK_COLORS.map(c => (
+                <button key={c} className={`pool-swatch${p0color === c ? ' pool-swatch--on' : ''}`}
+                  style={{ background: c }} onClick={() => setP0color(c)} />
+              ))}
+            </div>
+          )}
 
-          <label className="pool-setup__label">{mode === 'hvh' ? 'Player 2 name' : 'Difficulty'}</label>
+          <label className="pool-setup__label">
+            {isAI1 && !isAI0 ? 'Difficulty' : isAI0 ? 'CPU 2 name / Difficulty' : 'Player 2 name'}
+          </label>
           {mode === 'hvh'
             ? <>
                 <input className="pool-setup__inp" value={p1name} maxLength={16} onChange={e => setP1name(e.target.value)} />
@@ -1069,19 +1046,28 @@ export default function Pool({ onQuit }: PoolProps) {
                   ))}
                 </div>
               </>
-            : <div className="pool-setup__row">
-                {(['easy', 'normal', 'hard'] as AIDiff[]).map(d => (
-                  <button key={d} className={`pool-btn${diff === d ? ' pool-btn--on' : ''}`} onClick={() => setDiff(d)}>
-                    {d.charAt(0).toUpperCase() + d.slice(1)}
-                  </button>
-                ))}
-              </div>
+            : <>
+                {mode === 'aiai' && (
+                  <input className="pool-setup__inp" value={p1name} maxLength={16} onChange={e => setP1name(e.target.value)} />
+                )}
+                <div className="pool-setup__row">
+                  {(['easy', 'normal', 'hard'] as AIDiff[]).map(d => (
+                    <button key={d} className={`pool-btn${diff === d ? ' pool-btn--on' : ''}`} onClick={() => setDiff(d)}>
+                      {d.charAt(0).toUpperCase() + d.slice(1)}
+                    </button>
+                  ))}
+                </div>
+              </>
           }
         </div>
         <div className="pool-setup__actions">
           <button
             className="pool-btn pool-btn--primary"
-            onClick={() => startGame(mode, p0name || 'Player 1', mode === 'hvh' ? (p1name || 'Player 2') : `CPU (${diff})`, p0color, p1color)}
+            onClick={() => {
+              const n0 = p0name || (isAI0 ? 'CPU 1' : 'Player 1');
+              const n1 = p1name || (isAI1 ? `CPU (${diff})` : 'Player 2');
+              startGame(mode, n0, n1, p0color, p1color);
+            }}
           >
             BREAK!
           </button>
@@ -1095,13 +1081,46 @@ export default function Pool({ onQuit }: PoolProps) {
     uiTurn === idx && uiPhase !== 'moving' && uiPhase !== 'over';
 
   const hintText = uiPhase === 'inhand'
-    ? 'Drag cue ball · release to place'
+    ? (isHumanTurn ? 'Move cue ball · click Set Ball' : 'CPU placing ball...')
     : uiPhase === 'aiming' && isHumanTurn
     ? 'Tap/hold to aim · drag cue down to shoot'
     : uiMsg;
 
+  const strictnessLabel: Record<Strictness, string> = {
+    strict: 'Strict', loose: 'Loose', generous: 'Generous',
+  };
+
   return (
     <div className="pool-game">
+
+      {/* ── Settings modal ── */}
+      {showSettings && (
+        <div className="pool-modal-backdrop" onClick={() => setShowSettings(false)}>
+          <div className="pool-modal" onClick={e => e.stopPropagation()}>
+            <div className="pool-modal__title">SETTINGS</div>
+            <div className="pool-modal__section">
+              <div className="pool-modal__label">Pocket Size</div>
+              <div className="pool-modal__options">
+                {(['strict', 'loose', 'generous'] as Strictness[]).map(s => (
+                  <button
+                    key={s}
+                    className={`pool-btn${strictness === s ? ' pool-btn--on' : ''}`}
+                    onClick={() => setStrictness(s)}
+                  >
+                    {strictnessLabel[s]}
+                  </button>
+                ))}
+              </div>
+              <div className="pool-modal__desc">
+                {strictness === 'strict'   && 'Standard hitboxes for all balls.'}
+                {strictness === 'loose'    && 'Slightly larger pockets for your balls.'}
+                {strictness === 'generous' && 'Bigger pockets for your balls, tighter for opponent\'s.'}
+              </div>
+            </div>
+            <button className="pool-btn pool-btn--primary" onClick={() => setShowSettings(false)}>OK</button>
+          </div>
+        </div>
+      )}
 
       {/* ── Canvas ── */}
       <div className="pool-canvas-wrap">
@@ -1113,6 +1132,20 @@ export default function Pool({ onQuit }: PoolProps) {
           onTouchStart={onTouchStart} onTouchMove={onTouchMove}
           onTouchEnd={handleCanvasUp}
         />
+
+        {/* Ball-in-hand confirm button */}
+        {uiPhase === 'inhand' && isHumanTurn && (
+          <div className="pool-inhand-bar">
+            <button
+              className={`pool-btn pool-btn--primary${!inHandValid ? ' pool-btn--disabled' : ''}`}
+              onClick={setBall}
+              disabled={!inHandValid}
+            >
+              Set Ball
+            </button>
+          </div>
+        )}
+
         {uiPhase === 'over' && (
           <div className="pool-over">
             <div className="pool-over__box">

--- a/src/experiences/Pool/poolLogic.test.ts
+++ b/src/experiences/Pool/poolLogic.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { processTurnEnd, groupBalls } from './poolLogic';
+import type { GState, Ball, Player } from './poolLogic';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBall(num: number, pocketed = false): Ball {
+  return { num, x: 0, y: 0, vx: 0, vy: 0, spinX: 0, spinY: 0, pocketed, rotAngle: 0 };
+}
+
+function makeState(overrides: Partial<GState> = {}): GState {
+  const p0: Player = { name: 'Alice', group: 'solids', isAI: false, color: '#fff' };
+  const p1: Player = { name: 'Bob',   group: 'stripes', isAI: false, color: '#fff' };
+  return {
+    balls: [makeBall(0), ...Array.from({ length: 15 }, (_, i) => makeBall(i + 1))],
+    phase: 'aiming',
+    turn: 0,
+    players: [p0, p1],
+    foul: false,
+    isBreak: false,
+    pocketedThisTurn: [],
+    sunkBalls: [],
+    winner: null,
+    msg: '',
+    aimAngle: 0,
+    englishX: 0,
+    englishY: 0,
+    inHandPos: { x: 210, y: 210 },
+    firstBallHit: null,
+    ...overrides,
+  };
+}
+
+/** Mark balls as pocketed and return a fresh ball list */
+function withPocketed(ballNums: number[]): Ball[] {
+  return [makeBall(0), ...Array.from({ length: 15 }, (_, i) => {
+    const n = i + 1;
+    return makeBall(n, ballNums.includes(n));
+  })];
+}
+
+// ── groupBalls ────────────────────────────────────────────────────────────────
+describe('groupBalls', () => {
+  const balls = Array.from({ length: 15 }, (_, i) => makeBall(i + 1));
+
+  it('returns solids 1–7 for solids group', () => {
+    const result = groupBalls(balls, 'solids');
+    expect(result.map(b => b.num)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('returns stripes 9–15 for stripes group', () => {
+    const result = groupBalls(balls, 'stripes');
+    expect(result.map(b => b.num)).toEqual([9, 10, 11, 12, 13, 14, 15]);
+  });
+
+  it('returns all non-cue non-8 balls when group is null', () => {
+    const all = [makeBall(0), ...balls, makeBall(8)];
+    const result = groupBalls(all, null);
+    expect(result.map(b => b.num)).toEqual([1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15]);
+  });
+});
+
+// ── 8-ball win/loss ───────────────────────────────────────────────────────────
+describe('processTurnEnd — 8-ball', () => {
+  it('player wins when they sink the 8-ball after clearing all solids', () => {
+    // Alice has pocketed all solids (1–7) in previous turns; now sinks 8-ball
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 7, 8]); // 8 pocketed this turn too
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [8],
+      firstBallHit: 8,        // hit the 8-ball first — legal because no solids remain
+      sunkBalls: [1, 2, 3, 4, 5, 6, 7],
+    });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('over');
+    expect(next.winner).toBe(0);
+    expect(next.msg).toContain('Alice wins');
+  });
+
+  it('player wins when they pocket their last solid AND the 8-ball in the same shot', () => {
+    // Last solid (7) plus 8-ball both go in; solids player hit ball 7 first
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 7, 8]);
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [7, 8],
+      firstBallHit: 7,         // hit a solid first — legal
+      sunkBalls: [1, 2, 3, 4, 5, 6],
+    });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('over');
+    expect(next.winner).toBe(0);
+  });
+
+  it('player loses when they sink the 8-ball while solids remain', () => {
+    // Solids 1–6 are pocketed; ball 7 is still on the table; player sinks 8-ball
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 8]);
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [8],
+      firstBallHit: 8,
+      sunkBalls: [1, 2, 3, 4, 5, 6],
+    });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('over');
+    expect(next.winner).toBe(1); // opponent wins
+    expect(next.msg).toContain('illegally');
+  });
+
+  it('player loses when they foul AND sink the 8-ball', () => {
+    // All solids cleared; player hits a stripe first (foul) then 8-ball goes in
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 7, 8]);
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [8],
+      firstBallHit: 9,         // hit opponent's stripe first — foul even when going for 8
+      sunkBalls: [1, 2, 3, 4, 5, 6, 7],
+    });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('over');
+    expect(next.winner).toBe(1);
+  });
+
+  it('player loses on scratch while sinking the 8-ball', () => {
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 7, 8]);
+    // Mark cue ball pocketed too
+    balls[0].pocketed = true;
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [0, 8], // scratch + 8
+      firstBallHit: 8,
+      sunkBalls: [1, 2, 3, 4, 5, 6, 7],
+    });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('over');
+    expect(next.winner).toBe(1);
+  });
+
+  // The previously-broken case: hitting 8-ball first was falsely flagged as a foul
+  it('does NOT foul when player targets 8-ball and hits it first (all group balls cleared)', () => {
+    const balls = withPocketed([1, 2, 3, 4, 5, 6, 7, 8]);
+    const gs = makeState({
+      balls,
+      pocketedThisTurn: [8],
+      firstBallHit: 8,
+      sunkBalls: [1, 2, 3, 4, 5, 6, 7],
+    });
+    const next = processTurnEnd(gs);
+    // Should be a WIN, not a loss
+    expect(next.winner).toBe(0);
+    expect(next.winner).not.toBe(1);
+  });
+});
+
+// ── Scratch / inhand ──────────────────────────────────────────────────────────
+describe('processTurnEnd — scratch', () => {
+  it('switches turn on scratch', () => {
+    const balls = withPocketed([0]); // cue ball pocketed
+    balls[0].pocketed = true;
+    const gs = makeState({ balls, turn: 0, pocketedThisTurn: [0], firstBallHit: 5 });
+    const next = processTurnEnd(gs);
+    expect(next.turn).toBe(1);
+  });
+
+  it('sets phase to inhand on scratch', () => {
+    const balls = withPocketed([0]);
+    balls[0].pocketed = true;
+    const gs = makeState({ balls, pocketedThisTurn: [0], firstBallHit: 3 });
+    const next = processTurnEnd(gs);
+    expect(next.phase).toBe('inhand');
+  });
+
+  it('leaves cue ball pocketed after scratch (placement deferred to UI)', () => {
+    const balls = withPocketed([0]);
+    balls[0].pocketed = true;
+    const gs = makeState({ balls, pocketedThisTurn: [0], firstBallHit: 3 });
+    const next = processTurnEnd(gs);
+    const cue = next.balls.find(b => b.num === 0);
+    expect(cue?.pocketed).toBe(true);
+  });
+
+  it('includes scratch message', () => {
+    const balls = withPocketed([0]);
+    balls[0].pocketed = true;
+    const gs = makeState({ balls, pocketedThisTurn: [0], firstBallHit: 3 });
+    const next = processTurnEnd(gs);
+    expect(next.msg.toLowerCase()).toContain('scratch');
+  });
+});
+
+// ── Turn logic ────────────────────────────────────────────────────────────────
+describe('processTurnEnd — turn switching', () => {
+  it('keeps the same turn when player pockets one of their own balls', () => {
+    const balls = withPocketed([1]);
+    const gs = makeState({ balls, pocketedThisTurn: [1], firstBallHit: 1, sunkBalls: [] });
+    const next = processTurnEnd(gs);
+    expect(next.turn).toBe(0);
+    expect(next.phase).toBe('aiming');
+  });
+
+  it('switches turn when player pockets nothing', () => {
+    const gs = makeState({ pocketedThisTurn: [], firstBallHit: 5 });
+    const next = processTurnEnd(gs);
+    expect(next.turn).toBe(1);
+  });
+
+  it('switches turn on foul (wrong ball hit first)', () => {
+    const gs = makeState({ pocketedThisTurn: [], firstBallHit: 9 }); // Alice is solids; hit stripe
+    const next = processTurnEnd(gs);
+    expect(next.turn).toBe(1);
+    expect(next.msg.toLowerCase()).toContain('foul');
+  });
+});

--- a/src/experiences/Pool/poolLogic.ts
+++ b/src/experiences/Pool/poolLogic.ts
@@ -1,0 +1,148 @@
+// ── Types ─────────────────────────────────────────────────────────────────────
+export interface Ball {
+  num: number;
+  x: number; y: number;
+  vx: number; vy: number;
+  spinX: number; spinY: number;
+  pocketed: boolean;
+  rotAngle: number;
+}
+
+export type Group  = 'solids' | 'stripes';
+export type Phase  = 'aiming' | 'moving' | 'inhand' | 'over';
+
+export interface Player {
+  name: string;
+  group: Group | null;
+  isAI: boolean;
+  color: string;
+}
+
+export interface GState {
+  balls: Ball[];
+  phase: Phase;
+  turn: 0 | 1;
+  players: [Player, Player];
+  foul: boolean;
+  isBreak: boolean;
+  pocketedThisTurn: number[];
+  sunkBalls: number[];
+  winner: 0 | 1 | null;
+  msg: string;
+  aimAngle: number;
+  englishX: number;
+  englishY: number;
+  inHandPos: { x: number; y: number };
+  firstBallHit: number | null;
+}
+
+// Default cue-ball placement position (matches CUE_HOME in Pool.tsx)
+export const DEFAULT_INHAND_POS = { x: 210, y: 210 };
+
+// ── Game logic ────────────────────────────────────────────────────────────────
+export function groupBalls(balls: Ball[], group: Group | null): Ball[] {
+  if (!group) return balls.filter(b => b.num !== 0 && b.num !== 8);
+  if (group === 'solids') return balls.filter(b => b.num >= 1 && b.num <= 7);
+  return balls.filter(b => b.num >= 9 && b.num <= 15);
+}
+
+export function processTurnEnd(gs: GState): GState {
+  const { turn, players, balls, pocketedThisTurn, firstBallHit, isBreak } = gs;
+  const newPlayers: [Player, Player] = [{ ...players[0] }, { ...players[1] }];
+  let nextTurn: 0 | 1 = turn;
+  let foul = false;
+  let msg = '';
+
+  const scratch      = pocketedThisTurn.includes(0);
+  const eight        = pocketedThisTurn.includes(8);
+  const currentGroup = players[turn].group;
+  const oppTurn      = (1 - turn) as 0 | 1;
+
+  const newlySunk = pocketedThisTurn.filter(n => n !== 0 && n !== 8);
+  const sunkBalls = [...gs.sunkBalls, ...newlySunk];
+
+  // Wrong-ball-first foul.
+  // When group balls remain: must hit one of your own group first.
+  // When all group balls are cleared: must hit the 8-ball first.
+  if (!isBreak && !scratch && firstBallHit !== null) {
+    const hitSolid  = firstBallHit >= 1 && firstBallHit <= 7;
+    const hitStripe = firstBallHit >= 9 && firstBallHit <= 15;
+    const hitEight  = firstBallHit === 8;
+    if (currentGroup === 'solids' && !hitSolid) {
+      const remainSolids  = balls.filter(b => !b.pocketed && b.num >= 1 && b.num <= 7).length;
+      const sunkSolidsNow = newlySunk.filter(n => n >= 1 && n <= 7).length;
+      const hadSolids     = remainSolids + sunkSolidsNow > 0;
+      if (hadSolids || !hitEight) foul = true;
+    }
+    if (currentGroup === 'stripes' && !hitStripe) {
+      const remainStripes  = balls.filter(b => !b.pocketed && b.num >= 9 && b.num <= 15).length;
+      const sunkStripesNow = newlySunk.filter(n => n >= 9 && n <= 15).length;
+      const hadStripes     = remainStripes + sunkStripesNow > 0;
+      if (hadStripes || !hitEight) foul = true;
+    }
+  }
+  if (firstBallHit === null && !isBreak) foul = true;
+
+  if (eight) {
+    const activeMine = groupBalls(balls.filter(b => !b.pocketed), currentGroup);
+    if (foul || scratch || activeMine.length > 0) {
+      return { ...gs, sunkBalls, players: newPlayers, winner: oppTurn, phase: 'over',
+        msg: `${newPlayers[oppTurn].name} wins — ${newPlayers[turn].name} sank the 8-ball illegally!` };
+    }
+    return { ...gs, sunkBalls, players: newPlayers, winner: turn, phase: 'over',
+      msg: `${newPlayers[turn].name} wins! 🎱` };
+  }
+
+  if (newPlayers[0].group === null && !isBreak) {
+    const solidsIn  = pocketedThisTurn.some(n => n >= 1 && n <= 7);
+    const stripesIn = pocketedThisTurn.some(n => n >= 9 && n <= 15);
+    if (solidsIn && !stripesIn) {
+      newPlayers[turn].group = 'solids';
+      newPlayers[oppTurn].group = 'stripes';
+      msg = `${newPlayers[turn].name}: solids · ${newPlayers[oppTurn].name}: stripes`;
+    } else if (stripesIn && !solidsIn) {
+      newPlayers[turn].group = 'stripes';
+      newPlayers[oppTurn].group = 'solids';
+      msg = `${newPlayers[turn].name}: stripes · ${newPlayers[oppTurn].name}: solids`;
+    }
+  }
+
+  if (scratch) {
+    nextTurn = oppTurn;
+    // Cue ball stays pocketed — placed via the inhand UI (or AI auto-placement)
+    return {
+      ...gs, sunkBalls, players: newPlayers, turn: nextTurn, isBreak: false,
+      phase: 'inhand', inHandPos: { ...DEFAULT_INHAND_POS },
+      pocketedThisTurn: [], firstBallHit: null, foul: false,
+      msg: `Scratch! ${newPlayers[nextTurn].name} has ball in hand.`,
+    };
+  }
+
+  const myGroup      = newPlayers[turn].group;
+  const pocketedOwn  = pocketedThisTurn.some(n => {
+    if (n === 0 || n === 8) return false;
+    if (!myGroup) return true;
+    return myGroup === 'solids' ? n >= 1 && n <= 7 : n >= 9 && n <= 15;
+  });
+  const pocketedOpp  = pocketedThisTurn.some(n => {
+    if (n === 0 || n === 8 || !myGroup) return false;
+    return myGroup === 'solids' ? n >= 9 && n <= 15 : n >= 1 && n <= 7;
+  });
+
+  if (foul || pocketedOpp) {
+    nextTurn = oppTurn;
+    if (!msg) msg = `Foul! ${newPlayers[nextTurn].name}'s turn.`;
+  } else if (!pocketedOwn) {
+    nextTurn = oppTurn;
+  }
+  if (!msg) {
+    msg = nextTurn === turn
+      ? `Nice! ${newPlayers[turn].name} shoots again.`
+      : `${newPlayers[nextTurn].name}'s turn.`;
+  }
+
+  return {
+    ...gs, sunkBalls, players: newPlayers, turn: nextTurn, isBreak: false,
+    phase: 'aiming', pocketedThisTurn: [], firstBallHit: null, foul: false, msg,
+  };
+}

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"errors":true,"version":"6.0.2"}
+{"root":["./vite.config.ts"],"version":"5.9.3"}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // src/utils/*.test.ts use Node's built-in test runner (node --test), not vitest
+    include: ['src/experiences/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
8-ball bug: Winning shot was incorrectly flagged as a foul. When a player
clears all their group balls, hitting the 8-ball first is legal — the
previous foul check didn't account for this, causing the player to lose
on a valid winning shot.

Scratch bug: Cue ball was immediately un-pocketed in processTurnEnd,
creating a confusing double-ball visual. Now the cue ball stays pocketed
during 'inhand' phase; a "Set Ball" button confirms placement. AI
opponents also auto-place after a short delay instead of hanging forever.

Strictness settings: Added Strict/Loose/Generous pocket-size options
(Options > Settings). Loose gives player's own balls a 1.1× catch radius;
Generous gives 1.15× for own balls and 0.95× for opponent's — subtly
helping the player without being obvious.

CPU vs CPU: Added 'aiai' mode so both players can be AI. Good for
watching the game play itself.

Tests: Extracted pure game logic to poolLogic.ts; added vitest with 16
unit tests covering win/loss conditions, scratch, and turn switching.

https://claude.ai/code/session_01Txb3ZNxPSibfVjr92Awfui