### PR TITLE
feat: Phase 1 — unified virtual filesystem core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,12 +199,127 @@ Key points:
 
 ## NS Doors 97 — key details
 
-NS Doors 97 is the flagship experience. It simulates a 1990s desktop:
+NS Doors 97 is the flagship experience. It simulates a 1990s desktop OS (a Noahsoft parody of Windows 95/98):
 - Draggable windows (`react-draggable`)
-- Desktop icons, taskbar with Start menu
+- Desktop icons driven by the real virtual filesystem (see below)
+- Taskbar with Start menu, clock
 - Screensaver system (activates after idle timeout)
-- Built-in apps: file browser, About Noahsoft dialog, simulated internet browser, Tic-Tac-Toe window
+- Built-in apps: file browser (My Doors), Recycle Bin, About dialog, simulated browser, Notebook, NS Art, Sound Recorder, MIDI Editor, NS-TOS terminal, all games
 - All windows use Win95-style chrome: title bar (orange/brown gradient), close/min/max buttons, beveled borders
+
+## Unified Virtual Filesystem — architecture and rules
+
+**This is the single most important system in Doors 97.** Everything that persists data goes through it. No exceptions.
+
+### Philosophy: NS Doors 97 is hackable
+
+This is intentional design. Users can open files in the fake OS and make changes that have real effects:
+- **Scores** — SCORES.DAT files are plaintext JSON in each game's folder. Open in Notebook, edit the number, save. Your score changes. This is a feature.
+- **Config/INI files** — `win.ini` and `system.ini` in `C:\System\` are (progressively) wired to real OS behavior. Agents should wire up settings rather than leaving them decorative. Example: `[Desktop] Wallpaper=...` should change the desktop wallpaper.
+- **Desktop** — users can add/remove shortcuts, files, and folders on the desktop. The system icons (My Doors, Dumpster) are protected (`system: true`) and cannot be deleted.
+- **App assets (future)** — bundled assets (HELL sprites, wallpapers, sound effects) have FS counterparts. If a user draws a new sprite in NS Art and saves it at the right FS path, the game uses their version on next load. Detection is path-based: non-empty FS file content wins over the bundled file.
+
+### Architecture
+
+| Layer | What |
+|---|---|
+| `FileSystemStore` | Singleton. Flat `Map<string, FSNode>`. Persists to localStorage via `StorageAdapter`. |
+| `StorageAdapter` | Interface: `getItem/setItem/removeItem`. `LocalStorageAdapter` is current impl. Swap for IndexedDB by changing the constructor arg — never bypass it with direct `localStorage` calls. |
+| `FSProvider` + `useFS()` | React context. `FSProvider` subscribes to `fsStore` and re-renders on any change. Use `useFS()` inside the NS Doors 97 component tree. |
+| Direct singleton access | Components outside `FSProvider` (standalone pages, game components) import `fsStore` directly and call it without reactivity. |
+| `seed.ts` | Creates the full C:\ tree on first load (batch call, ~1 save). |
+| `migrate()` | Runs after every load. Adds stable-ID nodes that may have been added after initial seeding. **When you add a new stable-ID node, add it to both `seed.ts` AND `migrate()`.** |
+
+### The mandatory rule
+
+**Every new app or experience that saves any data MUST use `fsStore`. No direct `localStorage` calls, no custom IndexedDB stores, no other mechanism.** If audio data is too large for the FS (Sound Recorder), store it in IDB but register a metadata FSFile in the FS so it appears in the file browser.
+
+### Well-known folder IDs (from `filesystem/types.ts`)
+
+```
+ROOT_ID      = "fs:root"         C:\
+DESKTOP_ID   = "fs:desktop"      drives desktop icon rendering
+DUMPSTER_ID  = "fs:dumpster"     Recycle Bin
+DOCUMENTS_ID = "fs:documents"
+PROGRAMS_ID  = "fs:programs"
+GAMES_ID     = "fs:games"
+ACC_ID       = "fs:accessories"
+SYSTEM_ID    = "fs:system"
+DOWNLOADS_ID = "fs:downloads"
+EGO_ID       = "fs:ego"          HELL game folder
+```
+
+### Stable file IDs (app-owned files that need direct access)
+
+```
+NS_ART_BACKUP_ID = "fs:nsart-backup"   NS Art auto-save
+DH_SCORES_ID     = "fs:scores-dh"      Duck & Learn SCORES.DAT
+TR_SCORES_ID     = "fs:scores-tr"      Typing Racer SCORES.DAT
+```
+
+Add new stable IDs here when an app needs to find a specific file without traversing the tree.
+
+### How to integrate a new app
+
+1. Decide what the FS node(s) look like: which folder they live in, what `fileType` they use, whether they need a stable ID.
+2. Add any stable IDs to `types.ts` and create the file in both `seed.ts` (for new installs) and `migrate()` (for existing sessions).
+3. In the component: use `fsStore.writeFile(id, content)` to save, `fsStore.getFile(id)?.content` to load. Check FS first, then any legacy storage key, then delete the legacy key (one-time migration).
+4. If the file needs to open with a specific app when double-clicked from FilesApp, set `appId` on the FSFile.
+
+### Key API
+
+```typescript
+// Queries
+fsStore.getNode(id)          // FSNode | undefined
+fsStore.getFile(id)          // FSFile | undefined
+fsStore.getChildren(folderId)  // sorted: folders first, then alpha
+fsStore.getPath(id)          // "C:\\Documents\\todo.txt"
+fsStore.getNodeByPath(path)  // resolves "C:\\..." path string to a node
+fsStore.findChild(folderId, name)  // case-insensitive name lookup
+
+// Mutations
+fsStore.createFile(parentId, name, options?)   // options: fileType, appId, content, readonly, system, id
+fsStore.createFolder(parentId, name, options?) // options: system, id
+fsStore.createShortcut(parentId, name, options?) // options: targetAppId, targetFilePath, system, id
+fsStore.ensureFile(parentId, name, options?)   // find-or-create
+fsStore.writeFile(id, content)  // update content, triggers re-render
+fsStore.deleteNode(id)          // moves to Dumpster (unless already there → permanentDelete)
+fsStore.emptyDumpster()
+fsStore.batch(fn)               // defer save/emit until after fn
+```
+
+### FSNode types
+
+```typescript
+type FSFileType = "text"|"exe"|"bat"|"sys"|"scr"|"drv"|"tmp"|"zip"|"bmp"|"png"|"ini"|"wav"|"dat"|"lnk"
+
+interface FSFile     { kind:"file",     ..., fileType, content:string, readonly, appId? }
+interface FSFolder   { kind:"folder",   ..., parentId: string|null, system }
+interface FSShortcut { kind:"shortcut", ..., targetAppId?, targetFilePath?, system }
+```
+
+- Shortcuts with `system: true` cannot be deleted by users.
+- `appId` on a file determines which app opens it when double-clicked in the file browser.
+- A `.wav` file with `appId: "sound-recorder"` opens Sound Recorder pre-loaded with that recording.
+
+### Current integrations at a glance
+
+| App | FS path | Stable ID | Notes |
+|---|---|---|---|
+| NS Art backup | `C:\Programs\Accessories\NS Art\Untitled.nsart` | `NS_ART_BACKUP_ID` | Full JSON backup content stored in FS |
+| Sound recordings | `C:\Programs\Accessories\Sound Recorder\*.wav` | — | Metadata node only; audio stays in IDB |
+| Duck & Learn scores | `C:\Programs\Games\Duck & Learn\SCORES.DAT` | `DH_SCORES_ID` | JSON array, hackable in Notebook |
+| Typing Racer score | `C:\Programs\Games\Typing Racer\SCORES.DAT` | `TR_SCORES_ID` | Single integer string |
+| Notebook files | anywhere in `C:\` | — | Full text content in FS |
+| Desktop shortcuts | `C:\Desktop\` | — | Created when Notebook/SoundRecorder saves |
+
+### Future vision (preserve these for future agents)
+
+1. **StorageAdapter swap** — Swap `LocalStorageAdapter` for an IndexedDB adapter when storage needs grow. Change the constructor; all app code stays the same.
+2. **Asset override system** — Bundled repo files (sprites in `/public/`, wallpapers) have FS counterparts seeded as stubs. When the FS file has non-empty content, the game/app uses it instead of the bundled file. Path-based detection.
+3. **Config file wiring** — `win.ini`/`system.ini` entries should progressively affect real OS behavior. Wire them up; don't leave them decorative.
+4. **NS-TOS as a real shell** — Expand terminal commands (COPY, MOVE, more piping) to operate on the real FS.
+5. **All new apps** — Any new app or feature that persists state must integrate with the FS. Do not add standalone localStorage keys.
 
 ## Before finishing any task
 

--- a/specs/filesystem.spec.md
+++ b/specs/filesystem.spec.md
@@ -1,0 +1,370 @@
+# NS Doors 97 — Virtual Filesystem Architecture
+
+## Overview
+
+The virtual filesystem (FS) is a persistent, in-memory tree of nodes (files, folders, and shortcuts) that underpins all data storage in NS Doors 97. Every app that needs to save or read data — score files, drawings, recordings, text documents — uses the FS. No app may use raw `localStorage` keys or IndexedDB directly.
+
+The FS is a singleton (`fsStore`) backed by `localStorage` through a swappable `StorageAdapter` interface. A React context layer (`FSProvider` / `useFS`) wraps the singleton so components re-render automatically whenever the tree changes.
+
+## Source files
+
+| File | Purpose |
+|---|---|
+| `src/experiences/NsDoors97/filesystem/types.ts` | Node type definitions, well-known IDs, icon map |
+| `src/experiences/NsDoors97/filesystem/StorageAdapter.ts` | Storage abstraction (`StorageAdapter` interface + `LocalStorageAdapter`) |
+| `src/experiences/NsDoors97/filesystem/FileSystemStore.ts` | Singleton class with full CRUD, persistence, migration, events |
+| `src/experiences/NsDoors97/filesystem/FSContext.tsx` | `FSProvider` component + `useFS` hook |
+| `src/experiences/NsDoors97/filesystem/seed.ts` | First-run tree seeding (called on new users or after `reset()`) |
+| `src/experiences/NsDoors97/filesystem/index.ts` | Barrel re-export of all above |
+
+## Node types
+
+All tree nodes are one of three shapes, discriminated by `kind`:
+
+```typescript
+type FSNode = FSFile | FSFolder | FSShortcut;
+
+interface FSFile {
+  id: string;
+  kind: "file";
+  name: string;
+  parentId: string;
+  createdAt: number;        // Unix ms
+  modifiedAt: number;
+  fileType: FSFileType;     // see below
+  content: string;          // UTF-8 text; binary assets store base64 or are left empty
+  mimeType: string;
+  system: boolean;          // true = protected from deletion/rename
+  readonly: boolean;        // true = Notebook shows read-only; writeFile is still allowed internally
+  appId?: string;           // ID of the app that owns/opens this file
+}
+
+interface FSFolder {
+  id: string;
+  kind: "folder";
+  name: string;
+  parentId: string | null;  // null only for the root node
+  createdAt: number;
+  modifiedAt: number;
+  system: boolean;
+}
+
+interface FSShortcut {
+  id: string;
+  kind: "shortcut";
+  name: string;
+  parentId: string;
+  createdAt: number;
+  modifiedAt: number;
+  system: boolean;
+  targetAppId?: string;     // open this app when the shortcut is activated
+  targetFilePath?: string;  // C:\-style path to resolve and open
+}
+```
+
+### File types (`FSFileType`)
+
+```
+"text" | "exe" | "bat" | "sys" | "scr" | "drv"
+"tmp"  | "zip" | "bmp" | "png" | "ini" | "wav" | "dat" | "lnk"
+```
+
+Each type has an emoji icon defined in `FILE_TYPE_ICONS` (used by `FilesApp` and desktop icon rendering). `getNodeIcon(node)` returns the appropriate emoji for any node.
+
+## Well-known IDs
+
+All stable IDs are declared as constants in `types.ts` and re-exported from the barrel.
+
+### Folder IDs
+
+| Constant | Value | Path | Notes |
+|---|---|---|---|
+| `ROOT_ID` | `"fs:root"` | `C:\` | Virtual drive root |
+| `DESKTOP_ID` | `"fs:desktop"` | `C:\Desktop` | Drives desktop icon rendering |
+| `DUMPSTER_ID` | `"fs:dumpster"` | `C:\Recycle Bin` | Recycle Bin; `system: true` |
+| `DOCUMENTS_ID` | `"fs:documents"` | `C:\Documents` | User documents |
+| `PROGRAMS_ID` | `"fs:programs"` | `C:\Programs` | App programs folder |
+| `GAMES_ID` | `"fs:games"` | `C:\Programs\Games` | Game sub-folders |
+| `ACC_ID` | `"fs:accessories"` | `C:\Programs\Accessories` | Accessory apps |
+| `SYSTEM_ID` | `"fs:system"` | `C:\System` | OS config files (readonly) |
+| `DOWNLOADS_ID` | `"fs:downloads"` | `C:\Downloads` | Easter-egg downloads |
+| `EGO_ID` | `"fs:ego"` | `C:\EGO` | HELL game folder |
+
+### Stable file IDs (app-owned)
+
+| Constant | Value | App |
+|---|---|---|
+| `NS_ART_BACKUP_ID` | `"fs:nsart-backup"` | NS Art auto-save (`Untitled.nsart` in `C:\Programs\Accessories\NS Art\`) |
+| `DH_SCORES_ID` | `"fs:scores-dh"` | Duck & Learn (`SCORES.DAT` in `C:\Programs\Games\Duck & Learn\`) |
+| `TR_SCORES_ID` | `"fs:scores-tr"` | Typing Racer (`SCORES.DAT` in `C:\Programs\Games\Typing Racer\`) |
+
+## Storage layer
+
+### `StorageAdapter` interface
+
+```typescript
+interface StorageAdapter {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+```
+
+`LocalStorageAdapter` is the production implementation. It wraps every call in a try/catch to silently survive quota errors or private-browsing restrictions.
+
+The `FileSystemStore` constructor accepts any `StorageAdapter`. Swapping to IndexedDB requires only a new adapter class — no other changes.
+
+**Never** bypass the adapter with direct `localStorage` calls inside app code. Always go through `fsStore` or the adapter.
+
+### Storage key
+
+The entire tree is serialized as `JSON.stringify([...Map.entries()])` under the key `"ns97_fs_v1"`. The Map maps node ID strings to `FSNode` objects. Deserialization reconstructs the Map with `new Map<string, FSNode>(entries)`.
+
+## `FileSystemStore` API
+
+The singleton is exported as `fsStore` from `FileSystemStore.ts`.
+
+### Queries
+
+| Method | Returns | Notes |
+|---|---|---|
+| `getNode(id)` | `FSNode \| undefined` | Any node by ID |
+| `getFolder(id)` | `FSFolder \| undefined` | Type-safe folder getter |
+| `getFile(id)` | `FSFile \| undefined` | Type-safe file getter |
+| `getShortcut(id)` | `FSShortcut \| undefined` | Type-safe shortcut getter |
+| `getChildren(folderId)` | `FSNode[]` | Sorted: folders first, then alphabetical by name |
+| `getPath(id)` | `string` | Returns `"C:\\"` for root; `"C:\\Folder\\file.txt"` otherwise |
+| `getNodeByPath(path)` | `FSNode \| undefined` | Case-insensitive path resolution from `C:\...` |
+| `findChild(folderId, name)` | `FSNode \| undefined` | Case-insensitive name search within a folder |
+
+### Mutations
+
+| Method | Notes |
+|---|---|
+| `createFile(parentId, name, options)` | `options`: `fileType`, `appId`, `content`, `mimeType`, `readonly`, `system`, `id` |
+| `createFolder(parentId, name, options)` | `options`: `system`, `id`; `parentId` may be `null` for root |
+| `createShortcut(parentId, name, options)` | `options`: `targetAppId`, `targetFilePath`, `system`, `id` |
+| `ensureFile(parentId, name, options)` | Find-or-create: returns existing file if name matches, otherwise creates |
+| `writeFile(id, content, mimeType?)` | Update file content and `modifiedAt`; triggers save + emit |
+| `renameNode(id, newName)` | No-op if `node.system === true` |
+| `moveNode(id, newParentId)` | Reparents the node (used internally by `deleteNode`) |
+| `deleteNode(id)` | Moves to Dumpster; if already in Dumpster, permanently deletes; no-op for system nodes |
+| `permanentDelete(id)` | Recursively deletes node and all descendants immediately |
+| `emptyDumpster()` | Permanently deletes all direct children of the Dumpster folder |
+
+### Batching
+
+```typescript
+fsStore.batch(() => {
+  // multiple createFile / createFolder calls
+});
+// save() + emit() fire exactly once after the function returns
+```
+
+Use during seeding and migration to avoid a save+emit on every individual node creation. Always prefer `batch()` when creating more than one node at a time.
+
+### Events
+
+```typescript
+const unsubscribe = fsStore.subscribe(() => {
+  // re-read whatever you care about
+});
+// later:
+unsubscribe();
+```
+
+The event system is a simple Set of listeners. `emit()` calls every listener synchronously after every mutation (or after a batch ends). `FSProvider` uses this to trigger a React re-render.
+
+### Dev helper
+
+`fsStore.reset()` clears the node map and re-seeds from scratch. Exposed for development; not called in production.
+
+## React integration
+
+### `FSProvider`
+
+Wrap the entire NsDoors97 component tree with `FSProvider`. It subscribes to `fsStore` and forces a re-render on every FS change, making `useFS()` always return a fresh view.
+
+```typescript
+// In NsDoors97Page.tsx
+<FSProvider>
+  <OsDialogProvider>
+    <NsDoors97 />
+  </OsDialogProvider>
+</FSProvider>
+```
+
+### `useFS()`
+
+Returns the `FileSystemStore` singleton. Any call to `store.getChildren(...)` or `store.getNode(...)` inside a component that called `useFS()` will re-run on every FS mutation. Throws if called outside an `FSProvider`.
+
+```typescript
+const store = useFS();
+const children = store.getChildren(DESKTOP_ID); // re-evaluated on every FS change
+```
+
+### Direct singleton access (outside FSProvider)
+
+Apps or utilities that run outside the React tree (standalone pages, non-FS-aware child components) may import and call `fsStore` directly. This is intentional and correct — it bypasses the reactivity layer but the data is always up to date.
+
+```typescript
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { NS_ART_BACKUP_ID } from "../NsDoors97/filesystem/types";
+
+fsStore.writeFile(NS_ART_BACKUP_ID, json); // works anywhere; no re-render in other components
+```
+
+## Migration pattern
+
+`FileSystemStore.migrate()` runs automatically after every `load()`. It checks for stable-ID nodes that may not exist in old serialized data (because they were added to the seed after the user's first visit) and creates them if absent.
+
+When adding a new stable-ID node:
+1. Add it to `seed.ts` (for new users).
+2. Add a corresponding block to `migrate()` in `FileSystemStore.ts` (for existing users).
+
+The migration block should:
+- Check `this.nodes.has(STABLE_ID)` — skip if already present.
+- Locate the parent folder by path (`this.getNodeByPath(...)`).
+- Create the node with `this.nodes.set(STABLE_ID, { ... })` (no flush, no batch — `migrate()` calls `this.save()` once at the end if `changed === true`).
+
+## Initial file tree (seed)
+
+The `seedFileSystem()` function populates the tree for first-time users. All folder and file creation happens inside a `batch()` call so only one save+emit fires.
+
+### Top-level structure
+
+```
+C:\
+  Desktop\
+    My Doors            (shortcut → app:files, system)
+    Dumpster            (shortcut → app:dumpster, system)
+    README.txt          (text file with HELL.EXE instructions)
+  Documents\
+    readme.txt          (NS Doors 97 welcome / system requirements)
+    Letter to Mom.txt
+    Todo.txt
+    Budget 1997.txt
+    Secret Diary.txt
+  Programs\
+    Games\
+      HELL\
+        HELL.EXE        (appId: "tos-only" — shows error if double-clicked)
+        README.TXT      (readonly)
+      Tic-Tac-Toe\      (Tic-Tac-Toe.exe, SCORES.DAT)
+      Word Whirlwind\   (Word Whirlwind.exe, SCORES.DAT)
+      Chain Reaction\   (Chain Reaction.exe, SCORES.DAT)
+      Number Muncher\   (Number Muncher.exe, SCORES.DAT)
+      Cards\            (Cards.exe)
+      8-Ball Pool\      (Pool.exe)
+      Duck & Learn\     (Duck & Learn.exe, SCORES.DAT [id: DH_SCORES_ID])
+      Bomb Finder\      (Bomb Finder.exe)
+      WORDS\            (WORDS.exe, SCORES.DAT)
+      Peg Solitaire\    (Peg Solitaire.exe)
+      Typing Racer\     (Typing Racer.exe, SCORES.DAT [id: TR_SCORES_ID])
+      Solitaire.exe     (stub — no appId)
+      Minesweeper.exe   (stub — no appId)
+      SkiFree.exe       (stub — no appId)
+    Accessories\
+      Notebook\         (Notebook.exe)
+      NS Art\           (NS Art.exe, Untitled.nsart [id: NS_ART_BACKUP_ID])
+      Sound Recorder\   (Sound Recorder.exe)
+      MIDI Editor\      (MIDI Editor.exe)
+    Internet\
+      Internet Explorer.exe  (appId: "internet")
+      Netscape Navigator.exe (stub)
+      WinZip.exe             (stub)
+    Screensavers\
+      Starfield.scr, Fireworks.scr, Bouncing Shapes.scr (appId: "screensavers")
+      Flying Toasters.scr (stub)
+  System\
+    config.sys, autoexec.bat, win.ini, system.ini  (readonly)
+    Drivers\  (mouse.drv, display.drv, sound.drv, comm.drv)
+    Temp\     (~tmp0001.tmp, ~tmp0002.tmp, ~tmp0087.tmp)
+  Downloads\
+    netscape_40_setup.exe, clipart_pack_vol2.zip,
+    cool_space_wallpaper.bmp, AUTORUN.INF
+  EGO\        [id: EGO_ID]
+    HELL.EXE  (appId: "tos-only")
+    README.TXT, INSTALL.BAT (readonly)
+    SPRITES\  (23 .BMP sprite files, all readonly)
+  Recycle Bin\  [id: DUMPSTER_ID, system]
+    old_draft.txt       (pre-seeded deleted letter)
+    budget_old_1996.txt
+    ns95_uninstall.exe
+```
+
+## App integrations
+
+### Notebook
+
+Reads and writes `FSFile.content` via `fsStore.writeFile(fileId, content)`. When a file is saved, fires `onFileSaved(fileId, fileName)` so `NsDoors97.tsx` can add a desktop shortcut pointing to the file's FS path.
+
+Opening from the taskbar Start menu creates a new empty `text` file in `C:\Documents\` and opens it. Opening from `FilesApp` passes the existing file's ID.
+
+### FilesApp (My Doors)
+
+Drives navigation via a folder-ID stack (`useState<string[]>`). `store.getChildren(currentFolderId)` is called reactively on every render (re-renders on FS change via `useFS()`). Address bar shows `store.getPath(currentFolderId)`.
+
+The Dumpster window (`isDumpster={true}`) reuses `FilesApp` with `startFolderId={DUMPSTER_ID}`. In Dumpster mode, clicking a non-folder item prompts for permanent deletion rather than opening it. The "Empty Dumpster" button calls `store.emptyDumpster()`.
+
+### NS Art
+
+Saves to `NS_ART_BACKUP_ID` via `fsStore.writeFile(NS_ART_BACKUP_ID, json)`. On load, reads from that file; if empty, checks the old localStorage key for legacy migration, then falls back to blank canvas.
+
+NS Art may be opened standalone (outside the FSProvider). In that case it uses the singleton directly with no reactivity.
+
+### Sound Recorder
+
+Saves WAV metadata nodes under `C:\Programs\Accessories\Sound Recorder\` using `fsStore.createFile(...)` with `fileType: "wav"` and `appId: "sound-recorder"`. Audio data is stored in IndexedDB (exception to the FS-only rule because IDB handles binary efficiently; the FS node is the metadata record and desktop shortcut anchor).
+
+After saving, fires `onFileSaved(name)` so `NsDoors97.tsx` creates a desktop shortcut pointing to the recording.
+
+Clicking a `.wav` file with `appId === "sound-recorder"` — whether from the desktop or `FilesApp` — opens Sound Recorder pre-loaded with that recording.
+
+### Duck & Learn
+
+Reads and writes `DH_SCORES_ID` with plain-text score content. The file lives in `C:\Programs\Games\Duck & Learn\SCORES.DAT`.
+
+### Typing Racer
+
+Reads and writes `TR_SCORES_ID`. The file lives in `C:\Programs\Games\Typing Racer\SCORES.DAT`. If the Typing Racer folder did not exist in an old session, `migrate()` creates it along with the `SCORES.DAT` file.
+
+### NS-TOS terminal
+
+Uses folder IDs as the current working directory (`cwd`). `CD`, `DIR`, `TYPE`, `MKDIR`, `RMDIR`, `DEL`, `REN`, and `ECHO text > file` all operate on `fsStore`. `HELL.EXE` can only be run when the cwd contains a file with `appId === "tos-only"`.
+
+## Desktop icon rendering
+
+`NsDoors97.tsx` calls `store.getChildren(DESKTOP_ID)` reactively.
+
+- Nodes where `node.system === true` render in the **left** icon column (My Doors, Dumpster). These are undeletable.
+- Nodes where `node.system === false` render in the **right** icon column (README.txt, user-saved shortcuts, files).
+
+Double-clicking (or single-tap on touch) any desktop node calls `openFSNode(nodeId)`, which dispatches based on node kind and file type.
+
+Icons animate in one-by-one after boot in randomized order, with occasional cursor-wait flashes to simulate a slow system initialising.
+
+## The "hackable" philosophy
+
+NS Doors 97 is intentionally hackable. Editing files in the fake OS should have real effects:
+
+- **Score files** — `SCORES.DAT` files are plain JSON or numeric text. Open one in Notebook, edit it, save — the game reads the changed value on next load. This is intentional.
+- **Config files** — `win.ini` and `system.ini` exist in `C:\System\`. Settings in them should progressively become wired to real OS behavior (desktop color, screensaver, etc.). Currently they are decorative; future agents should wire them up.
+- **Desktop** — users can create shortcuts and files; system nodes are protected. User-created shortcuts added by Notebook or Sound Recorder appear automatically.
+- **App assets (future)** — sprite and image files in the FS will override bundled `/public/` assets when non-empty (path-based detection). A user could draw a new HELL enemy sprite in NS Art, save it at the matching path, and the game uses it.
+
+## Rules for new apps
+
+1. Every app that persists data **must** use `fsStore`. No direct `localStorage` calls, no custom IDB keys (except for binary blobs like audio data where the FS node acts as a metadata anchor).
+2. Add the app's data files to `seed.ts` with a stable ID and add a corresponding block to `migrate()`.
+3. Score files should use `fileType: "dat"` and store human-readable content (plain numbers or JSON) so Notebook can display them.
+4. Do not call `fsStore.batch()` from inside a React render. Use it only in setup code, seed, or migration.
+
+## Future work
+
+- **StorageAdapter swap** — replace `LocalStorageAdapter` with an IndexedDB adapter. No API changes required; swap the adapter passed to the `FileSystemStore` constructor.
+- **Asset override system** — if an FS file at a path matching a bundled `/public/` asset has non-empty content, the app uses that content instead. Enables in-game sprite editing via NS Art.
+- **NS-TOS completeness** — add `COPY`, `MOVE`, `TYPE` with piping, wildcard expansion.
+- **Config file effects** — wire `win.ini` / `system.ini` entries to real OS behavior (screensaver choice, desktop color, beep toggle, etc.).
+- **Richer file metadata** — file size display (based on `content.length`), last-modified timestamps in `FilesApp` status bar.
+- **Folder navigation from desktop** — double-clicking a folder on the desktop should open `FilesApp` navigated to that folder, not just open the root My Doors window.

--- a/specs/ns-doors-97.md
+++ b/specs/ns-doors-97.md
@@ -3,95 +3,218 @@
 ## Related
 
 - [`spec.md`](spec.md)
+- [`filesystem.spec.md`](filesystem.spec.md)
 - [`tic-tac-toe.md`](tic-tac-toe.md)
 
 ## Overview
 
 NS Doors 97 is the flagship Toy Box experience: a simulated 1990s desktop OS (a parody of Windows 95/98) made by "Noahsoft". It is the default route (`/`) — the first thing users see. All other experiences are accessible as windows within it.
 
+The OS is built around a real virtual filesystem (`FileSystemStore`) backed by `localStorage`. All data — desktop icons, app files, score files, saved drawings, recordings — lives in this FS. See [`filesystem.spec.md`](filesystem.spec.md) for architecture details.
+
 ## Routes
 
 - `/` — primary entry point
 - `/doors97` — alias
 
+## Provider tree
+
+```
+NsDoors97Page
+  FSProvider          ← singleton FileSystemStore; any FS change re-renders children
+    OsDialogProvider  ← modal OS dialog system
+      NsDoors97       ← desktop, windows, taskbar
+```
+
+## Boot screen
+
+On first visit (or after 30 minutes of absence), a BIOS-style boot sequence plays before the desktop appears:
+
+- Randomised CPU name, RAM count, drive detection, IRQ table, and POST messages.
+- Noahsoft splash screen with progress bar.
+- Returning from NS-TOS shows only the splash (skips BIOS).
+- Returning from a standalone app page skips boot entirely.
+- Restart (via Start menu) plays a shutdown sound, blanks the screen, then replays the full boot.
+
+After boot, desktop icons animate in one-by-one in randomised order, with occasional cursor-wait flashes to simulate a slow system initialising.
+
 ## Desktop
 
-- Dark teal/green desktop wallpaper (`#008080`, the classic Win95 default).
-- Desktop icons arranged in a column on the left: static icons + one icon per registered experience.
-- Double-clicking (or single-clicking on touch) an icon opens a window.
-- Clicking the desktop (outside any window) deselects icons.
+- Configurable background (solid color, Noahsoft dark gradient, or wallpaper image). Default: `#cc4400` orange.
+- Desktop icons in two columns: system icons on the left, user files/shortcuts on the right.
+- All desktop icons are driven by `store.getChildren(DESKTOP_ID)` — the filesystem is the source of truth.
+- Double-clicking (or single-tap on touch) an icon calls `openFSNode(nodeId)`.
 
-### Static desktop icons
+### System desktop icons (left column, `system: true`)
 
-| Icon | Title | Opens |
+| Node | Shortcut target | Opens |
 |---|---|---|
-| 🖥️ | My Doors | Folder browser window |
-| 🗑️ | Recycle Bin | Placeholder / not implemented |
-| ℹ️ | About NS Doors 97 | About dialog |
-| 🌐 | Internet | Simulated browser window |
-| 💤 | Screensavers | Screensaver settings window |
+| My Doors | `targetAppId: "files"` | FilesApp window (folder browser) |
+| Dumpster | `targetAppId: "dumpster"` | FilesApp window (Recycle Bin mode) |
 
-### Experience icons
+These nodes are `system: true` and cannot be deleted or renamed.
 
-One icon per experience registered in `src/data/experiences.ts` (excluding NS Doors 97 itself). Opening launches either an app-launcher window or an embedded app window, depending on the experience.
+### User desktop icons (right column, `system: false`)
 
-## Windows
+- `README.txt` — pre-seeded text file; opens in Notebook
+- User-created Notebook files (added as desktop shortcuts when a new file is saved in Notebook)
+- User-created Sound Recorder recordings (added as desktop shortcuts when a recording is saved)
+- Any other shortcuts or files created at runtime
+
+## Window system
 
 Windows use `react-draggable`. Each window has:
-- **Title bar** — orange/brown gradient, icon, title text, minimize/maximize/close buttons (close is functional; min/max are decorative)
+- **Title bar** — orange/brown gradient, emoji icon, title text, minimize / maximize / close buttons (min is functional; max is decorative)
+- **Menu bar** — Win95-style File / Edit / Help menus populated per-app via `useWindowMenus()`
 - **Beveled chrome** — Win95 raised outer border, sunken inner frame
 - **Content area** — white or gray depending on app
 
-Multiple windows can be open simultaneously. Clicking a window brings it to the front (z-index management). Windows can be dragged anywhere on the desktop.
+Multiple windows can be open simultaneously. Clicking a window brings it to the front (z-index management). Windows can be dragged anywhere on the desktop. Minimising collapses the window to the taskbar only.
 
 ### Window types
 
-| Type | Content |
-|---|---|
-| `app-launcher` | "Open in new tab" button for external experiences |
-| `tictactoe` | Embedded `<TicTacToe />` component |
-| `nomnom` | Embedded `<NumberMuncher />` (Nom Nom Numerals) |
-| `screensaver-settings` | Screensaver picker and preview |
-| `about` | About Noahsoft dialog |
-| `my-doors` | Folder / file browser |
-| `internet` | Simulated internet browser |
+| Content type | App | Notes |
+|---|---|---|
+| `app-launcher` | External experience launcher | "Play" button navigates to the standalone route |
+| `tictactoe` | Tic-Tac-Toe | Window width changes with board size (3→380px, 5→480px, 7→580px) |
+| `nomnom` | Nom Nom Numerals (Number Muncher) | |
+| `word-whirlwind` | Word Whirlwind | |
+| `words` | WORDS | |
+| `pool` | 8-Ball Pool | Width: 800px |
+| `bombfinder` | Bomb Finder | Width changes with difficulty |
+| `duckhunt` | Duck & Learn | Width: 740px |
+| `cards-launcher` | Cards launcher | Picker for War, Blackjack, Pyramid |
+| `cards-game` | War / Blackjack / Pyramid | Replaces launcher window |
+| `chain-reaction` | Chain Reaction | |
+| `peg-solitaire` | Peg Solitaire | |
+| `screensaver-settings` | Screensaver settings | |
+| `desktop-display` | Display properties | Background type, color, wallpaper |
+| `about` | About NS Doors 97 | Noahsoft logo, version, OK button |
+| `internet` | Simulated browser | Fake address bar + hardcoded fake websites |
+| `files` | My Doors (folder browser) | Navigates real FS via FilesApp |
+| `dumpster` | Recycle Bin | FilesApp in dumpster mode |
+| `notebook` | Notebook text editor | Reads/writes FS files |
+| `nsart` | NS Art (pixel drawing) | Auto-saves to FS |
+| `nsart-backup` | NS Art (loaded from backup) | Alias for nsart |
+| `sound-recorder` | Sound Recorder | Saves WAV metadata to FS |
+| `midi-editor` | MIDI Editor | |
 
-## Taskbar
+## App: My Doors (FilesApp)
 
-- Fixed to the bottom of the screen.
-- **Start button** (left): opens the Start menu.
-- **Window buttons** (middle): one pill per open window; clicking focuses the window.
-- **Clock** (right): live digital clock showing current time.
+A Win95-style folder browser driven entirely by the virtual filesystem.
 
-## Start menu
+- Navigation is a folder-ID stack. "Up" pops the stack.
+- Address bar shows the `C:\`-style path from `store.getPath(currentFolderId)`.
+- Contents are sorted: folders first, then files/shortcuts alphabetically.
+- Clicking a folder navigates into it; clicking a file dispatches by type:
+  - Text-like files (`text`, `bat`, `sys`, `ini`, `dat` with content) → open in Notebook
+  - `.exe` with `appId` → open that app window
+  - `.exe` with `appId: "tos-only"` → dialog explaining NS-TOS launch requirement
+  - `.wav` with `appId: "sound-recorder"` → open Sound Recorder with that recording
+  - `.tmp` → "file damaged" error dialog
+  - `.zip`, `.bmp`, `.png`, `.wav` (no app) → "need additional program" error dialog
+  - Anything else without appId → "not a valid NS Doors application" error (with fake error code)
+- Status bar shows object count and folder count.
+- File menu exposes "Empty Dumpster" in Dumpster mode.
+- Deleting a file moves it to the Dumpster (or permanently deletes if already there). System nodes are protected.
 
-Opens when the Start button is clicked. Contains shortcuts to launch apps (About, My Doors, Internet, Screensavers, Toy Box launcher). Clicking outside closes it.
+## App: Notebook
 
-## Screensaver system
+A simple text editor that reads and writes FS files.
 
-- Activates after an idle timeout (no mouse movement or click).
-- Screensaver overlay renders over the entire desktop.
-- Available screensavers: Starfield, Fireworks, Bouncing Shapes.
-- Moving the mouse or clicking dismisses the screensaver.
-- Settings window lets the user choose the active screensaver and preview it.
+- File path shown in a path bar at the top.
+- `File > Save` writes `fsStore.writeFile(fileId, content)`.
+- After saving, fires a callback to `NsDoors97.tsx` which creates a desktop shortcut for the file (if one does not already exist).
+- `Edit > Word Wrap` toggles line wrapping.
+- Status bar shows line count, character count, read-only indicator, and unsaved/saved state.
+- Files with `readonly: true` show in read-only mode (no save).
+- Opening from Start > Tools > Notebook creates a new `Untitled.txt` in `C:\Documents\`.
 
-## App: My Doors (folder browser)
+## App: NS Art
 
-Simulates a Windows Explorer folder view. Shows a fake file tree of "drives" and folders. Clicking folders navigates in. Double-clicking files shows a placeholder message.
+Pixel drawing tool.
+
+- Auto-saves to `NS_ART_BACKUP_ID` (`C:\Programs\Accessories\NS Art\Untitled.nsart`).
+- On load, reads from the FS backup; if the file is empty, checks old localStorage key for legacy migration.
+- Close button triggers a "save?" prompt before closing if there are unsaved changes.
+- Can be opened standalone at its own route (uses the singleton directly without the FSProvider).
+
+## App: Sound Recorder
+
+Records audio via the browser microphone API.
+
+- Saved recordings appear as `.wav` files in `C:\Programs\Accessories\Sound Recorder\`.
+- Audio data is stored in IndexedDB (efficient for binary); the FS node is metadata only.
+- After saving, a desktop shortcut is created.
+- Clicking a `.wav` file (from desktop or FilesApp) opens Sound Recorder preloaded with that recording.
+
+## App: Dumpster (Recycle Bin)
+
+Reuses `FilesApp` with `startFolderId={DUMPSTER_ID}` and `isDumpster={true}`.
+
+- Clicking a file in Dumpster mode prompts to permanently delete it.
+- "Empty" button (toolbar) and "Empty Dumpster" (File menu) call `store.emptyDumpster()`.
+- Pre-seeded with three files to look lived-in: an unsent complaint letter, an old budget, and a NS Doors 95 uninstaller.
 
 ## App: Internet (simulated browser)
 
-A fake browser window with an address bar and navigation buttons. Loads a set of hardcoded fake "websites". Not a real browser — purely decorative.
+A fake browser window with an address bar and navigation buttons. Loads hardcoded fake "websites". Not a real browser — purely decorative.
 
-## App: About NS Doors 97
+## App: Screensaver settings
 
-A Win95-style About dialog: Noahsoft logo area, version text, copyright, and an OK button.
+Lets the user choose the active screensaver (Starfield, Fireworks, Bouncing Shapes), set idle timeout, and preview the screensaver immediately.
+
+## App: Display properties
+
+Lets the user configure the desktop background:
+- **Noahsoft gradient** — the dark radial gradient (signature look)
+- **Solid color** — any hex color (default: `#cc4400` orange)
+- **Wallpaper** — preset images (Sunset, Arch) or a custom uploaded image, with cover/contain fit
+
+Settings persist to `localStorage` (separate from the FS).
+
+## Taskbar
+
+Fixed to the bottom of the screen.
+
+- **Open button** (left, door emoji): opens the Start menu.
+- **Window buttons** (middle): one pill per open window; clicking focuses/restores the window; active window is highlighted; minimized windows are dimmed.
+- **System tray** (right): fullscreen toggle button, retro clock (real time; date displayed 30 years in the past to show a 1990s date).
+
+## Start menu
+
+Opens when the Open button is clicked. Flyout submenus on hover:
+
+| Item | Submenu / action |
+|---|---|
+| Games | Cards, Tic-Tac-Toe, 8-Ball Pool, Word Whirlwind, WORDS, Bomb Finder, Duck & Learn, Nom Nom Numerals, Type 'Em Up, Chain Reaction, Peg Solitaire |
+| Tools | Notebook, NS Art, Sound Recorder, MIDI Editor |
+| Internet | Opens internet browser window |
+| Settings | Display..., Screensavers... |
+| About NS Doors 97 | Opens about dialog |
+| Exit to NS-TOS... | Navigates to `/ns-tos` |
+| Restart... | Plays shutdown sound, blanks screen, replays boot |
+
+Clicking outside the menu closes it.
+
+## Screensaver system
+
+- Activates after configurable idle timeout (no mouse movement, click, key, or touch).
+- Available screensavers: Starfield, Fireworks, Bouncing Shapes.
+- Moving the mouse or clicking dismisses the screensaver.
+- Settings persisted via `screensaverSettings.ts` (not in the FS — separate localStorage key).
+
+## Virtual filesystem integration
+
+The desktop, My Doors, Notebook, NS Art, Sound Recorder, Duck & Learn, and Typing Racer all use the FS. Score files are plain text/JSON stored in each game's sub-folder under `C:\Programs\Games\`. Opening a `SCORES.DAT` file in Notebook shows the raw scores; editing and saving changes the score — this is intentional (the hackable OS philosophy).
+
+See [`filesystem.spec.md`](filesystem.spec.md) for the complete architecture.
 
 ## Styling
 
 All OS chrome uses the Noahsoft Win95 palette:
-- Desktop background: `#008080`
+- Desktop background: configurable (default orange `#cc4400`)
 - Title bar: brown-orange gradient
-- Window chrome: `#c0c0c0` with beveled borders
+- Window chrome: `#c0c0c0` with beveled borders (raised: `#ffffff #808080 #808080 #ffffff`; sunken: `#808080 #ffffff #ffffff #808080`)
 - Font: "Press Start 2P" for all OS UI text
 - Taskbar: dark gray with raised border

--- a/specs/ns-doors-97.todo.md
+++ b/specs/ns-doors-97.todo.md
@@ -13,17 +13,34 @@
     - Recreate old-school games: eat-smaller-fish, helicopter dodge, bubble pop, Snood-like, etc.
     - Accessed by navigating to a fake URL inside the browser
 
-- [#32](https://github.com/NoahWright87/toybox/issues/32) Fake file structure — "My Machine" (or similar) folder browser
-  - Opens in a Win95-style folder viewer from My Doors or a desktop icon
-  - Navigate folder hierarchy; back-up control (no fancy breadcrumbs — 90s style)
-  - Fixed locations: games in `/Games`, backgrounds in `/Backgrounds`, OS files in `/System`
-  - Randomly placed Easter-egg files scattered throughout (see #31)
-  - Rule: anything added to the desktop / Start menu must also appear somewhere in the file system
+- Wire up `win.ini` / `system.ini` to real OS behavior
+  - `[Desktop] Wallpaper=` → set desktop wallpaper from FS path
+  - `[Desktop]` solid color entries → change desktop background color
+  - `[windows] Beep=` → toggle system beep sounds
+  - `[sounds]` entries → wire to actual audio playback on OS events
+  - Rule: every new INI entry wired up should be reflected in Display/Screensaver settings and vice versa
 
-- [#31](https://github.com/NoahWright87/toybox/issues/31) Documents folder with Easter-egg files
-  - Stored in a settings/config file in the repo so agents can add to it over time
-  - Include: `passwords.txt` (ridiculous credentials), `cheat codes.txt`, walkthrough for "that hard stage", random phone numbers, multiple drafts of "Important - Don't Forget", etc.
-  - Tone: humorous, 90s-appropriate; lean into nerd/gaming/computer references
+- Asset override system (FS-backed sprite replacement)
+  - If a FS file at a path matching a `/public/` bundled asset has non-empty content, the game/app uses that content instead
+  - Enables: draw a HELL sprite in NS Art → save to `C:\EGO\SPRITES\ENEMY0.BMP` → HELL game loads it on next run
+  - Detection is path-based; empty FS content means "use bundled default"
+
+- Folder navigation from desktop
+  - Double-clicking a folder node on the desktop should open My Doors navigated to that specific folder (not just the root)
+  - Requires passing `startFolderId` through `openFSNode` when `node.kind === "folder"`
+
+- StorageAdapter swap to IndexedDB
+  - Implement `IndexedDBAdapter` implementing the `StorageAdapter` interface
+  - Swap into `FileSystemStore` constructor; no other code changes required
+  - Benefit: larger storage quota, avoids localStorage 5 MB limit for large NS Art files
+
+- NS-TOS as a more complete shell
+  - `COPY src dst` — copy a file to a new location in the FS
+  - `MOVE src dst` — move (rename + reparent)
+  - `TYPE file | more` — paginate long text files
+  - Wildcard expansion for `DIR *.exe`, `DEL *.tmp`, etc.
+  - `CLS` — clear terminal output
+  - `VER` — print OS version string
 
 ## Backlog
 
@@ -33,4 +50,4 @@
 
 - Move completed items to `ns-doors-97.md` — this file is for future plans, not current state
 - Items flow: INTAKE → `spec.todo.md` → this file → `ns-doors-97.md` (when done)
-- If you add content to the file structure (#32), update both the folder-data config and `ns-doors-97.md`
+- New apps that save data must use `fsStore` — see `filesystem.spec.md` for the rules

--- a/src/experiences/DuckHunt/DuckHunt.tsx
+++ b/src/experiences/DuckHunt/DuckHunt.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { DH_SCORES_ID } from "../NsDoors97/filesystem/types";
 import "./DuckHunt.css";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -569,8 +571,17 @@ export default function DuckHunt() {
 
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(LS_KEY);
-      if (raw) setHighScores(JSON.parse(raw) as HighScore[]);
+      // Prefer FS SCORES.DAT; fall back to legacy localStorage, migrating on first read
+      const fsContent = fsStore.getFile(DH_SCORES_ID)?.content;
+      const legacyRaw = !fsContent ? localStorage.getItem(LS_KEY) : null;
+      const raw = fsContent || legacyRaw;
+      if (raw) {
+        setHighScores(JSON.parse(raw) as HighScore[]);
+        if (legacyRaw) {
+          fsStore.writeFile(DH_SCORES_ID, legacyRaw);
+          localStorage.removeItem(LS_KEY);
+        }
+      }
     } catch { /* ignore */ }
   }, []);
 
@@ -588,7 +599,7 @@ export default function DuckHunt() {
       .sort((a, b) => b.score - a.score)
       .slice(0, 5);
     setHighScores(updated);
-    try { localStorage.setItem(LS_KEY, JSON.stringify(updated)); } catch { /* ignore */ }
+    try { fsStore.writeFile(DH_SCORES_ID, JSON.stringify(updated)); } catch { /* ignore */ }
   }
 
   // ── Audio ──────────────────────────────────────────────────────────────────

--- a/src/experiences/Hellzone/Hellzone.tsx
+++ b/src/experiences/Hellzone/Hellzone.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Sprite } from "./sprites";
+import { getAssetUrl } from "./assetOverride";
 import { QUIPS, QuipKey, SubtitleCategory, SubtitleSettings, EXIT_QUIPS, pickRandom, pickLockedDoorQuip } from "./quips";
 import { generateMap as genMapFromModule, type MapGenParams, type Topology, GEN_WALL as MGEN_WALL } from './mapgen';
 import "./Hellzone.css";
@@ -449,9 +450,9 @@ export default function Hellzone() {
     let longPressTriggered = false;
 
     // ── Sprites ─────────────────────────────────────────────────────────────────
-    const sprWallRock = new Sprite('/sprites/wall-rock.png');
+    const sprWallRock = new Sprite(getAssetUrl('/sprites/wall-rock.png'));
     // Lava sheet: 2×2 grid of 4 frames, each 627×627 within a 1254×1254 image.
-    const sprWallLava = new Sprite('/sprites/wall-lava.png', [
+    const sprWallLava = new Sprite(getAssetUrl('/sprites/wall-lava.png'), [
       { x: 0,   y: 0,   w: 627, h: 627 },
       { x: 627, y: 0,   w: 627, h: 627 },
       { x: 0,   y: 627, w: 627, h: 627 },
@@ -459,39 +460,39 @@ export default function Hellzone() {
     ]);
 
     const sprEnemy = [
-      new Sprite('/sprites/enemy-0.png'),
-      new Sprite('/sprites/enemy-1.png'),
-      new Sprite('/sprites/enemy-2.png'),
+      new Sprite(getAssetUrl('/sprites/enemy-0.png')),
+      new Sprite(getAssetUrl('/sprites/enemy-1.png')),
+      new Sprite(getAssetUrl('/sprites/enemy-2.png')),
     ];
-    const sprEnemyDead = new Sprite('/sprites/enemy-dead.png');
-    const sprTarget = new Sprite('/sprites/target-dummy.png');
-    const sprTargetDead = new Sprite('/sprites/target-dummy-dead.png');
-    const sprPickupHealth = new Sprite('/sprites/pickup-health.png');
-    const sprPickupAmmo = new Sprite('/sprites/pickup-ammo.png');
+    const sprEnemyDead = new Sprite(getAssetUrl('/sprites/enemy-dead.png'));
+    const sprTarget = new Sprite(getAssetUrl('/sprites/target-dummy.png'));
+    const sprTargetDead = new Sprite(getAssetUrl('/sprites/target-dummy-dead.png'));
+    const sprPickupHealth = new Sprite(getAssetUrl('/sprites/pickup-health.png'));
+    const sprPickupAmmo = new Sprite(getAssetUrl('/sprites/pickup-ammo.png'));
     const sprWeapon: Record<WeaponId, Sprite> = {
-      claws:        new Sprite('/sprites/gun-claws.png'),
-      subwoofer:    new Sprite('/sprites/gun-subwoofer.png'),
-      woofer:       new Sprite('/sprites/gun-woofer.png'),
-      tennis:       new Sprite('/sprites/gun-tennis.png'),
-      flamethrower: new Sprite('/sprites/gun-flamethrower.png'),
+      claws:        new Sprite(getAssetUrl('/sprites/gun-claws.png')),
+      subwoofer:    new Sprite(getAssetUrl('/sprites/gun-subwoofer.png')),
+      woofer:       new Sprite(getAssetUrl('/sprites/gun-woofer.png')),
+      tennis:       new Sprite(getAssetUrl('/sprites/gun-tennis.png')),
+      flamethrower: new Sprite(getAssetUrl('/sprites/gun-flamethrower.png')),
     };
-    const sprPickupBullets  = new Sprite('/sprites/pickup-bullets.png');
-    const sprPickupFuel     = new Sprite('/sprites/pickup-fuel.png');
-    const sprPickupBalls    = new Sprite('/sprites/pickup-balls.png');
-    const sprPickupWoofer   = new Sprite('/sprites/pickup-weapon-woofer.png');
-    const sprPickupTennis   = new Sprite('/sprites/pickup-weapon-tennis.png');
-    const sprPickupFlame    = new Sprite('/sprites/pickup-weapon-flamethrower.png');
-    const sprTennisBall     = new Sprite('/sprites/projectile-tennis.png');
-    const sprFlameParticle  = new Sprite('/sprites/flame-particle.png');
-    const sprImpactWall = new Sprite('/sprites/impact-wall.png');
-    const sprImpactEnemy = new Sprite('/sprites/impact-enemy.png');
+    const sprPickupBullets  = new Sprite(getAssetUrl('/sprites/pickup-bullets.png'));
+    const sprPickupFuel     = new Sprite(getAssetUrl('/sprites/pickup-fuel.png'));
+    const sprPickupBalls    = new Sprite(getAssetUrl('/sprites/pickup-balls.png'));
+    const sprPickupWoofer   = new Sprite(getAssetUrl('/sprites/pickup-weapon-woofer.png'));
+    const sprPickupTennis   = new Sprite(getAssetUrl('/sprites/pickup-weapon-tennis.png'));
+    const sprPickupFlame    = new Sprite(getAssetUrl('/sprites/pickup-weapon-flamethrower.png'));
+    const sprTennisBall     = new Sprite(getAssetUrl('/sprites/projectile-tennis.png'));
+    const sprFlameParticle  = new Sprite(getAssetUrl('/sprites/flame-particle.png'));
+    const sprImpactWall = new Sprite(getAssetUrl('/sprites/impact-wall.png'));
+    const sprImpactEnemy = new Sprite(getAssetUrl('/sprites/impact-enemy.png'));
     const sprKeys: Record<KeyColor, Sprite> = {
-      red:    new Sprite('/sprites/key-red.png'),
-      orange: new Sprite('/sprites/key-orange.png'),
-      yellow: new Sprite('/sprites/key-yellow.png'),
-      green:  new Sprite('/sprites/key-green.png'),
-      blue:   new Sprite('/sprites/key-blue.png'),
-      purple: new Sprite('/sprites/key-purple.png'),
+      red:    new Sprite(getAssetUrl('/sprites/key-red.png')),
+      orange: new Sprite(getAssetUrl('/sprites/key-orange.png')),
+      yellow: new Sprite(getAssetUrl('/sprites/key-yellow.png')),
+      green:  new Sprite(getAssetUrl('/sprites/key-green.png')),
+      blue:   new Sprite(getAssetUrl('/sprites/key-blue.png')),
+      purple: new Sprite(getAssetUrl('/sprites/key-purple.png')),
     };
 
     // ── Sound system ───────────────────────────────────────────────────────────
@@ -509,7 +510,7 @@ export default function Hellzone() {
           'pickup-weapon','weapon-switch','door-open',
         ];
         for (const name of names) {
-          fetch(`/sounds/${name}.wav`)
+          fetch(getAssetUrl(`/sounds/${name}.wav`))
             .then(r => r.arrayBuffer())
             .then(buf => audioCtx!.decodeAudioData(buf))
             .then(decoded => { soundBuffers.set(name, decoded); })

--- a/src/experiences/Hellzone/assetOverride.ts
+++ b/src/experiences/Hellzone/assetOverride.ts
@@ -1,0 +1,25 @@
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+
+/**
+ * Resolves a public asset path to either the user's custom version (stored in
+ * the virtual FS) or the original bundled file.
+ *
+ * /sprites/enemy-0.png  → checks C:\EGO\SPRITES\enemy-0.png in FS
+ * /sounds/alert.wav     → checks C:\EGO\SOUNDS\alert.wav in FS
+ *
+ * The FS file content is expected to be a data URL (e.g. "data:image/png;base64,...").
+ * If the FS file exists but has empty content, the bundled path is used as fallback.
+ */
+export function getAssetUrl(publicPath: string): string {
+  let fsPath: string;
+  if (publicPath.startsWith("/sprites/")) {
+    fsPath = "C:\\EGO\\SPRITES\\" + publicPath.slice("/sprites/".length);
+  } else if (publicPath.startsWith("/sounds/")) {
+    fsPath = "C:\\EGO\\SOUNDS\\" + publicPath.slice("/sounds/".length);
+  } else {
+    return publicPath;
+  }
+  const node = fsStore.getNodeByPath(fsPath);
+  if (node?.kind === "file" && node.content) return node.content;
+  return publicPath;
+}

--- a/src/experiences/NsArt/NsArt.css
+++ b/src/experiences/NsArt/NsArt.css
@@ -516,6 +516,18 @@
 
 .ns-art__bottom-undo:active { border-color: #808080 #ffffff #ffffff #808080; }
 
+.ns-art__sprite-status {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #228833;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 0 4px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.ns-art__sprite-status--visible { opacity: 1; }
+
 /* Minimap section — centered, grows to fill */
 
 .ns-art__bottom-map {

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -40,6 +40,8 @@ export interface NsArtHandle {
 
 export interface NsArtProps {
   onBackupSaved?: () => void;
+  fileId?: string;   // FS file to persist PNG data URL to on every auto-save
+  fileUrl?: string;  // initial image URL to load when opening a sprite file
 }
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -347,7 +349,7 @@ function FrameThumbnail({
 // ── Component ──────────────────────────────────────────────────────────────
 
 const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
-  { onBackupSaved }: NsArtProps,
+  { onBackupSaved, fileId, fileUrl }: NsArtProps,
   ref,
 ) {
   // DOM refs
@@ -450,7 +452,9 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
   const containerSizeRef        = useRef({ w: 0, h: 0 });
   const renderMinimapRef        = useRef<() => void>(() => {});
 
+  const fileIdRef = useRef(fileId);
   useEffect(() => { onBackupSavedRef.current = onBackupSaved; }, [onBackupSaved]);
+  useEffect(() => { fileIdRef.current = fileId; }, [fileId]);
   useEffect(() => { currentStripRef.current  = currentStrip;  }, [currentStrip]);
   useEffect(() => { currentFrameRef.current  = currentFrame;  }, [currentFrame]);
   useEffect(() => { frameCountRef.current    = frameCount;    }, [frameCount]);
@@ -547,11 +551,58 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
     }
   }, [canvasSize]);
 
-  // ── Load backup ────────────────────────────────────────────────────────
+  // ── Load backup / sprite file ───────────────────────────────────────────
 
   useEffect(() => {
     const t = setTimeout(() => {
-      // Prefer FS backup; fall back to legacy localStorage, migrating on first read
+      if (fileId) {
+        // Sprite edit mode: load from FS file content (user's override) or bundled URL
+        const fsContent = fsStore.getFile(fileId)?.content;
+        const sourceUrl = fsContent || fileUrl;
+        if (!sourceUrl || !canvasRef.current) return;
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        img.onload = () => {
+          const w = img.naturalWidth || 64;
+          const h = img.naturalHeight || 64;
+          const tmp = document.createElement("canvas");
+          tmp.width = w; tmp.height = h;
+          const tmpCtx = tmp.getContext("2d")!;
+          tmpCtx.drawImage(img, 0, 0);
+          const imageData = tmpCtx.getImageData(0, 0, w, h);
+          const canvas = canvasRef.current;
+          if (!canvas) return;
+          const pending: PendingRestore = {
+            strips: [{ name: "Sprite" }],
+            frames: [[imageData]],
+            frameCount: 1,
+            frameW: w,
+            frameH: h,
+          };
+          if (canvas.width === w && canvas.height === h) {
+            framesDataRef.current      = [[imageData]];
+            stripsRef.current          = [{ name: "Sprite" }];
+            frameCountRef.current      = 1;
+            currentStripRef.current    = 0;
+            currentFrameRef.current    = 0;
+            setStrips([{ name: "Sprite" }]);
+            setFrameCount(1);
+            setCurrentStrip(0);
+            setCurrentFrame(0);
+            canvas.getContext("2d")!.putImageData(imageData, 0, 0);
+            isDirtyRef.current = false;
+            renderOnionRef.current();
+          } else {
+            pendingRestoreRef.current = pending;
+            setCanvasSize({ w, h });
+          }
+        };
+        img.onerror = () => {};
+        img.src = sourceUrl;
+        return;
+      }
+
+      // Normal backup mode: prefer FS backup; fall back to legacy localStorage
       const fsContent = fsStore.getFile(NS_ART_BACKUP_ID)?.content;
       const legacy = !fsContent ? localStorage.getItem(LS_KEY) : null;
       if (legacy) {
@@ -643,6 +694,14 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
           return tmp.toDataURL("image/png");
         })
       );
+
+      // Save current frame as PNG data URL to the target FS file (sprite edit mode)
+      if (fileIdRef.current) {
+        const currentUrl = framesUrls[currentStripRef.current]?.[currentFrameRef.current];
+        if (currentUrl) {
+          fsStore.writeFile(fileIdRef.current, currentUrl);
+        }
+      }
 
       try {
         fsStore.writeFile(NS_ART_BACKUP_ID, JSON.stringify({

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -4,6 +4,8 @@ import {
 } from "react";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { NS_ART_BACKUP_ID } from "../NsDoors97/filesystem/types";
 import "./NsArt.css";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -549,7 +551,14 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
 
   useEffect(() => {
     const t = setTimeout(() => {
-      const raw = localStorage.getItem(LS_KEY);
+      // Prefer FS backup; fall back to legacy localStorage, migrating on first read
+      const fsContent = fsStore.getFile(NS_ART_BACKUP_ID)?.content;
+      const legacy = !fsContent ? localStorage.getItem(LS_KEY) : null;
+      if (legacy) {
+        fsStore.writeFile(NS_ART_BACKUP_ID, legacy);
+        localStorage.removeItem(LS_KEY);
+      }
+      const raw = fsContent || legacy;
       if (!raw || !canvasRef.current) return;
       try {
         const backup = JSON.parse(raw);
@@ -636,7 +645,7 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
       );
 
       try {
-        localStorage.setItem(LS_KEY, JSON.stringify({
+        fsStore.writeFile(NS_ART_BACKUP_ID, JSON.stringify({
           version: 2,
           frameW: fw,
           frameH: fh,

--- a/src/experiences/NsArt/NsArt.tsx
+++ b/src/experiences/NsArt/NsArt.tsx
@@ -385,6 +385,7 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
   const [dragOverStripIdx, setDragOverStripIdx] = useState<number | null>(null);
   const [showPaletteDlg, setShowPaletteDlg] = useState(false);
   const [paletteTarget, setPaletteTarget] = useState<"primary" | "secondary" | null>(null);
+  const [spriteSaved, setSpriteSaved] = useState(false);
 
   // Animation state
   const [strips,        setStrips]        = useState<Strip[]>([{ name: "Strip 1" }]);
@@ -426,6 +427,7 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
   const moveOffsetRef        = useRef({ x: 0, y: 0 });
   const isDirtyRef          = useRef(false);
   const saveTimerRef        = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const spriteSaveTimerRef  = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onBackupSavedRef    = useRef(onBackupSaved);
 
   // Animation refs
@@ -507,15 +509,41 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
   useImperativeHandle(ref, () => ({
     requestClose: (proceed) => {
       if (isDirtyRef.current) {
-        setConfirmState({
-          title: "NS Art",
-          message: "Your artwork has unsaved changes.",
-          buttons: [
-            { label: "Export PNG", primary: true, onClick: () => { exportCurrentFrame(); proceed(); setConfirmState(null); } },
-            { label: "Close without saving",      onClick: () => { proceed(); setConfirmState(null); } },
-            { label: "Cancel",                    onClick: () => setConfirmState(null) },
-          ],
-        });
+        if (fileIdRef.current) {
+          // Sprite edit mode: save directly to FS file
+          setConfirmState({
+            title: "NS Art",
+            message: "Save changes to this sprite?",
+            buttons: [
+              { label: "Save", primary: true, onClick: () => {
+                const canvas = canvasRef.current;
+                if (canvas) {
+                  saveFrameRef.current();
+                  const frame = framesDataRef.current[currentStripRef.current]?.[currentFrameRef.current];
+                  if (frame) {
+                    const tmp = document.createElement("canvas");
+                    tmp.width = canvas.width; tmp.height = canvas.height;
+                    tmp.getContext("2d")!.putImageData(frame, 0, 0);
+                    fsStore.writeFile(fileIdRef.current!, tmp.toDataURL("image/png"));
+                  }
+                }
+                proceed(); setConfirmState(null);
+              }},
+              { label: "Discard changes", onClick: () => { proceed(); setConfirmState(null); } },
+              { label: "Cancel",          onClick: () => setConfirmState(null) },
+            ],
+          });
+        } else {
+          setConfirmState({
+            title: "NS Art",
+            message: "Your artwork has unsaved changes.",
+            buttons: [
+              { label: "Export PNG", primary: true, onClick: () => { exportCurrentFrame(); proceed(); setConfirmState(null); } },
+              { label: "Close without saving",      onClick: () => { proceed(); setConfirmState(null); } },
+              { label: "Cancel",                    onClick: () => setConfirmState(null) },
+            ],
+          });
+        }
       } else {
         proceed();
       }
@@ -700,6 +728,10 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
         const currentUrl = framesUrls[currentStripRef.current]?.[currentFrameRef.current];
         if (currentUrl) {
           fsStore.writeFile(fileIdRef.current, currentUrl);
+          isDirtyRef.current = false; // auto-save is complete
+          if (spriteSaveTimerRef.current) clearTimeout(spriteSaveTimerRef.current);
+          setSpriteSaved(true);
+          spriteSaveTimerRef.current = setTimeout(() => setSpriteSaved(false), 2500);
         }
       }
 
@@ -2085,6 +2117,13 @@ const NsArt = forwardRef<NsArtHandle, NsArtProps>(function NsArt(
 
         {/* Undo */}
         <button className="ns-art__bottom-undo" onClick={undo} title="Undo (Ctrl+Z)">↩</button>
+
+        {/* Sprite save status — only visible in sprite edit mode */}
+        {fileId && (
+          <span className={`ns-art__sprite-status${spriteSaved ? " ns-art__sprite-status--visible" : ""}`}>
+            ✓ Saved
+          </span>
+        )}
 
         {/* Minimap + zoom — grows to fill center */}
         <div className="ns-art__bottom-map">

--- a/src/experiences/NsDoors97/FilesApp.tsx
+++ b/src/experiences/NsDoors97/FilesApp.tsx
@@ -2,24 +2,23 @@ import { useState, useMemo } from "react";
 import { useOsDialog } from "./OsDialog";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
-import {
-  ROOT,
-  type FsNode,
-  type FsFolder,
-  type FsFile,
-  getNodeIcon,
-} from "./fileSystem";
+import { useFS } from "./filesystem/FSContext";
+import { getNodeIcon, ROOT_ID, DUMPSTER_ID, type FSNode, type FSFile } from "./filesystem/types";
+import { fsStore } from "./filesystem/FileSystemStore";
 import "./FilesApp.css";
 
 interface FilesAppProps {
+  startFolderId?: string;
+  isDumpster?: boolean;
   onOpenApp: (appId: string) => void;
-  onOpenNotebook: (path: string, fileName: string, content: string) => void;
+  onOpenNotebook: (fileId: string, fileName: string) => void;
+  onOpenFSNode?: (nodeId: string) => void;
   onQuit?: () => void;
 }
 
 interface FolderItemProps {
-  node: FsNode;
-  onOpen: (node: FsNode) => void;
+  node: FSNode;
+  onOpen: (node: FSNode) => void;
 }
 
 function FolderItem({ node, onOpen }: FolderItemProps) {
@@ -38,7 +37,7 @@ function FolderItem({ node, onOpen }: FolderItemProps) {
     lastClick.current = now;
   }
 
-  const dimmed = node.kind === "file" && node.type === "tmp";
+  const dimmed = node.kind === "file" && node.fileType === "tmp";
 
   return (
     <button
@@ -53,119 +52,216 @@ function FolderItem({ node, onOpen }: FolderItemProps) {
   );
 }
 
-export default function FilesApp({ onOpenApp, onOpenNotebook, onQuit }: FilesAppProps) {
+export default function FilesApp({
+  startFolderId,
+  isDumpster,
+  onOpenApp,
+  onOpenNotebook,
+  onOpenFSNode,
+  onQuit,
+}: FilesAppProps) {
   const { showDialog } = useOsDialog();
+  const store = useFS();
+
+  const rootId = startFolderId ?? ROOT_ID;
+  const [stack, setStack] = useState<string[]>([rootId]);
+  const currentFolderId = stack[stack.length - 1];
+  const children = store.getChildren(currentFolderId);
+  const pathStr = store.getPath(currentFolderId);
+
+  const canGoUp = stack.length > 1;
+
+  const dumpsterMenuItems = isDumpster
+    ? [
+        {
+          label: "Empty Dumpster",
+          onClick: () => {
+            showDialog("Are you sure? This will permanently delete all items in the Recycle Bin.", {
+              title: "Empty Recycle Bin",
+              icon: "🗑️",
+              buttons: ["Yes", "No"],
+              onButton: (btn: string) => {
+                if (btn === "Yes") {
+                  store.emptyDumpster();
+                  showDialog("Recycle Bin emptied.", { title: "Done", icon: "✅" });
+                }
+              },
+            });
+          },
+        },
+        { separator: true as const },
+      ]
+    : [];
 
   const menus = useMemo<MenuBarMenu[]>(() => [
     {
       label: "File",
       items: [
+        ...dumpsterMenuItems,
         ...(onQuit ? [{ label: "Exit", onClick: onQuit }] : [{ label: "(not implemented)", disabled: true as const }]),
       ],
     },
-    { label: "Edit", items: [{ label: "(not implemented)", disabled: true }] },
-    { label: "View", items: [{ label: "(not implemented)", disabled: true }] },
+    { label: "Edit", items: [{ label: "(not implemented)", disabled: true as const }] },
+    { label: "View", items: [{ label: "(not implemented)", disabled: true as const }] },
     {
       label: "Help",
       items: [
-        { label: "About Files", onClick: () => showDialog("NS Doors 97 Files\nBrowse and open files on this computer.", { title: "About Files", icon: "ℹ️" }) },
+        {
+          label: "About Files",
+          onClick: () => showDialog(
+            isDumpster
+              ? "Recycle Bin\nItems sent here are not permanently deleted until the bin is emptied."
+              : "NS Doors 97 Files\nBrowse and open files on this computer.",
+            { title: isDumpster ? "About Recycle Bin" : "About Files", icon: "ℹ️" }
+          ),
+        },
       ],
     },
-  ], [showDialog, onQuit]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [showDialog, onQuit, isDumpster, store]);
 
   useWindowMenus(menus);
 
-  // Navigation stack: each entry is a FsFolder
-  const [stack, setStack] = useState<FsFolder[]>([ROOT]);
-  const current = stack[stack.length - 1];
-
-  const pathStr = stack.map((f) => f.name).join("\\").replace("C:\\\\", "C:\\");
-
-  function navigate(folder: FsFolder) {
-    setStack((s) => [...s, folder]);
+  function navigate(folderId: string) {
+    setStack((s) => [...s, folderId]);
   }
 
   function goUp() {
     setStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
   }
 
-  function openNode(node: FsNode) {
+  function openNode(node: FSNode) {
     if (node.kind === "folder") {
-      navigate(node);
+      navigate(node.id);
       return;
     }
-    handleFile(node);
+    if (node.kind === "shortcut") {
+      onOpenFSNode?.(node.id);
+      return;
+    }
+    handleFile(node as FSFile);
   }
 
-  function handleFile(file: FsFile) {
-    // Text files — open in Notebook
-    if (file.content !== undefined) {
-      const path = pathStr + "\\" + file.name;
-      onOpenNotebook(path, file.name, file.content);
+  function handleFile(file: FSFile) {
+    // Readable text-like files
+    const textTypes = ["text", "bat", "sys", "ini", "dat"] as const;
+    const isTextLike = (textTypes as readonly string[]).includes(file.fileType);
+    if (isTextLike && (file.content || file.fileType === "text")) {
+      onOpenNotebook(file.id, file.name);
       return;
     }
 
-    // Executables with an action
-    if (file.action && file.action !== "noop") {
-      if (file.action === "notebook") {
-        onOpenNotebook("(new file)", "Untitled.txt", "");
-        return;
-      }
-      if (file.action === "tos-only") {
+    // Executables with an app ID
+    if (file.appId) {
+      if (file.appId === "tos-only") {
         showDialog(
           "HELL.EXE must be launched from NS-TOS.\n\nOpen NS-TOS and type:\n  HELL.EXE\n\nDouble-clicking does not work.",
           { title: "Cannot Run Program", icon: "⛔" }
         );
         return;
       }
-      // Screensavers and games open as experiences
-      onOpenApp(file.action);
+      onOpenApp(file.appId);
       return;
     }
 
-    // Non-functional files
+    // Non-functional file types
     const ext = file.name.split(".").pop()?.toUpperCase() ?? "";
-    if (file.type === "tmp") {
+    if (file.fileType === "tmp") {
       showDialog("This temporary file is damaged and cannot be opened.", { title: "Error", icon: "❌" });
-    } else if (["zip", "bmp"].includes(file.type)) {
-      showDialog(`Cannot open .${ext} files.\nYou need an additional program to view this file type.`, { title: "Open Error", icon: "⚠️" });
+    } else if (["zip", "bmp", "png", "wav"].includes(file.fileType)) {
+      showDialog(
+        `Cannot open .${ext} files.\nYou need an additional program to view this file type.`,
+        { title: "Open Error", icon: "⚠️" }
+      );
     } else {
-      showDialog(`${file.name} is not a valid NS Doors application, or cannot be run in this mode.\n\nError code: 0xC0000034`, { title: "Program Error", icon: "❌" });
+      showDialog(
+        `${file.name} is not a valid NS Doors application, or cannot be run in this mode.\n\nError code: 0xC0000034`,
+        { title: "Program Error", icon: "❌" }
+      );
     }
   }
 
-  const itemCount = current.children.length;
-  const folderCount = current.children.filter((n) => n.kind === "folder").length;
+  function handleDeleteSelected(node: FSNode) {
+    if (node.system) {
+      showDialog("This item is required by the system and cannot be deleted.", { title: "Error", icon: "⛔" });
+      return;
+    }
+    const inDumpster = node.parentId === DUMPSTER_ID;
+    const msg = inDumpster
+      ? `Permanently delete "${node.name}"?`
+      : `Move "${node.name}" to the Recycle Bin?`;
+    showDialog(msg, {
+      title: "Confirm Delete",
+      icon: "🗑️",
+      buttons: ["Yes", "No"],
+      onButton: (btn: string) => {
+        if (btn === "Yes") fsStore.deleteNode(node.id);
+      },
+    });
+  }
+
+  const folderCount = children.filter((n) => n.kind === "folder").length;
+  const itemCount = children.length;
 
   return (
     <div className="nsf-window">
-      {/* ── Toolbar ── */}
       <div className="nsf-toolbar">
         <button
           className="nsf-toolbar__btn"
           onClick={goUp}
-          disabled={stack.length <= 1}
+          disabled={!canGoUp}
           title="Up one level"
         >
           ↑ Up
         </button>
+        {isDumpster && (
+          <button
+            className="nsf-toolbar__btn"
+            onClick={() => {
+              showDialog("Are you sure? This will permanently delete all items in the Recycle Bin.", {
+                title: "Empty Recycle Bin",
+                icon: "🗑️",
+                buttons: ["Yes", "No"],
+                onButton: (btn: string) => {
+                  if (btn === "Yes") {
+                    store.emptyDumpster();
+                    showDialog("Recycle Bin emptied.", { title: "Done", icon: "✅" });
+                  }
+                },
+              });
+            }}
+            title="Empty Recycle Bin"
+          >
+            🗑️ Empty
+          </button>
+        )}
         <div className="nsf-toolbar__sep" />
         <span className="nsf-toolbar__label">Address:</span>
         <div className="nsf-toolbar__address nsf-sunken">{pathStr}</div>
       </div>
 
-      {/* ── Content ── */}
       <div className="nsf-content">
-        {current.children.length === 0 ? (
-          <div className="nsf-empty">This folder is empty.</div>
+        {children.length === 0 ? (
+          <div className="nsf-empty">
+            {isDumpster ? "The Recycle Bin is empty." : "This folder is empty."}
+          </div>
         ) : (
-          current.children.map((node: FsNode) => (
-            <FolderItem key={node.name} node={node} onOpen={openNode} />
+          children.map((node) => (
+            <FolderItem
+              key={node.id}
+              node={node}
+              onOpen={(n) => {
+                if (isDumpster && n.kind !== "folder") {
+                  handleDeleteSelected(n);
+                } else {
+                  openNode(n);
+                }
+              }}
+            />
           ))
         )}
       </div>
 
-      {/* ── Status bar ── */}
       <div className="nsf-statusbar nsf-sunken">
         {folderCount > 0
           ? `${itemCount} object${itemCount !== 1 ? "s" : ""} (${folderCount} folder${folderCount !== 1 ? "s" : ""})`

--- a/src/experiences/NsDoors97/FilesApp.tsx
+++ b/src/experiences/NsDoors97/FilesApp.tsx
@@ -151,6 +151,12 @@ export default function FilesApp({
       return;
     }
 
+    // Sound recordings — open in Sound Recorder with the specific file loaded
+    if (file.fileType === "wav" && file.appId === "sound-recorder") {
+      onOpenFSNode?.(file.id);
+      return;
+    }
+
     // Executables with an app ID
     if (file.appId) {
       if (file.appId === "tos-only") {

--- a/src/experiences/NsDoors97/FilesApp.tsx
+++ b/src/experiences/NsDoors97/FilesApp.tsx
@@ -157,6 +157,12 @@ export default function FilesApp({
       return;
     }
 
+    // PNG sprites — open in NS Art with the sprite loaded for editing
+    if (file.fileType === "png" && file.appId === "nsart") {
+      onOpenFSNode?.(file.id);
+      return;
+    }
+
     // Executables with an app ID
     if (file.appId) {
       if (file.appId === "tos-only") {

--- a/src/experiences/NsDoors97/NotebookApp.tsx
+++ b/src/experiences/NsDoors97/NotebookApp.tsx
@@ -2,71 +2,56 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useOsDialog } from "./OsDialog";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { fsStore } from "./filesystem/FileSystemStore";
 import "./NotebookApp.css";
 
 interface NotebookAppProps {
-  filePath: string;
+  fileId: string;
   fileName: string;
-  initialContent: string;
-  onFileSaved?: (filePath: string, fileName: string) => void;
+  onFileSaved?: (fileId: string, fileName: string) => void;
 }
 
-const STORAGE_PREFIX = "ns97_notebook_";
-
-function storageKey(path: string) {
-  return STORAGE_PREFIX + path;
-}
-
-export default function NotebookApp({ filePath, fileName, initialContent, onFileSaved }: NotebookAppProps) {
+export default function NotebookApp({ fileId, fileName, onFileSaved }: NotebookAppProps) {
   const { showDialog } = useOsDialog();
-  const isNewFile = filePath === "(new file)";
 
-  const [content, setContent] = useState(() => {
-    if (isNewFile) return "";
-    const saved = localStorage.getItem(storageKey(filePath));
-    return saved !== null ? saved : initialContent;
-  });
+  const fsFile = fsStore.getFile(fileId);
+  const isReadOnly = fsFile?.readonly ?? false;
+  const filePath = fsStore.getPath(fileId);
 
+  const [content, setContent] = useState(() => fsStore.getFile(fileId)?.content ?? "");
   const [dirty, setDirty] = useState(false);
   const [lastSaved, setLastSaved] = useState<string | null>(null);
   const [wordWrap, setWordWrap] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Reset when a different file is opened in the same window (shouldn't normally happen,
-  // but guards against edge cases)
-  const prevPathRef = useRef(filePath);
+  // Reset when a different file is opened in the same window
+  const prevIdRef = useRef(fileId);
   useEffect(() => {
-    if (prevPathRef.current !== filePath) {
-      prevPathRef.current = filePath;
-      const saved = localStorage.getItem(storageKey(filePath));
-      setContent(saved !== null ? saved : initialContent);
+    if (prevIdRef.current !== fileId) {
+      prevIdRef.current = fileId;
+      setContent(fsStore.getFile(fileId)?.content ?? "");
       setDirty(false);
       setLastSaved(null);
     }
-  }, [filePath, initialContent]);
+  }, [fileId]);
 
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     setContent(e.target.value);
     setDirty(true);
   }
 
-  // Capture latest content via ref so save() stays stable
   const contentRef = useRef(content);
   contentRef.current = content;
 
   const save = useCallback(() => {
-    localStorage.setItem(storageKey(filePath), contentRef.current);
+    fsStore.writeFile(fileId, contentRef.current);
     setDirty(false);
-    const now = new Date();
-    setLastSaved(now.toLocaleTimeString());
+    setLastSaved(new Date().toLocaleTimeString());
     showDialog(`File saved.\n\n${fileName}`, { title: "Notebook", icon: "💾" });
-    onFileSaved?.(filePath, fileName);
-  }, [filePath, fileName, showDialog, onFileSaved]);
+    onFileSaved?.(fileId, fileName);
+  }, [fileId, fileName, showDialog, onFileSaved]);
 
   const toggleWordWrap = useCallback(() => setWordWrap((w) => !w), []);
-
-  const isReadOnly = !isNewFile && initialContent !== undefined &&
-    (filePath.includes("System\\") || filePath.includes("Drivers\\") || filePath.includes("Temp\\"));
 
   const menus = useMemo<MenuBarMenu[]>(() => [
     {
@@ -90,10 +75,7 @@ export default function NotebookApp({ filePath, fileName, initialContent, onFile
 
   return (
     <div className="nsnb-window">
-      {/* ── Path bar ── */}
       <div className="nsnb-pathbar nsnb-sunken">{filePath}</div>
-
-      {/* ── Text area ── */}
       <textarea
         ref={textareaRef}
         className={`nsnb-editor${wordWrap ? "" : " nsnb-editor--nowrap"}`}
@@ -103,8 +85,6 @@ export default function NotebookApp({ filePath, fileName, initialContent, onFile
         spellCheck={false}
         aria-label={`Editing ${fileName}`}
       />
-
-      {/* ── Status bar ── */}
       <div className="nsnb-statusbar nsnb-sunken">
         <span>{lineCount} line{lineCount !== 1 ? "s" : ""}</span>
         <span className="nsnb-statusbar__sep">|</span>

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -89,6 +89,7 @@ interface AppDef {
 
 const APP_REGISTRY: Record<string, AppDef> = {
   "my-doors":       { title: "My Doors",          icon: "🖥️", action: "files"         },
+  "files":          { title: "My Doors",          icon: "🖥️", action: "files"         },
   "dumpster":       { title: "Dumpster",           icon: "🗑️", action: "dumpster"      },
   "readme":         { title: "README.txt",         icon: "📋", action: "readme"        },
   "about":          { title: "About NS Doors 97",  icon: "ℹ️",  action: "about"         },

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -158,9 +158,9 @@ type WindowContent =
   | { type: "dumpster" }
   | { type: "notebook"; fileId: string; fileName: string }
   | { type: "desktop-display" }
-  | { type: "nsart" }
+  | { type: "nsart"; fileId?: string; fileUrl?: string }
   | { type: "nsart-backup" }
-  | { type: "sound-recorder"; fileName?: string }
+  | { type: "sound-recorder"; fileName?: string; fileId?: string; fallbackUrl?: string }
   | { type: "midi-editor" }
   | { type: "chain-reaction" }
   | { type: "peg-solitaire" };
@@ -574,9 +574,9 @@ export default function NsDoors97() {
         );
         return;
       }
-      // .wav files in the SR folder should open SR loaded with that recording
-      if (file.fileType === "wav" && file.appId === "sound-recorder") {
-        const winId = `sound-recorder:${file.name}`;
+      // .png sprite files in EGO/SPRITES open NS Art loaded with that sprite
+      if (file.fileType === "png" && file.appId === "nsart") {
+        const winId = `nsart:${file.id}`;
         setOpenWindows((prev) => {
           if (prev.some((w) => w.id === winId)) {
             maxZ++;
@@ -588,8 +588,48 @@ export default function NsDoors97() {
           maxZ++;
           setActiveWindowId(winId);
           return [...prev, {
-            id: winId, title: file.name, icon: "🎵",
-            content: { type: "sound-recorder" as const, fileName: file.name },
+            id: winId,
+            title: `NS Art — ${file.name}`,
+            icon: "🎨",
+            content: {
+              type: "nsart" as const,
+              fileId: file.id,
+              fileUrl: `/sprites/${file.name}`,
+            },
+            zIndex: maxZ,
+            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            width: 760, minimized: false,
+          }];
+        });
+        return;
+      }
+      // .wav files open Sound Recorder; EGO/SOUNDS files pass fileId + fallbackUrl
+      if (file.fileType === "wav" && file.appId === "sound-recorder") {
+        const filePath = fsStore.getPath(file.id);
+        const isEgoSound = filePath.toUpperCase().startsWith("C:\\EGO\\");
+        const winId = `sound-recorder:${file.id}`;
+        setOpenWindows((prev) => {
+          if (prev.some((w) => w.id === winId)) {
+            maxZ++;
+            setActiveWindowId(winId);
+            return prev.map((w) => (w.id === winId ? { ...w, zIndex: maxZ } : w));
+          }
+          const offset = (windowSeq % 8) * 32;
+          windowSeq++;
+          maxZ++;
+          setActiveWindowId(winId);
+          return [...prev, {
+            id: winId,
+            title: isEgoSound ? `Sound Recorder — ${file.name}` : file.name,
+            icon: "🎵",
+            content: {
+              type: "sound-recorder" as const,
+              fileName: file.name,
+              ...(isEgoSound ? {
+                fileId: file.id,
+                fallbackUrl: `/sounds/${file.name}`,
+              } : {}),
+            },
             zIndex: maxZ,
             defaultPosition: { x: 80 + offset, y: 48 + offset },
             width: 420, minimized: false,
@@ -840,7 +880,12 @@ export default function NsDoors97() {
             />
           )}
           {win.content.type === "nsart" && (
-            <NsArt ref={nsArtRef} onBackupSaved={() => {}} />
+            <NsArt
+              ref={nsArtRef}
+              onBackupSaved={() => {}}
+              fileId={win.content.fileId}
+              fileUrl={win.content.fileUrl}
+            />
           )}
           {win.content.type === "nsart-backup" && (
             <NsArt ref={nsArtRef} onBackupSaved={() => {}} />
@@ -930,6 +975,8 @@ export default function NsDoors97() {
           {win.content.type === "sound-recorder" && (
             <SoundRecorder
               fileName={win.content.fileName}
+              fileId={win.content.fileId}
+              fallbackUrl={win.content.fallbackUrl}
               onQuit={() => closeWindow(win.id)}
               onFileSaved={handleSoundFileSaved}
             />

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -27,7 +27,7 @@ import TicTacToe from "../TicTacToe/TicTacToe";
 import Pool from "../Pool/Pool";
 import DuckHunt from "../DuckHunt/DuckHunt";
 import NumberMuncher from "../NumberMuncher/NumberMuncher";
-import SoundRecorder, { lsGetSoundNames } from "./SoundRecorder";
+import SoundRecorder from "./SoundRecorder";
 import MidiEditor from "../MidiEditor/MidiEditor";
 import ChainReaction from "../ChainReaction/ChainReaction";
 import PegSolitaire from "../PegSolitaire/PegSolitaire";
@@ -45,6 +45,12 @@ import {
   getDesktopBackground,
   type DesktopSettings,
 } from "./desktopSettings";
+import { useFS } from "./filesystem/FSContext";
+import { fsStore } from "./filesystem/FileSystemStore";
+import {
+  DESKTOP_ID, DUMPSTER_ID, DOCUMENTS_ID,
+  getNodeIcon, type FSNode,
+} from "./filesystem/types";
 import "./NsDoors97.css";
 
 // ── App registry ───────────────────────────────────────────────────────────────
@@ -65,6 +71,7 @@ type AppAction =
   | "about"
   | "internet"
   | "files"
+  | "dumpster"
   | "notebook"
   | "nsart"
   | "art-backup"
@@ -82,7 +89,7 @@ interface AppDef {
 
 const APP_REGISTRY: Record<string, AppDef> = {
   "my-doors":       { title: "My Doors",          icon: "🖥️", action: "files"         },
-  "dumpster":       { title: "Dumpster",           icon: "🗑️", action: "placeholder"   },
+  "dumpster":       { title: "Dumpster",           icon: "🗑️", action: "dumpster"      },
   "readme":         { title: "README.txt",         icon: "📋", action: "readme"        },
   "about":          { title: "About NS Doors 97",  icon: "ℹ️",  action: "about"         },
   "internet":       { title: "Internet",           icon: "🌐", action: "internet"      },
@@ -104,73 +111,31 @@ const APP_REGISTRY: Record<string, AppDef> = {
   "peg-solitaire":  { title: "Peg Solitaire",       icon: "🔴", action: "peg-solitaire"   },
 };
 
-// ── Desktop icon entries (subset actually shown on desktop) ───────────────────
+// ── Desktop icon helpers ───────────────────────────────────────────────────────
 
-interface DesktopIconEntry {
-  id: string;
-  title: string;
-  icon: string;
-}
+// Map app IDs to their display icons for desktop shortcuts
+const APP_ICON_MAP: Record<string, string> = {
+  "files":          "🖥️",
+  "dumpster":       "🗑️",
+  "notebook":       "📝",
+  "nsart":          "🎨",
+  "sound-recorder": "🎵",
+  "internet":       "🌐",
+  "about":          "ℹ️",
+  "screensavers":   "💤",
+  "midi-editor":    "🎹",
+};
 
-const STATIC_DESKTOP_ICONS: DesktopIconEntry[] = [
-  { id: "my-doors",  title: "My Doors",  icon: "🖥️" },
-  { id: "dumpster",  title: "Dumpster",  icon: "🗑️" },
-];
-
-const STATIC_RIGHT_ICONS: DesktopIconEntry[] = [
-  { id: "readme", title: "README.txt", icon: "📋" },
-];
-
-const DESKTOP_README = `IMPORTANT NOTE TO MYSELF
-=========================
-
-To play HELL.EXE you can NOT just
-double-click it. I know. I tried.
-It gives you a whole lecture.
-
-You have to go through the TOS
-(the scary black text screen).
-
-HOW TO DO IT (I keep forgetting):
-
-  1. Click Start
-  2. Programs
-  3. NS-TOS
-  4. Type this exactly:
-       cd Programs\\Games
-       HELL.EXE
-  5. Press Enter. That's it!!
-
-Gerald says I "should not have
-that game installed." Gerald has
-never beaten level 3. I have.
-
-DO NOT tell Gerald.
-
-                        - Noah
-
-P.S. If you get stuck in the text
-screen just type DOORS to come back.
-`;
-
-const NB_PREFIX = "ns97_notebook_";
-const README_PATH = "C:\\Desktop\\README.txt";
-
-function loadSavedNotebookIcons(): DesktopIconEntry[] {
-  const entries: DesktopIconEntry[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (!key || !key.startsWith(NB_PREFIX)) continue;
-    const filePath = key.slice(NB_PREFIX.length);
-    if (filePath === "(new file)" || filePath === README_PATH) continue;
-    const fileName = filePath.split(/[/\\]/).pop() || filePath;
-    entries.push({ id: `nb:${filePath}`, title: fileName, icon: "📝" });
+function desktopNodeIcon(node: FSNode): string {
+  if (node.kind === "shortcut") {
+    if (node.targetAppId) return APP_ICON_MAP[node.targetAppId] ?? "🔗";
+    if (node.targetFilePath) {
+      const target = fsStore.getNodeByPath(node.targetFilePath);
+      return target ? getNodeIcon(target) : "📄";
+    }
+    return "🔗";
   }
-  return entries;
-}
-
-function loadSavedSoundIcons(): DesktopIconEntry[] {
-  return lsGetSoundNames().map(name => ({ id: `sound:${name}`, title: name, icon: "🎵" }));
+  return getNodeIcon(node);
 }
 
 // ── Window content union ───────────────────────────────────────────────────
@@ -190,7 +155,8 @@ type WindowContent =
   | { type: "about" }
   | { type: "internet" }
   | { type: "files" }
-  | { type: "notebook"; filePath: string; fileName: string; initialContent: string }
+  | { type: "dumpster" }
+  | { type: "notebook"; fileId: string; fileName: string }
   | { type: "desktop-display" }
   | { type: "nsart" }
   | { type: "nsart-backup" }
@@ -264,36 +230,39 @@ export default function NsDoors97() {
   const skipBoot = (location.state as { skipBoot?: boolean } | null)?.skipBoot === true;
   const initialShouldBoot = !skipBoot && (fromTos || shouldShowBoot());
 
-  const nsArtRef       = useRef<NsArtHandle>(null);
+  const nsArtRef = useRef<NsArtHandle>(null);
+  const store = useFS();
 
   const [showBoot, setShowBoot]             = useState(initialShouldBoot);
   const [shuttingDown, setShuttingDown]     = useState(false);
   const [desktopLoading, setDesktopLoading] = useState(false);
 
-  // Saved notebook files that appear on the desktop
-  const [savedNotebookIcons, setSavedNotebookIcons] = useState<DesktopIconEntry[]>(
-    () => loadSavedNotebookIcons()
-  );
-  const savedNotebookIconsRef = useRef(savedNotebookIcons);
-  useEffect(() => { savedNotebookIconsRef.current = savedNotebookIcons; }, [savedNotebookIcons]);
-
-  // Saved sound files that appear on the desktop
-  const [savedSoundIcons, setSavedSoundIcons] = useState<DesktopIconEntry[]>(
-    () => loadSavedSoundIcons()
-  );
-  const savedSoundIconsRef = useRef(savedSoundIcons);
-  useEffect(() => { savedSoundIconsRef.current = savedSoundIcons; }, [savedSoundIcons]);
+  // Desktop folder contents from the FS (reactive — re-reads on any FS change)
+  const desktopNodes = store.getChildren(DESKTOP_ID);
+  const leftDesktopNodes  = desktopNodes.filter((n) => n.system);
+  const rightDesktopNodes = desktopNodes.filter((n) => !n.system);
 
   // Icons start empty whenever there's a boot screen; all-visible otherwise.
   const [visibleIcons, setVisibleIcons] = useState<ReadonlySet<string>>(() => {
     if (initialShouldBoot) return new Set<string>();
-    return new Set<string>([
-      ...STATIC_DESKTOP_ICONS.map((d) => d.id),
-      ...STATIC_RIGHT_ICONS.map((d) => d.id),
-      ...loadSavedNotebookIcons().map((d) => d.id),
-      ...loadSavedSoundIcons().map((d) => d.id),
-    ]);
+    return new Set<string>(store.getChildren(DESKTOP_ID).map((n) => n.id));
   });
+
+  // When the FS changes and new desktop icons appear (after boot), make them visible
+  useEffect(() => {
+    if (!desktopLoading && !showBoot) {
+      setVisibleIcons((prev) => {
+        const allIds = store.getChildren(DESKTOP_ID).map((n) => n.id);
+        const next = new Set<string>(prev);
+        let changed = false;
+        for (const id of allIds) {
+          if (!next.has(id)) { next.add(id); changed = true; }
+        }
+        return changed ? next : prev;
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [desktopNodes, desktopLoading, showBoot]);
 
   // Called when the boot screen finishes (both initial boot and after restart)
   const handleBootComplete = useCallback(() => {
@@ -334,12 +303,7 @@ export default function NsDoors97() {
       document.body.style.cursor = "";
 
       // Phase 2 — icons pop in one by one in random order
-      const allIds = [
-        ...STATIC_DESKTOP_ICONS.map((d) => d.id),
-        ...STATIC_RIGHT_ICONS.map((d) => d.id),
-        ...savedNotebookIconsRef.current.map((d) => d.id),
-        ...savedSoundIconsRef.current.map((d) => d.id),
-      ];
+      const allIds = store.getChildren(DESKTOP_ID).map((n) => n.id);
       const shuffled = [...allIds];
       for (let i = shuffled.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -443,8 +407,8 @@ export default function NsDoors97() {
   // ── Window management ────────────────────────────────────────────────────
 
   const openNotebook = useCallback(
-    (filePath: string, fileName: string, initialContent: string) => {
-      const winId = `notebook:${filePath}`;
+    (fileId: string, fileName: string) => {
+      const winId = `notebook:${fileId}`;
       setOpenWindows((prev) => {
         if (prev.some((w) => w.id === winId)) {
           maxZ++;
@@ -461,7 +425,7 @@ export default function NsDoors97() {
             id: winId,
             title: fileName,
             icon: "📝",
-            content: { type: "notebook" as const, filePath, fileName, initialContent },
+            content: { type: "notebook" as const, fileId, fileName },
             zIndex: maxZ,
             defaultPosition: { x: 100 + offset, y: 60 + offset },
             width: 560,
@@ -474,46 +438,6 @@ export default function NsDoors97() {
   );
 
   const openWindow = useCallback((id: string) => {
-    // Sound file desktop icons use "sound:{fileName}" id format
-    if (id.startsWith("sound:")) {
-      const soundFileName = id.slice(6);
-      const winId = `sound-recorder:${soundFileName}`;
-      setOpenWindows((prev) => {
-        if (prev.some((w) => w.id === winId)) {
-          maxZ++;
-          setActiveWindowId(winId);
-          return prev.map((w) => (w.id === winId ? { ...w, zIndex: maxZ } : w));
-        }
-        const offset = (windowSeq % 8) * 32;
-        windowSeq++;
-        maxZ++;
-        setActiveWindowId(winId);
-        return [
-          ...prev,
-          {
-            id: winId,
-            title: soundFileName,
-            icon: "🎵",
-            content: { type: "sound-recorder" as const, fileName: soundFileName },
-            zIndex: maxZ,
-            defaultPosition: { x: 80 + offset, y: 48 + offset },
-            width: 420,
-            minimized: false,
-          },
-        ];
-      });
-      return;
-    }
-
-    // Notebook saved-file desktop icons use "nb:{filePath}" id format
-    if (id.startsWith("nb:")) {
-      const filePath = id.slice(3);
-      const fileName = filePath.split(/[/\\]/).pop() || filePath;
-      const savedContent = localStorage.getItem(`${NB_PREFIX}${filePath}`) ?? "";
-      openNotebook(filePath, fileName, savedContent);
-      return;
-    }
-
     const appDef = APP_REGISTRY[id];
     if (!appDef) return;
 
@@ -538,26 +462,35 @@ export default function NsDoors97() {
       let width: number | undefined;
 
       switch (appDef.action) {
-        case "screensavers": content = { type: "screensaver-settings" }; width = 440; break;
-        case "about":        content = { type: "about" };                width = 340; break;
-        case "internet":     content = { type: "internet" };             width = 640; break;
-        case "files":        content = { type: "files" };                width = 600; break;
-        case "notebook":     content = { type: "notebook", filePath: "(new file)", fileName: "Untitled.txt", initialContent: "" }; width = 560; break;
-        case "readme":       content = { type: "notebook", filePath: README_PATH, fileName: "README.txt", initialContent: DESKTOP_README }; width = 420; break;
-        case "nsart":        content = { type: "nsart" };                width = 760; break;
-        case "art-backup":   content = { type: "nsart-backup" };         width = 760; break;
-        case "pool":         content = { type: "pool" };                 width = 800; break;
-        case "tictactoe":    content = { type: "tictactoe" };            width = TTT_WINDOW_WIDTHS[3]; break;
-        case "nomnom":       content = { type: "nomnom" };               width = 700; break;
-        case "wordwhirlwind":content = { type: "word-whirlwind" };       width = 600; break;
-        case "words":        content = { type: "words" };                width = 440; break;
-        case "bombfinder":   content = { type: "bombfinder" };           width = BF_WINDOW_WIDTHS.beginner; break;
-        case "duckhunt":     content = { type: "duckhunt" };             width = 740; break;
-        case "cards":          content = { type: "cards-launcher" };                           width = 320; break;
-        case "sound-recorder": content = { type: "sound-recorder" as const };                  width = 420; break;
-        case "midi-editor":    content = { type: "midi-editor" as const };                     width = 860; break;
-        case "chain-reaction": content = { type: "chain-reaction" as const };                  width = 540; break;
-        case "peg-solitaire":  content = { type: "peg-solitaire" as const };                   width = 580; break;
+        case "screensavers": content = { type: "screensaver-settings" };      width = 440; break;
+        case "about":        content = { type: "about" };                     width = 340; break;
+        case "internet":     content = { type: "internet" };                  width = 640; break;
+        case "files":        content = { type: "files" };                     width = 600; break;
+        case "dumpster":     content = { type: "dumpster" };                  width = 560; break;
+        case "notebook": {
+          // Create a new file in Documents for this session
+          const newFile = fsStore.createFile(DOCUMENTS_ID, "Untitled.txt", {
+            fileType: "text", content: "",
+          });
+          content = { type: "notebook", fileId: newFile.id, fileName: "Untitled.txt" };
+          width = 560;
+          break;
+        }
+        case "readme":       openNotebook("fs:desktop-readme", "README.txt"); return prev;
+        case "nsart":        content = { type: "nsart" };                     width = 760; break;
+        case "art-backup":   content = { type: "nsart-backup" };              width = 760; break;
+        case "pool":         content = { type: "pool" };                      width = 800; break;
+        case "tictactoe":    content = { type: "tictactoe" };                 width = TTT_WINDOW_WIDTHS[3]; break;
+        case "nomnom":       content = { type: "nomnom" };                    width = 700; break;
+        case "wordwhirlwind":content = { type: "word-whirlwind" };            width = 600; break;
+        case "words":        content = { type: "words" };                     width = 440; break;
+        case "bombfinder":   content = { type: "bombfinder" };                width = BF_WINDOW_WIDTHS.beginner; break;
+        case "duckhunt":     content = { type: "duckhunt" };                  width = 740; break;
+        case "cards":          content = { type: "cards-launcher" };          width = 320; break;
+        case "sound-recorder": content = { type: "sound-recorder" as const }; width = 420; break;
+        case "midi-editor":    content = { type: "midi-editor" as const };    width = 860; break;
+        case "chain-reaction": content = { type: "chain-reaction" as const }; width = 540; break;
+        case "peg-solitaire":  content = { type: "peg-solitaire" as const };  width = 580; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -582,6 +515,77 @@ export default function NsDoors97() {
       ];
     });
   }, [showDialog, openNotebook]);
+
+  // Open any node from the virtual filesystem (desktop double-click, FilesApp, etc.)
+  const openFSNode = useCallback((nodeId: string) => {
+    const node = store.getNode(nodeId);
+    if (!node) return;
+
+    if (node.kind === "shortcut") {
+      if (node.targetAppId === "sound-recorder" && node.targetFilePath) {
+        // Open SoundRecorder with this specific saved recording
+        const winId = `sound-recorder:${node.targetFilePath}`;
+        setOpenWindows((prev) => {
+          if (prev.some((w) => w.id === winId)) {
+            maxZ++;
+            setActiveWindowId(winId);
+            return prev.map((w) => (w.id === winId ? { ...w, zIndex: maxZ } : w));
+          }
+          const offset = (windowSeq % 8) * 32;
+          windowSeq++;
+          maxZ++;
+          setActiveWindowId(winId);
+          return [...prev, {
+            id: winId, title: node.targetFilePath!, icon: "🎵",
+            content: { type: "sound-recorder" as const, fileName: node.targetFilePath },
+            zIndex: maxZ,
+            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            width: 420, minimized: false,
+          }];
+        });
+        return;
+      }
+      if (node.targetAppId) { openWindow(node.targetAppId); return; }
+      if (node.targetFilePath) {
+        const target = store.getNodeByPath(node.targetFilePath);
+        if (target) openFSNode(target.id);
+      }
+      return;
+    }
+
+    if (node.kind === "folder") {
+      // Open My Doors at this folder — for now just open the default files browser
+      openWindow("files");
+      return;
+    }
+
+    // File node
+    const file = node;
+    const textLike = ["text", "bat", "sys", "ini"] as const;
+    if ((textLike as readonly string[]).includes(file.fileType) || file.content) {
+      openNotebook(file.id, file.name);
+      return;
+    }
+    if (file.appId) {
+      if (file.appId === "tos-only") {
+        showDialog(
+          "HELL.EXE must be launched from NS-TOS.\n\nOpen NS-TOS and type:\n  cd EGO\n  HELL.EXE",
+          { title: "Cannot Run Program", icon: "⛔" }
+        );
+        return;
+      }
+      openWindow(file.appId);
+      return;
+    }
+    const ext = file.name.split(".").pop()?.toUpperCase() ?? "";
+    if (file.fileType === "tmp") {
+      showDialog("This temporary file is damaged and cannot be opened.", { title: "Error", icon: "❌" });
+    } else if (["zip", "bmp", "png", "wav"].includes(file.fileType)) {
+      showDialog(`Cannot open .${ext} files.\nYou need an additional program to view this file type.`, { title: "Open Error", icon: "⚠️" });
+    } else {
+      showDialog(`${file.name} is not a valid NS Doors application.\n\nError code: 0xC0000034`, { title: "Program Error", icon: "❌" });
+    }
+  }, [store, openWindow, openNotebook, showDialog]);
 
   const openAbout = useCallback(() => {
     openWindow("about");
@@ -612,25 +616,31 @@ export default function NsDoors97() {
     setActiveWindowId((cur) => (cur === id ? null : cur));
   }, []);
 
-  // When Notebook saves a file, add it to the desktop if not already there
-  const handleNotebookFileSaved = useCallback((filePath: string, fileName: string) => {
-    if (filePath === "(new file)" || filePath === README_PATH) return;
-    const newId = `nb:${filePath}`;
-    setSavedNotebookIcons((prev) => {
-      if (prev.some((d) => d.id === newId)) return prev;
-      return [...prev, { id: newId, title: fileName, icon: "📝" }];
-    });
-    setVisibleIcons((prev) => new Set<string>([...prev, newId]));
+  // When Notebook saves a file, add a desktop shortcut if not already there
+  const handleNotebookFileSaved = useCallback((fileId: string, fileName: string) => {
+    const filePath = fsStore.getPath(fileId);
+    // Don't add a desktop icon for the README (it's already there)
+    if (fileId === "fs:desktop-readme") return;
+    // Check if a shortcut already exists
+    const existing = fsStore.getChildren(DESKTOP_ID).find(
+      (n) => n.kind === "shortcut" && (n as { targetFilePath?: string }).targetFilePath === filePath
+    );
+    if (!existing) {
+      fsStore.createShortcut(DESKTOP_ID, fileName, { targetFilePath: filePath });
+    }
   }, []);
 
-  // Called by SoundRecorder when a file is saved — add its icon to the desktop
+  // Called by SoundRecorder when a file is saved — add a desktop shortcut
   const handleSoundFileSaved = useCallback((name: string) => {
-    const newId = `sound:${name}`;
-    setSavedSoundIcons((prev) => {
-      if (prev.some((d) => d.id === newId)) return prev;
-      return [...prev, { id: newId, title: name, icon: "🎵" }];
-    });
-    setVisibleIcons((prev) => new Set<string>([...prev, newId]));
+    const existing = fsStore.getChildren(DESKTOP_ID).find(
+      (n) => n.kind === "shortcut" && n.name === name && (n as { targetAppId?: string }).targetAppId === "sound-recorder"
+    );
+    if (!existing) {
+      fsStore.createShortcut(DESKTOP_ID, name, {
+        targetAppId: "sound-recorder",
+        targetFilePath: name,
+      });
+    }
   }, []);
 
   // Called by TicTacToe when board size changes — resize the window
@@ -726,36 +736,36 @@ export default function NsDoors97() {
     return { background: getDesktopBackground(desktopSettings) };
   })();
 
-  const rightIcons = [...STATIC_RIGHT_ICONS, ...savedNotebookIcons, ...savedSoundIcons];
-
   return (
     <div className="ns-desktop" style={desktopStyle}>
-      {/* ── Icon grid (icons pop in one by one during boot) ── */}
+      {/* ── Left icon column: system shortcuts (My Doors, Dumpster) ── */}
       <div className="ns-desktop__icons">
-        {STATIC_DESKTOP_ICONS
-          .filter((def) => visibleIcons.has(def.id))
-          .map((def) => (
+        {leftDesktopNodes
+          .filter((n) => visibleIcons.has(n.id))
+          .map((n) => (
             <DesktopIcon
-              key={def.id}
-              id={def.id}
-              title={def.title}
-              icon={def.icon}
-              onOpen={openWindow}
+              key={n.id}
+              id={n.id}
+              title={n.name}
+              icon={desktopNodeIcon(n)}
+              onOpen={openFSNode}
             />
           ))}
       </div>
 
-      {/* ── Right-side pinned icons (README, saved notebook files) ── */}
+      {/* ── Right icon column: user files, README, saved shortcuts ── */}
       <div className="ns-desktop__icons-right">
-        {rightIcons.filter((def) => visibleIcons.has(def.id)).map((def) => (
-          <DesktopIcon
-            key={def.id}
-            id={def.id}
-            title={def.title}
-            icon={def.icon}
-            onOpen={openWindow as (id: string) => void}
-          />
-        ))}
+        {rightDesktopNodes
+          .filter((n) => visibleIcons.has(n.id))
+          .map((n) => (
+            <DesktopIcon
+              key={n.id}
+              id={n.id}
+              title={n.name}
+              icon={desktopNodeIcon(n)}
+              onOpen={openFSNode}
+            />
+          ))}
       </div>
 
       {/* ── Branding watermark ── */}
@@ -873,14 +883,24 @@ export default function NsDoors97() {
             <FilesApp
               onOpenApp={openWindow}
               onOpenNotebook={openNotebook}
+              onOpenFSNode={openFSNode}
+              onQuit={() => closeWindow(win.id)}
+            />
+          )}
+          {win.content.type === "dumpster" && (
+            <FilesApp
+              startFolderId={DUMPSTER_ID}
+              isDumpster={true}
+              onOpenApp={openWindow}
+              onOpenNotebook={openNotebook}
+              onOpenFSNode={openFSNode}
               onQuit={() => closeWindow(win.id)}
             />
           )}
           {win.content.type === "notebook" && (
             <NotebookApp
-              filePath={win.content.filePath}
+              fileId={win.content.fileId}
               fileName={win.content.fileName}
-              initialContent={win.content.initialContent}
               onFileSaved={handleNotebookFileSaved}
             />
           )}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -574,6 +574,29 @@ export default function NsDoors97() {
         );
         return;
       }
+      // .wav files in the SR folder should open SR loaded with that recording
+      if (file.fileType === "wav" && file.appId === "sound-recorder") {
+        const winId = `sound-recorder:${file.name}`;
+        setOpenWindows((prev) => {
+          if (prev.some((w) => w.id === winId)) {
+            maxZ++;
+            setActiveWindowId(winId);
+            return prev.map((w) => (w.id === winId ? { ...w, zIndex: maxZ } : w));
+          }
+          const offset = (windowSeq % 8) * 32;
+          windowSeq++;
+          maxZ++;
+          setActiveWindowId(winId);
+          return [...prev, {
+            id: winId, title: file.name, icon: "🎵",
+            content: { type: "sound-recorder" as const, fileName: file.name },
+            zIndex: maxZ,
+            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            width: 420, minimized: false,
+          }];
+        });
+        return;
+      }
       openWindow(file.appId);
       return;
     }

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -563,7 +563,9 @@ export default function NsDoors97() {
     // File node
     const file = node;
     const textLike = ["text", "bat", "sys", "ini"] as const;
-    if ((textLike as readonly string[]).includes(file.fileType) || file.content) {
+    // Only open in Notebook if the file is text-like OR has content and no app to handle it.
+    // Files with appId must reach their own handler even after content has been written.
+    if ((textLike as readonly string[]).includes(file.fileType) || (!file.appId && file.content)) {
       openNotebook(file.id, file.name);
       return;
     }

--- a/src/experiences/NsDoors97/OsDialog.tsx
+++ b/src/experiences/NsDoors97/OsDialog.tsx
@@ -9,14 +9,23 @@ import "./OsDialog.css";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+interface DialogOptions {
+  title?: string;
+  icon?: string;
+  buttons?: string[];
+  onButton?: (btn: string) => void;
+}
+
 interface DialogState {
   title: string;
   message: string;
   icon: string;
+  buttons: string[];
+  onButton?: (btn: string) => void;
 }
 
 interface OsDialogContextValue {
-  showDialog: (message: string, opts?: { title?: string; icon?: string }) => void;
+  showDialog: (message: string, opts?: DialogOptions) => void;
 }
 
 // ── Context ───────────────────────────────────────────────────────────────────
@@ -35,10 +44,17 @@ function OsDialog({
   title,
   message,
   icon,
+  buttons,
+  onButton,
   onClose,
 }: DialogState & { onClose: () => void }) {
+  function handleButton(btn: string) {
+    onButton?.(btn);
+    onClose();
+  }
+
   return (
-    <div className="ns-dialog-overlay" onClick={onClose}>
+    <div className="ns-dialog-overlay" onClick={() => handleButton(buttons[0])}>
       <div
         className="ns-dialog"
         onClick={(e) => e.stopPropagation()}
@@ -55,7 +71,7 @@ function OsDialog({
           </span>
           <button
             className="ns-dialog__titlebar-close"
-            onClick={onClose}
+            onClick={() => handleButton(buttons[0])}
             aria-label="Close"
           >
             ✕
@@ -74,9 +90,16 @@ function OsDialog({
 
         {/* Footer */}
         <div className="ns-dialog__footer">
-          <button className="ns-dialog__ok" onClick={onClose} autoFocus>
-            OK
-          </button>
+          {buttons.map((btn, i) => (
+            <button
+              key={btn}
+              className="ns-dialog__ok"
+              onClick={() => handleButton(btn)}
+              autoFocus={i === 0}
+            >
+              {btn}
+            </button>
+          ))}
         </div>
       </div>
     </div>
@@ -89,11 +112,13 @@ export function OsDialogProvider({ children }: { children: ReactNode }) {
   const [dialog, setDialog] = useState<DialogState | null>(null);
 
   const showDialog = useCallback(
-    (message: string, opts?: { title?: string; icon?: string }) => {
+    (message: string, opts?: DialogOptions) => {
       setDialog({
-        title: opts?.title ?? "NS Doors 97",
+        title:    opts?.title    ?? "NS Doors 97",
         message,
-        icon: opts?.icon ?? "⚠️",
+        icon:     opts?.icon     ?? "⚠️",
+        buttons:  opts?.buttons  ?? ["OK"],
+        onButton: opts?.onButton,
       });
     },
     []
@@ -107,6 +132,8 @@ export function OsDialogProvider({ children }: { children: ReactNode }) {
           title={dialog.title}
           message={dialog.message}
           icon={dialog.icon}
+          buttons={dialog.buttons}
+          onButton={dialog.onButton}
           onClose={() => setDialog(null)}
         />
       )}

--- a/src/experiences/NsDoors97/SoundRecorder.tsx
+++ b/src/experiences/NsDoors97/SoundRecorder.tsx
@@ -201,12 +201,16 @@ function fmtTime(samplePos: number, sr: number): string {
 
 export interface SoundRecorderProps {
   fileName?: string;
+  fileId?: string;       // FS file to write WAV data URL to when saving (for EGO/SOUNDS)
+  fallbackUrl?: string;  // fetch from here if IDB has no audio (for bundled game sounds)
   onQuit?: () => void;
   onFileSaved?: (name: string) => void;
 }
 
 export default function SoundRecorder({
   fileName: initFileName,
+  fileId: initFileId,
+  fallbackUrl: initFallbackUrl,
   onQuit,
   onFileSaved,
 }: SoundRecorderProps = {}) {
@@ -239,6 +243,7 @@ export default function SoundRecorder({
   const fwdTimerRef    = useRef<ReturnType<typeof setInterval> | null>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
   const fileNameRef    = useRef<string>(initFileName ?? "Untitled.wav");
+  const fileIdRef      = useRef<string | undefined>(initFileId);
 
   // ── React state (only for UI rendering) ──────────────────────────────────
   const [isPlaying,   setIsPlaying]   = useState(false);
@@ -393,14 +398,37 @@ export default function SoundRecorder({
 
   useEffect(() => {
     if (initFileName) {
-      // Opening a saved file — load it directly, ignore any draft
+      // Opening a saved file — try IDB first, then fall back to bundled URL
       idbLoad(initFileName).then(result => {
-        if (!result) return;
-        samplesRef.current = result.samples;
-        srRef.current = result.sr;
-        playheadRef.current = 0;
-        setHasSamples(true);
-        setStatusMsg("File loaded");
+        if (result) {
+          samplesRef.current = result.samples;
+          srRef.current = result.sr;
+          playheadRef.current = 0;
+          setHasSamples(true);
+          setStatusMsg("File loaded");
+        } else if (initFallbackUrl) {
+          // Not in IDB yet — load from the bundled game asset
+          fetch(initFallbackUrl)
+            .then(r => r.arrayBuffer())
+            .then(buf => ensureCtx().decodeAudioData(buf))
+            .then(decoded => {
+              const mono = new Float32Array(decoded.length);
+              for (let ch = 0; ch < decoded.numberOfChannels; ch++) {
+                const d = decoded.getChannelData(ch);
+                for (let i = 0; i < decoded.length; i++) mono[i] += d[i];
+              }
+              if (decoded.numberOfChannels > 1) {
+                for (let i = 0; i < mono.length; i++) mono[i] /= decoded.numberOfChannels;
+              }
+              samplesRef.current = mono;
+              srRef.current = decoded.sampleRate;
+              playheadRef.current = 0;
+              setHasSamples(true);
+              setStatusMsg("File loaded");
+              drawCanvas();
+            })
+            .catch(() => setStatusMsg("Could not load file"));
+        }
       }).catch(() => setStatusMsg("Could not load file"));
     } else {
       // Fresh session — check for an auto-saved draft
@@ -662,17 +690,30 @@ export default function SoundRecorder({
     const saveName = name.endsWith(".wav") ? name : `${name}.wav`;
     setShowSaveDlg(false);
     idbSave(saveName, samplesRef.current, srRef.current).then(() => {
-      // Register a metadata node in the FS so the file appears in the browser
-      const soundDirId = getSoundDirId();
-      if (soundDirId) {
-        fsStore.ensureFile(soundDirId, saveName, { fileType: "wav", appId: "sound-recorder" });
+      if (fileIdRef.current) {
+        // Saving a game asset override — write WAV data URL to the FS file
+        const wavBuf = encodeWav(samplesRef.current, srRef.current);
+        const uint8 = new Uint8Array(wavBuf);
+        let binary = "";
+        for (let i = 0; i < uint8.length; i++) binary += String.fromCharCode(uint8[i]);
+        fsStore.writeFile(fileIdRef.current, `data:audio/wav;base64,${btoa(binary)}`);
+        setFileName(saveName);
+        fileNameRef.current = saveName;
+        setStatusMsg("Saved to system");
+        clearDraft().catch(() => {});
+      } else {
+        // Normal save to Sound Recorder library
+        const soundDirId = getSoundDirId();
+        if (soundDirId) {
+          fsStore.ensureFile(soundDirId, saveName, { fileType: "wav", appId: "sound-recorder" });
+        }
+        setFileName(saveName);
+        fileNameRef.current = saveName;
+        setStatusMsg("Saved");
+        onFileSaved?.(saveName);
+        downloadWav(encodeWav(samplesRef.current, srRef.current), saveName);
+        clearDraft().catch(() => {});
       }
-      setFileName(saveName);
-      fileNameRef.current = saveName;
-      setStatusMsg("Saved");
-      onFileSaved?.(saveName);
-      downloadWav(encodeWav(samplesRef.current, srRef.current), saveName);
-      clearDraft().catch(() => {});
     }).catch(() => setStatusMsg("Error saving"));
   }
 

--- a/src/experiences/NsDoors97/SoundRecorder.tsx
+++ b/src/experiences/NsDoors97/SoundRecorder.tsx
@@ -1,7 +1,14 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
 import "./SoundRecorder.css";
+
+// Find Sound Recorder's FS folder by its known path
+function getSoundDirId(): string | undefined {
+  const node = fsStore.getNodeByPath("C:\\Programs\\Accessories\\Sound Recorder");
+  return node?.kind === "folder" ? node.id : undefined;
+}
 
 // ── IndexedDB helpers ──────────────────────────────────────────────────────────
 
@@ -82,22 +89,6 @@ function draftTimestamp(): string {
   if (!raw) return "unknown time";
   const d = new Date(parseInt(raw, 10));
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-// ── localStorage: saved sound file names (for desktop icons) ──────────────────
-
-const LS_SOUNDS = "ns97_sound_names";
-
-export function lsGetSoundNames(): string[] {
-  try { return JSON.parse(localStorage.getItem(LS_SOUNDS) ?? "[]") as string[]; }
-  catch { return []; }
-}
-
-function lsAddSoundName(name: string): void {
-  const names = lsGetSoundNames();
-  if (!names.includes(name)) {
-    localStorage.setItem(LS_SOUNDS, JSON.stringify([...names, name]));
-  }
 }
 
 // ── WAV export: 8-bit, 8 kHz, mono (authentic lo-fi) ─────────────────────────
@@ -590,10 +581,21 @@ export default function SoundRecorder({
   }
 
   function handleOpenFile() {
-    idbListNames().then(names => {
-      setOpenDlgFiles(names);
+    const soundDirId = getSoundDirId();
+    if (soundDirId) {
+      // List .wav files registered in the FS
+      const wavNames = fsStore.getChildren(soundDirId)
+        .filter((n) => n.kind === "file" && (n as { fileType: string }).fileType === "wav")
+        .map((n) => n.name);
+      setOpenDlgFiles(wavNames);
       setShowOpenDlg(true);
-    }).catch(() => setStatusMsg("Error reading saved files"));
+    } else {
+      // Fallback: query IDB directly (no FS folder found)
+      idbListNames().then(names => {
+        setOpenDlgFiles(names.filter(n => !n.startsWith("__")));
+        setShowOpenDlg(true);
+      }).catch(() => setStatusMsg("Error reading saved files"));
+    }
   }
 
   function handleOpenFileSelect(name: string) {
@@ -660,7 +662,11 @@ export default function SoundRecorder({
     const saveName = name.endsWith(".wav") ? name : `${name}.wav`;
     setShowSaveDlg(false);
     idbSave(saveName, samplesRef.current, srRef.current).then(() => {
-      lsAddSoundName(saveName);
+      // Register a metadata node in the FS so the file appears in the browser
+      const soundDirId = getSoundDirId();
+      if (soundDirId) {
+        fsStore.ensureFile(soundDirId, saveName, { fileType: "wav", appId: "sound-recorder" });
+      }
       setFileName(saveName);
       fileNameRef.current = saveName;
       setStatusMsg("Saved");

--- a/src/experiences/NsDoors97/desktopSettings.ts
+++ b/src/experiences/NsDoors97/desktopSettings.ts
@@ -1,3 +1,7 @@
+import { fsStore } from "./filesystem/FileSystemStore";
+import { SYSTEM_INI_ID } from "./filesystem/types";
+import { parseIni, updateIniSection } from "./filesystem/ini";
+
 export type DesktopBgType    = "noahsoft" | "solid" | "wallpaper";
 export type WallpaperPreset  = "sunset" | "arch";
 export type WallpaperFit     = "cover" | "contain";
@@ -29,7 +33,34 @@ export function getDesktopBackground(settings: DesktopSettings): string {
 
 const LS_KEY = "ns-desktop-settings";
 
+function parseDesktopFromIni(content: string): DesktopSettings {
+  const ini = parseIni(content);
+  const d = ini["Desktop"] ?? {};
+  const bgType = (d["Background"] as DesktopBgType | undefined) ?? DEFAULT_DESKTOP_SETTINGS.bgType;
+  const solidColor = d["Color"] ?? DEFAULT_DESKTOP_SETTINGS.solidColor;
+  const wallpaperRaw = d["Wallpaper"] ?? "(None)";
+  const wallpaperPreset: WallpaperPreset | null =
+    wallpaperRaw === "sunset" || wallpaperRaw === "arch" ? wallpaperRaw : null;
+  const wallpaperFit = (d["WallpaperFit"] as WallpaperFit | undefined) ?? DEFAULT_DESKTOP_SETTINGS.wallpaperFit;
+  return { bgType, solidColor, wallpaperPreset, wallpaperCustomUrl: null, wallpaperFit };
+}
+
+function settingsToIniKvs(settings: DesktopSettings): Record<string, string> {
+  return {
+    Background:    settings.bgType,
+    Color:         settings.solidColor,
+    Wallpaper:     settings.wallpaperPreset ?? "(None)",
+    WallpaperFit:  settings.wallpaperFit,
+  };
+}
+
 export function loadDesktopSettings(): DesktopSettings {
+  // If system.ini has been explicitly modified by the user, it is authoritative.
+  const sysIni = fsStore.getFile(SYSTEM_INI_ID);
+  if (sysIni && sysIni.modifiedAt > sysIni.createdAt) {
+    return parseDesktopFromIni(sysIni.content);
+  }
+  // Fall back to localStorage (legacy / pre-system.ini sessions)
   try {
     const raw = localStorage.getItem(LS_KEY);
     if (!raw) return { ...DEFAULT_DESKTOP_SETTINGS };
@@ -47,13 +78,15 @@ export function loadDesktopSettings(): DesktopSettings {
 }
 
 export function saveDesktopSettings(settings: DesktopSettings): void {
+  // Write to system.ini so users can see and edit their settings there
+  const sysIni = fsStore.getFile(SYSTEM_INI_ID);
+  if (sysIni) {
+    const updated = updateIniSection(sysIni.content, "Desktop", settingsToIniKvs(settings));
+    fsStore.writeFile(SYSTEM_INI_ID, updated);
+  }
+  // Also keep localStorage for any code that hasn't migrated yet
   try {
-    // Don't persist large custom data URLs — they'd eat localStorage quota.
-    // We keep them in React state only for the current session.
-    const toSave: DesktopSettings = {
-      ...settings,
-      wallpaperCustomUrl: null,
-    };
+    const toSave: DesktopSettings = { ...settings, wallpaperCustomUrl: null };
     localStorage.setItem(LS_KEY, JSON.stringify(toSave));
   } catch {}
 }

--- a/src/experiences/NsDoors97/filesystem/FSContext.tsx
+++ b/src/experiences/NsDoors97/filesystem/FSContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, useEffect, useReducer, type ReactNode } from "react";
+import { fsStore, type FileSystemStore } from "./FileSystemStore";
+
+const FSContext = createContext<FileSystemStore | null>(null);
+
+export function FSProvider({ children }: { children: ReactNode }) {
+  const [, rerender] = useReducer((n: number) => n + 1, 0);
+
+  useEffect(() => fsStore.subscribe(rerender), []);
+
+  return <FSContext.Provider value={fsStore}>{children}</FSContext.Provider>;
+}
+
+export function useFS(): FileSystemStore {
+  const store = useContext(FSContext);
+  if (!store) throw new Error("useFS must be used within FSProvider");
+  return store;
+}

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -446,15 +446,19 @@ export class FileSystemStore {
           changed = true;
         }
       }
-      // Add PNG stubs that don't exist yet
+      // Add PNG stubs that don't exist yet; update existing ones to have appId
       for (const name of spriteNames) {
-        if (!this.findChild(spritesDir.id, name)) {
+        const existing = this.findChild(spritesDir.id, name);
+        if (existing?.kind === "file" && !existing.appId) {
+          this.nodes.set(existing.id, { ...existing, appId: "nsart" });
+          changed = true;
+        } else if (!existing) {
           const id = `fs:ego-spr-${name.replace(/\./g, "-")}`;
           this.nodes.set(id, {
             id, kind: "file", name,
             parentId: spritesDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
             fileType: "png", content: "", mimeType: "image/png",
-            system: false, readonly: false,
+            system: false, readonly: false, appId: "nsart",
           } as FSFile);
           changed = true;
         }
@@ -486,7 +490,7 @@ export class FileSystemStore {
           id: sid, kind: "file", name,
           parentId: sDirId, createdAt: Date.now(), modifiedAt: Date.now(),
           fileType: "wav", content: "", mimeType: "audio/wav",
-          system: false, readonly: false,
+          system: false, readonly: false, appId: "sound-recorder",
         } as FSFile);
       }
       changed = true;

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -1,0 +1,295 @@
+import {
+  type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
+  ROOT_ID, DUMPSTER_ID,
+} from "./types";
+import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
+import { seedFileSystem } from "./seed";
+
+const FS_KEY = "ns97_fs_v1";
+
+type Listener = () => void;
+
+function genId(): string {
+  return "fs:" + Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}
+
+export class FileSystemStore {
+  private nodes: Map<string, FSNode> = new Map();
+  private adapter: StorageAdapter;
+  private listeners = new Set<Listener>();
+  private batching = false;
+
+  readonly rootId    = ROOT_ID;
+  readonly dumpsterId = DUMPSTER_ID;
+
+  constructor(adapter: StorageAdapter = new LocalStorageAdapter()) {
+    this.adapter = adapter;
+    this.load();
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────────────────
+
+  getNode(id: string): FSNode | undefined {
+    return this.nodes.get(id);
+  }
+
+  getFolder(id: string): FSFolder | undefined {
+    const n = this.nodes.get(id);
+    return n?.kind === "folder" ? n : undefined;
+  }
+
+  getFile(id: string): FSFile | undefined {
+    const n = this.nodes.get(id);
+    return n?.kind === "file" ? n : undefined;
+  }
+
+  getShortcut(id: string): FSShortcut | undefined {
+    const n = this.nodes.get(id);
+    return n?.kind === "shortcut" ? n : undefined;
+  }
+
+  getChildren(folderId: string): FSNode[] {
+    const results: FSNode[] = [];
+    for (const node of this.nodes.values()) {
+      if (node.parentId === folderId) results.push(node);
+    }
+    return results.sort((a, b) => {
+      if (a.kind === "folder" && b.kind !== "folder") return -1;
+      if (a.kind !== "folder" && b.kind === "folder") return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  getPath(id: string): string {
+    if (id === ROOT_ID) return "C:\\";
+    const parts: string[] = [];
+    let current: FSNode | undefined = this.nodes.get(id);
+    while (current && current.id !== ROOT_ID) {
+      parts.unshift(current.name);
+      const pid = current.parentId;
+      if (!pid || pid === ROOT_ID) break;
+      current = this.nodes.get(pid);
+    }
+    return "C:\\" + parts.join("\\");
+  }
+
+  getNodeByPath(path: string): FSNode | undefined {
+    const normalized = path.replace(/^C:\\/, "").replace(/\\$/, "");
+    if (!normalized) return this.nodes.get(ROOT_ID);
+    const parts = normalized.split("\\").filter(Boolean);
+    let currentId = ROOT_ID;
+    for (const part of parts) {
+      const match = this.getChildren(currentId).find(
+        (n) => n.name.toLowerCase() === part.toLowerCase()
+      );
+      if (!match) return undefined;
+      currentId = match.id;
+    }
+    return this.nodes.get(currentId);
+  }
+
+  findChild(folderId: string, name: string): FSNode | undefined {
+    return this.getChildren(folderId).find(
+      (n) => n.name.toLowerCase() === name.toLowerCase()
+    );
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────────────────
+
+  createFile(
+    parentId: string,
+    name: string,
+    options: {
+      content?: string;
+      mimeType?: string;
+      fileType?: FSFileType;
+      appId?: string;
+      system?: boolean;
+      readonly?: boolean;
+      id?: string;
+    } = {}
+  ): FSFile {
+    const file: FSFile = {
+      id: options.id ?? genId(),
+      kind: "file",
+      name,
+      parentId,
+      createdAt: Date.now(),
+      modifiedAt: Date.now(),
+      fileType: options.fileType ?? "text",
+      content: options.content ?? "",
+      mimeType: options.mimeType ?? "text/plain",
+      system: options.system ?? false,
+      readonly: options.readonly ?? false,
+      ...(options.appId !== undefined ? { appId: options.appId } : {}),
+    };
+    this.nodes.set(file.id, file);
+    this.flush();
+    return file;
+  }
+
+  createFolder(
+    parentId: string | null,
+    name: string,
+    options: { system?: boolean; id?: string } = {}
+  ): FSFolder {
+    const folder: FSFolder = {
+      id: options.id ?? genId(),
+      kind: "folder",
+      name,
+      parentId,
+      createdAt: Date.now(),
+      modifiedAt: Date.now(),
+      system: options.system ?? false,
+    };
+    this.nodes.set(folder.id, folder);
+    this.flush();
+    return folder;
+  }
+
+  createShortcut(
+    parentId: string,
+    name: string,
+    options: {
+      targetAppId?: string;
+      targetFilePath?: string;
+      system?: boolean;
+      id?: string;
+    } = {}
+  ): FSShortcut {
+    const shortcut: FSShortcut = {
+      id: options.id ?? genId(),
+      kind: "shortcut",
+      name,
+      parentId,
+      createdAt: Date.now(),
+      modifiedAt: Date.now(),
+      system: options.system ?? false,
+      ...(options.targetAppId    !== undefined ? { targetAppId: options.targetAppId }       : {}),
+      ...(options.targetFilePath !== undefined ? { targetFilePath: options.targetFilePath } : {}),
+    };
+    this.nodes.set(shortcut.id, shortcut);
+    this.flush();
+    return shortcut;
+  }
+
+  writeFile(id: string, content: string, mimeType?: string): void {
+    const node = this.nodes.get(id);
+    if (!node || node.kind !== "file") return;
+    this.nodes.set(id, {
+      ...node,
+      content,
+      modifiedAt: Date.now(),
+      ...(mimeType !== undefined ? { mimeType } : {}),
+    });
+    this.flush();
+  }
+
+  renameNode(id: string, newName: string): void {
+    const node = this.nodes.get(id);
+    if (!node || node.system) return;
+    this.nodes.set(id, { ...node, name: newName, modifiedAt: Date.now() } as FSNode);
+    this.flush();
+  }
+
+  moveNode(id: string, newParentId: string): void {
+    const node = this.nodes.get(id);
+    if (!node) return;
+    this.nodes.set(id, { ...node, parentId: newParentId } as FSNode);
+    this.flush();
+  }
+
+  deleteNode(id: string): void {
+    const node = this.nodes.get(id);
+    if (!node || node.system) return;
+    if (node.parentId === DUMPSTER_ID) {
+      this.permanentDelete(id);
+      return;
+    }
+    this.moveNode(id, DUMPSTER_ID);
+  }
+
+  permanentDelete(id: string): void {
+    this._deleteSubtree(id);
+    this.flush();
+  }
+
+  emptyDumpster(): void {
+    const children = this.getChildren(DUMPSTER_ID);
+    for (const child of children) {
+      this._deleteSubtree(child.id);
+    }
+    this.flush();
+  }
+
+  // ── Batching ─────────────────────────────────────────────────────────────────
+
+  batch(fn: () => void): void {
+    this.batching = true;
+    try { fn(); }
+    finally {
+      this.batching = false;
+      this.save();
+      this.emit();
+    }
+  }
+
+  // ── Events ───────────────────────────────────────────────────────────────────
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // ── Dev / testing ─────────────────────────────────────────────────────────────
+
+  reset(): void {
+    this.nodes.clear();
+    this.batch(() => seedFileSystem(this));
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────────
+
+  private _deleteSubtree(id: string): void {
+    const queue = [id];
+    while (queue.length) {
+      const current = queue.pop()!;
+      for (const child of this.getChildren(current)) {
+        queue.push(child.id);
+      }
+      this.nodes.delete(current);
+    }
+  }
+
+  private flush(): void {
+    if (!this.batching) {
+      this.save();
+      this.emit();
+    }
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+
+  private save(): void {
+    const entries = [...this.nodes.entries()];
+    this.adapter.setItem(FS_KEY, JSON.stringify(entries));
+  }
+
+  private load(): void {
+    const raw = this.adapter.getItem(FS_KEY);
+    if (raw) {
+      try {
+        const entries = JSON.parse(raw) as [string, FSNode][];
+        this.nodes = new Map<string, FSNode>(entries);
+        return;
+      } catch {
+        console.warn("[FS] Corrupt data, re-seeding");
+      }
+    }
+    this.batch(() => seedFileSystem(this));
+  }
+}
+
+export const fsStore = new FileSystemStore();

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -1,6 +1,6 @@
 import {
   type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
-  ROOT_ID, DUMPSTER_ID,
+  ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -173,6 +173,23 @@ export class FileSystemStore {
     return shortcut;
   }
 
+  ensureFile(
+    parentId: string,
+    name: string,
+    options: {
+      content?: string;
+      mimeType?: string;
+      fileType?: FSFileType;
+      appId?: string;
+      system?: boolean;
+      readonly?: boolean;
+    } = {}
+  ): FSFile {
+    const existing = this.findChild(parentId, name);
+    if (existing?.kind === "file") return existing;
+    return this.createFile(parentId, name, options);
+  }
+
   writeFile(id: string, content: string, mimeType?: string): void {
     const node = this.nodes.get(id);
     if (!node || node.kind !== "file") return;
@@ -283,12 +300,42 @@ export class FileSystemStore {
       try {
         const entries = JSON.parse(raw) as [string, FSNode][];
         this.nodes = new Map<string, FSNode>(entries);
+        this.migrate();
         return;
       } catch {
         console.warn("[FS] Corrupt data, re-seeding");
       }
     }
     this.batch(() => seedFileSystem(this));
+  }
+
+  private migrate(): void {
+    let changed = false;
+
+    // Ensure NS Art backup file exists with its stable ID
+    if (!this.nodes.has(NS_ART_BACKUP_ID)) {
+      const nsArtDir = this.getNodeByPath("C:\\Programs\\Accessories\\NS Art");
+      if (nsArtDir?.kind === "folder") {
+        const file: FSFile = {
+          id: NS_ART_BACKUP_ID,
+          kind: "file",
+          name: "Untitled.nsart",
+          parentId: nsArtDir.id,
+          createdAt: Date.now(),
+          modifiedAt: Date.now(),
+          fileType: "dat",
+          content: "",
+          mimeType: "application/json",
+          system: false,
+          readonly: false,
+          appId: "nsart",
+        };
+        this.nodes.set(NS_ART_BACKUP_ID, file);
+        changed = true;
+      }
+    }
+
+    if (changed) this.save();
   }
 }
 

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -1,6 +1,6 @@
 import {
   type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
-  ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID,
+  ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -377,6 +377,119 @@ export class FileSystemStore {
         } as FSFile);
         changed = true;
       }
+    }
+
+    // Rename win.ini → doors.ini for existing sessions
+    const winIni = this.getNodeByPath("C:\\System\\win.ini");
+    if (winIni?.kind === "file") {
+      const doorsIniContent = `; doors.ini — Noahsoft configuration placeholder\n; Future home of user preferences, registered app associations,\n; and other settings too important to put in system.ini but\n; too silly not to customize.\n;\n; "A mind is like a computer: it works best when you clear the cache." — Gerald\n;\n; Coming in NS Doors 98:\n;   [FavoriteJokes]   JokeCount=0\n;   [WallpaperMood]   Monday=sad  Friday=happy\n;   [Gerald]          CalledToday=no\n`;
+      // Replace win.ini with doors.ini
+      this.nodes.delete(winIni.id);
+      this.nodes.set("fs:sys-doors-ini", {
+        id: "fs:sys-doors-ini", kind: "file", name: "doors.ini",
+        parentId: winIni.parentId, createdAt: Date.now(), modifiedAt: Date.now(),
+        fileType: "ini", content: doorsIniContent, mimeType: "text/plain",
+        system: false, readonly: false,
+      } as FSFile);
+      changed = true;
+    }
+
+    // Ensure system.ini has a stable ID and is editable; add [Desktop]/[Screen] if missing
+    if (!this.nodes.has(SYSTEM_INI_ID)) {
+      const sysDir = this.getNodeByPath("C:\\System");
+      if (sysDir?.kind === "folder") {
+        const existing = this.findChild(sysDir.id, "system.ini");
+        let content = existing?.kind === "file" ? existing.content : "";
+        // Append Desktop/Screen sections if not present
+        if (!content.includes("[Desktop]")) {
+          content += "\n[Desktop]\n; Background: noahsoft, solid, or wallpaper\nBackground=solid\n; Color used when Background=solid\nColor=#cc4400\n; Wallpaper preset: sunset, arch, or (None)\nWallpaper=(None)\n; WallpaperFit: cover or contain\nWallpaperFit=cover\n";
+        }
+        if (!content.includes("[Screen]")) {
+          content += "\n[Screen]\n; ScreenSaverActive: 0=off, 1=on\nScreenSaverActive=0\n; ScreenSaverTimeout in minutes (0=disabled)\nScreenSaverTimeout=1\n; ScreenSaver: starfield, fireworks, bouncing-shapes, scrolling-text,\n;              bouncing-polygons, raining-emojis, or (None)\nScreenSaver=(None)\n";
+        }
+        if (existing?.kind === "file") {
+          this.nodes.delete(existing.id);
+          this.nodes.set(SYSTEM_INI_ID, { ...existing, id: SYSTEM_INI_ID, content, readonly: false });
+        } else {
+          this.nodes.set(SYSTEM_INI_ID, {
+            id: SYSTEM_INI_ID, kind: "file", name: "system.ini",
+            parentId: sysDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "ini", content, mimeType: "text/plain",
+            system: false, readonly: false,
+          } as FSFile);
+        }
+        changed = true;
+      }
+    }
+
+    // Ensure EGO/SPRITES contains PNG stubs (replace old BMP stubs if present)
+    const spritesDir = this.getNodeByPath("C:\\EGO\\SPRITES");
+    if (spritesDir?.kind === "folder") {
+      const spriteNames = [
+        "enemy-0.png", "enemy-1.png", "enemy-2.png", "enemy-dead.png",
+        "gun-pistol.png", "gun-claws.png", "gun-flamethrower.png",
+        "gun-subwoofer.png", "gun-woofer.png", "gun-tennis.png",
+        "key-red.png", "key-blue.png", "key-green.png",
+        "key-orange.png", "key-purple.png", "key-yellow.png",
+        "pickup-health.png", "pickup-ammo.png", "pickup-fuel.png",
+        "pickup-bullets.png", "pickup-balls.png",
+        "pickup-weapon-woofer.png", "pickup-weapon-tennis.png", "pickup-weapon-flamethrower.png",
+        "flame-particle.png", "projectile-tennis.png",
+        "impact-wall.png", "impact-enemy.png",
+        "target-dummy.png", "target-dummy-dead.png",
+        "wall-rock.png", "wall-lava.png",
+      ];
+      // Remove any old BMP stubs
+      for (const child of this.getChildren(spritesDir.id)) {
+        if (child.kind === "file" && child.name.endsWith(".BMP")) {
+          this.nodes.delete(child.id);
+          changed = true;
+        }
+      }
+      // Add PNG stubs that don't exist yet
+      for (const name of spriteNames) {
+        if (!this.findChild(spritesDir.id, name)) {
+          const id = `fs:ego-spr-${name.replace(/\./g, "-")}`;
+          this.nodes.set(id, {
+            id, kind: "file", name,
+            parentId: spritesDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "png", content: "", mimeType: "image/png",
+            system: false, readonly: false,
+          } as FSFile);
+          changed = true;
+        }
+      }
+    }
+
+    // Ensure EGO/SOUNDS folder and WAV stubs exist
+    const egoDir = this.getNodeByPath("C:\\EGO");
+    if (egoDir?.kind === "folder" && !this.getNodeByPath("C:\\EGO\\SOUNDS")) {
+      const sDirId = "fs:ego-sounds";
+      const newSoundsDir: FSFolder = {
+        id: sDirId, kind: "folder", name: "SOUNDS",
+        parentId: egoDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+        system: false,
+      };
+      this.nodes.set(sDirId, newSoundsDir);
+      const soundNames = [
+        "intro.wav", "shoot.wav", "hit-wall.wav", "hit-enemy.wav",
+        "hurt.wav", "death.wav", "level-complete.wav",
+        "pickup.wav", "pickup-weapon.wav", "weapon-switch.wav",
+        "alert.wav", "door-open.wav",
+        "shoot-subwoofer.wav", "shoot-woofer.wav", "swipe-claws.wav", "hit-claws.wav",
+        "shoot-tennis.wav", "bounce-tennis.wav",
+        "shoot-flamethrower.wav", "burning.wav",
+      ];
+      for (const name of soundNames) {
+        const sid = `fs:ego-snd-${name.replace(/\./g, "-")}`;
+        this.nodes.set(sid, {
+          id: sid, kind: "file", name,
+          parentId: sDirId, createdAt: Date.now(), modifiedAt: Date.now(),
+          fileType: "wav", content: "", mimeType: "audio/wav",
+          system: false, readonly: false,
+        } as FSFile);
+      }
+      changed = true;
     }
 
     if (changed) this.save();

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -1,6 +1,6 @@
 import {
   type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
-  ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID,
+  ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -316,21 +316,65 @@ export class FileSystemStore {
     if (!this.nodes.has(NS_ART_BACKUP_ID)) {
       const nsArtDir = this.getNodeByPath("C:\\Programs\\Accessories\\NS Art");
       if (nsArtDir?.kind === "folder") {
-        const file: FSFile = {
-          id: NS_ART_BACKUP_ID,
-          kind: "file",
-          name: "Untitled.nsart",
-          parentId: nsArtDir.id,
-          createdAt: Date.now(),
-          modifiedAt: Date.now(),
-          fileType: "dat",
-          content: "",
-          mimeType: "application/json",
-          system: false,
-          readonly: false,
-          appId: "nsart",
-        };
-        this.nodes.set(NS_ART_BACKUP_ID, file);
+        this.nodes.set(NS_ART_BACKUP_ID, {
+          id: NS_ART_BACKUP_ID, kind: "file", name: "Untitled.nsart",
+          parentId: nsArtDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          fileType: "dat", content: "", mimeType: "application/json",
+          system: false, readonly: false, appId: "nsart",
+        } as FSFile);
+        changed = true;
+      }
+    }
+
+    // Ensure Duck & Learn SCORES.DAT exists with its stable ID
+    if (!this.nodes.has(DH_SCORES_ID)) {
+      const dhDir = this.getNodeByPath("C:\\Programs\\Games\\Duck & Learn");
+      if (dhDir?.kind === "folder") {
+        const existing = this.findChild(dhDir.id, "SCORES.DAT");
+        if (existing?.kind === "file") {
+          // Re-register existing file under stable ID (keeping its content)
+          this.nodes.delete(existing.id);
+          this.nodes.set(DH_SCORES_ID, { ...existing, id: DH_SCORES_ID });
+        } else {
+          this.nodes.set(DH_SCORES_ID, {
+            id: DH_SCORES_ID, kind: "file", name: "SCORES.DAT",
+            parentId: dhDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "dat", content: "", mimeType: "text/plain",
+            system: false, readonly: false,
+          } as FSFile);
+        }
+        changed = true;
+      }
+    }
+
+    // Ensure Typing Racer folder + SCORES.DAT exist
+    if (!this.nodes.has(TR_SCORES_ID)) {
+      let trDir = this.getNodeByPath("C:\\Programs\\Games\\Typing Racer");
+      if (!trDir) {
+        const gamesDir = this.getNodeByPath("C:\\Programs\\Games");
+        if (gamesDir?.kind === "folder") {
+          const folder: FSFolder = {
+            id: "fs:games-tr", kind: "folder", name: "Typing Racer",
+            parentId: gamesDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            system: false,
+          };
+          this.nodes.set(folder.id, folder);
+          this.nodes.set("fs:games-tr-exe", {
+            id: "fs:games-tr-exe", kind: "file", name: "Typing Racer.exe",
+            parentId: folder.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "exe", content: "", mimeType: "application/octet-stream",
+            system: false, readonly: false, appId: "typing-racer",
+          } as FSFile);
+          trDir = folder;
+        }
+      }
+      if (trDir?.kind === "folder") {
+        this.nodes.set(TR_SCORES_ID, {
+          id: TR_SCORES_ID, kind: "file", name: "SCORES.DAT",
+          parentId: trDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          fileType: "dat", content: "", mimeType: "text/plain",
+          system: false, readonly: false,
+        } as FSFile);
         changed = true;
       }
     }

--- a/src/experiences/NsDoors97/filesystem/StorageAdapter.ts
+++ b/src/experiences/NsDoors97/filesystem/StorageAdapter.ts
@@ -1,0 +1,22 @@
+export interface StorageAdapter {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export class LocalStorageAdapter implements StorageAdapter {
+  getItem(key: string): string | null {
+    try { return localStorage.getItem(key); }
+    catch { return null; }
+  }
+
+  setItem(key: string, value: string): void {
+    try { localStorage.setItem(key, value); }
+    catch (e) { console.warn("[FS] Storage quota exceeded", e); }
+  }
+
+  removeItem(key: string): void {
+    try { localStorage.removeItem(key); }
+    catch { /* silent */ }
+  }
+}

--- a/src/experiences/NsDoors97/filesystem/index.ts
+++ b/src/experiences/NsDoors97/filesystem/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./StorageAdapter";
+export * from "./FileSystemStore";
+export { FSProvider, useFS } from "./FSContext";

--- a/src/experiences/NsDoors97/filesystem/ini.ts
+++ b/src/experiences/NsDoors97/filesystem/ini.ts
@@ -1,0 +1,67 @@
+// Simple INI parser / section-updater.
+// Comments (lines starting with ; or @REM) and blank lines are preserved
+// in updateIniSection; they are stripped by parseIni.
+
+export function parseIni(text: string): Record<string, Record<string, string>> {
+  const sections: Record<string, Record<string, string>> = {};
+  let cur = "";
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith(";") || line.startsWith("@")) continue;
+    if (line.startsWith("[") && line.endsWith("]")) {
+      cur = line.slice(1, -1);
+      if (!sections[cur]) sections[cur] = {};
+    } else if (cur) {
+      const eq = line.indexOf("=");
+      if (eq > 0) sections[cur][line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    }
+  }
+  return sections;
+}
+
+// Update or append a section in an INI string, preserving all other content.
+// Existing keys in the section are replaced; unknown keys are preserved;
+// new keys are appended at the end of the section.
+export function updateIniSection(
+  text: string,
+  section: string,
+  kvs: Record<string, string>,
+): string {
+  const header = `[${section}]`;
+  const lines = text.split("\n");
+  const si = lines.findIndex((l) => l.trim() === header);
+
+  if (si === -1) {
+    // Section not present — append it
+    const block = `${header}\n${Object.entries(kvs).map(([k, v]) => `${k}=${v}`).join("\n")}`;
+    return text.trimEnd() + "\n\n" + block + "\n";
+  }
+
+  // Find section end (next section header or EOF)
+  let ei = lines.length;
+  for (let i = si + 1; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t.startsWith("[") && t.endsWith("]")) { ei = i; break; }
+  }
+
+  // Rebuild the section, preserving comments and unknown keys
+  const out: string[] = [header];
+  const done = new Set<string>();
+  for (let i = si + 1; i < ei; i++) {
+    const t = lines[i].trim();
+    if (!t || t.startsWith(";") || t.startsWith("@")) { out.push(lines[i]); continue; }
+    const eq = t.indexOf("=");
+    if (eq > 0) {
+      const k = t.slice(0, eq).trim();
+      if (k in kvs) { out.push(`${k}=${kvs[k]}`); done.add(k); }
+      else out.push(lines[i]);
+    } else {
+      out.push(lines[i]);
+    }
+  }
+  for (const [k, v] of Object.entries(kvs)) {
+    if (!done.has(k)) out.push(`${k}=${v}`);
+  }
+
+  return [...lines.slice(0, si), ...out, ...lines.slice(ei)].join("\n");
+}

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -2,7 +2,7 @@ import type { FileSystemStore } from "./FileSystemStore";
 import {
   ROOT_ID, DESKTOP_ID, DUMPSTER_ID, DOCUMENTS_ID,
   PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
-  NS_ART_BACKUP_ID,
+  NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID,
 } from "./types";
 
 // ── Text content (preserved from original fileSystem.ts) ─────────────────────
@@ -359,7 +359,7 @@ export function seedFileSystem(store: FileSystemStore): void {
 
   const dhDir = store.createFolder(GAMES_ID, "Duck & Learn");
   store.createFile(dhDir.id, "Duck & Learn.exe", { fileType: "exe", appId: "duckhunt" });
-  store.createFile(dhDir.id, "SCORES.DAT",       { fileType: "dat", content: "" });
+  store.createFile(dhDir.id, "SCORES.DAT",       { fileType: "dat", content: "", id: DH_SCORES_ID });
 
   const bfDir = store.createFolder(GAMES_ID, "Bomb Finder");
   store.createFile(bfDir.id, "Bomb Finder.exe", { fileType: "exe", appId: "bombfinder" });
@@ -370,6 +370,10 @@ export function seedFileSystem(store: FileSystemStore): void {
 
   const pegDir = store.createFolder(GAMES_ID, "Peg Solitaire");
   store.createFile(pegDir.id, "Peg Solitaire.exe", { fileType: "exe", appId: "peg-solitaire" });
+
+  const trDir = store.createFolder(GAMES_ID, "Typing Racer");
+  store.createFile(trDir.id, "Typing Racer.exe", { fileType: "exe", appId: "typing-racer" });
+  store.createFile(trDir.id, "SCORES.DAT",       { fileType: "dat", content: "", id: TR_SCORES_ID });
 
   // Stub / unimplemented games (no appId — opens "not a valid NS Doors application")
   store.createFile(GAMES_ID, "Solitaire.exe",   { fileType: "exe" });
@@ -439,6 +443,21 @@ export function seedFileSystem(store: FileSystemStore): void {
     content: "@ECHO OFF\nECHO HELL is already installed.\nECHO Launch NS-TOS and type HELL.EXE to play.\n",
     readonly: true,
   });
+
+  const spritesDir = store.createFolder(EGO_ID, "SPRITES");
+  const spriteNames = [
+    "ENEMY0.BMP", "ENEMY1.BMP", "ENEMY2.BMP", "ENEMY_DEAD.BMP",
+    "GUN_PISTOL.BMP", "GUN_CLAWS.BMP", "GUN_FLAMET.BMP",
+    "GUN_WOOFER.BMP", "GUN_TENNIS.BMP",
+    "KEY_RED.BMP", "KEY_BLUE.BMP", "KEY_GREEN.BMP",
+    "KEY_ORANGE.BMP", "KEY_PURPLE.BMP", "KEY_YELLOW.BMP",
+    "PICKUP_HP.BMP", "PICKUP_AMM.BMP", "PICKUP_FUEL.BMP",
+    "FLAME.BMP", "IMPACT_W.BMP", "IMPACT_E.BMP",
+    "TARGET.BMP", "TARGET_D.BMP",
+  ];
+  for (const name of spriteNames) {
+    store.createFile(spritesDir.id, name, { fileType: "bmp", readonly: true });
+  }
 
   // ── Recycle Bin (Dumpster) ────────────────────────────────────────────────
   store.createFolder(ROOT_ID, "Recycle Bin", { id: DUMPSTER_ID, system: true });

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -1,0 +1,449 @@
+import type { FileSystemStore } from "./FileSystemStore";
+import {
+  ROOT_ID, DESKTOP_ID, DUMPSTER_ID, DOCUMENTS_ID,
+  PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
+} from "./types";
+
+// ── Text content (preserved from original fileSystem.ts) ─────────────────────
+
+const README = `WELCOME TO NS DOORS 97
+======================
+Thank you for purchasing NS Doors 97 by Noahsoft Corporation.
+
+SYSTEM REQUIREMENTS:
+  - 486 DX2 66 MHz or faster
+  - 8 MB RAM (16 MB recommended)
+  - 200 MB free disk space
+  - VGA or better display (640x480, 256 colors)
+
+GETTING STARTED:
+Double-click any icon on the desktop to launch a program.
+Right-click for options (coming soon in NS Doors 98!).
+
+SUPPORT:
+Call 1-800-NOAHSOFT between 9AM-5PM EST, Mon-Fri.
+Long distance charges may apply.
+
+(c) 1997 Noahsoft Corporation. All rights reserved.
+Unauthorized duplication is prohibited by law.
+`;
+
+const DESKTOP_README = `IMPORTANT NOTE TO MYSELF
+=========================
+
+To play HELL.EXE you can NOT just
+double-click it. I know. I tried.
+It gives you a whole lecture.
+
+You have to go through the TOS
+(the scary black text screen).
+
+HOW TO DO IT (I keep forgetting):
+
+  1. Click Start
+  2. Programs
+  3. NS-TOS
+  4. Type this exactly:
+       cd EGO
+       HELL.EXE
+  5. Press Enter. That's it!!
+
+Gerald says I "should not have
+that game installed." Gerald has
+never beaten level 3. I have.
+
+DO NOT tell Gerald.
+
+                        - Noah
+
+P.S. If you get stuck in the text
+screen just type DOORS to come back.
+`;
+
+const LETTER_MOM = `October 14, 1997
+
+Dear Mom,
+
+I finally got the computer set up! It only took three days and
+I only called tech support twice. The man named Gerald was very
+patient with me about the CD-ROM situation.
+
+NS Doors 97 is really something. You should see the screensaver.
+It looks like actual stars flying at you. I nearly fell out of
+my chair the first time it came on.
+
+Dad keeps wanting to use it to look up fishing lures on the
+internet. I told him the internet costs by the minute so he
+needs to be quick about it.
+
+Can you send the recipe for that casserole? I'll type it up
+and keep it on the computer. Very modern.
+
+Love,
+Noah
+
+P.S. Tell Dad the fishing lure website is probably on America
+Online. We got a free disc in the mail.
+`;
+
+const TODO = `TODO LIST - Updated 10/22/1997
+================================
+[x] Figure out how to print (call Gerald again)
+[x] Set up the screensaver
+[ ] Learn how to make a spreadsheet
+[ ] Get Dad's fishing lure website bookmarked
+[ ] Find out what a "cookie" is (the computer kind)
+[ ] Back up important files to floppy disk
+[ ] Ask about that Y2K thing everyone's talking about
+[ ] DEFRAG the hard drive (Gerald said every month)
+[ ] Write letter to Grandma on the computer
+[ ] Make a family budget spreadsheet (in progress - see Budget97.txt)
+[ ] Find Minesweeper tips on the internet
+`;
+
+const BUDGET = `FAMILY BUDGET - FISCAL YEAR 1997
+==================================
+
+INCOME:
+  Noah's salary:          $2,400 / mo
+  Side work (odd jobs):     $150 / mo
+  TOTAL INCOME:           $2,550 / mo
+
+EXPENSES:
+  Rent:                     $650 / mo
+  Groceries:                $280 / mo
+  Car payment:              $215 / mo
+  Car insurance:             $94 / mo
+  Phone (long distance!):    $67 / mo   <- call Mom less (sorry Mom)
+  Electric:                  $58 / mo
+  Internet dial-up (AOL):    $21.95 / mo
+  Cable TV:                  $35 / mo
+  Misc / fun money:         $100 / mo
+  TOTAL EXPENSES:         $1,520.95 / mo
+
+SAVINGS:                  $1,029.05 / mo
+
+NOTES:
+- Remember internet is PER MINUTE after first 10 hours!
+  DO NOT leave AOL connected and walk away again.
+- Christmas gifts budget: $200 total (stick to it this year)
+- Computer cost $1,899 — paid off by February at this rate
+`;
+
+const DIARY = `PERSONAL DIARY - DO NOT READ - SERIOUSLY
+=========================================
+
+Sept 3, 1997
+Got the computer today. It's enormous. Had to rearrange the whole
+desk. The monitor alone weighs as much as a small child.
+
+Sept 5, 1997
+Finally got it to turn on properly. The startup sound scared
+the cat. She hasn't come back in the room since.
+
+Sept 8, 1997
+Found a website with jokes. Printed 47 of them. Ink cartridge
+now empty. This is going to be an expensive hobby.
+
+Sept 19, 1997
+Played Solitaire for 3 hours. The computer is supposed to make
+me more productive.
+
+Oct 2, 1997
+Got NS Doors 97 upgrade disc in the mail. Took all day to install.
+Gerald at tech support says I am his "most interesting caller."
+I'm not sure that's a compliment.
+
+Oct 14, 1997
+Wrote a letter to Mom. On the COMPUTER. Didn't even need to
+use white-out. This changes everything.
+
+Oct 22, 1997
+Figured out what a browser is. The internet is just full of
+people arguing about Star Trek and selling used cars.
+I feel prepared for the future.
+`;
+
+const CONFIG_SYS = `@REM NS DOORS 97 SYSTEM CONFIGURATION
+@REM Generated by NS Doors 97 Setup - DO NOT EDIT
+
+DEVICE=C:\\SYSTEM\\DRIVERS\\HIMEM.SYS
+DEVICE=C:\\SYSTEM\\DRIVERS\\EMM386.EXE NOEMS
+BUFFERS=40,0
+FILES=85
+LASTDRIVE=Z
+FCBS=4,0
+DOS=HIGH,UMB
+STACKS=9,256
+SHELL=C:\\SYSTEM\\COMMAND.COM /P /E:2048
+`;
+
+const AUTOEXEC = `@ECHO OFF
+PROMPT $P$G
+PATH C:\\SYSTEM;C:\\PROGRAMS;C:\\PROGRAMS\\ACCESSORIES
+SET TEMP=C:\\SYSTEM\\TEMP
+SET TMP=C:\\SYSTEM\\TEMP
+SET BLASTER=A220 I5 D1 H5 P330 T6
+SMARTDRV /X
+MODE CON RATE=32 DELAY=1
+@REM Uncomment below to load mouse driver
+@REM C:\\SYSTEM\\DRIVERS\\MOUSE.COM /Y
+ECHO Welcome to NS Doors 97.
+`;
+
+const WIN_INI = `[windows]
+spooler=yes
+load=
+run=
+Beep=yes
+NullPort=None
+BorderWidth=3
+CursorBlinkRate=530
+DoubleClickSpeed=452
+Programs=com exe bat pif
+Documents=txt doc
+
+[Desktop]
+Wallpaper=(None)
+TileWallpaper=0
+WallpaperStyle=0
+Pattern=(None)
+
+[Noahsoft]
+Version=97.2.1
+SerialNumber=NS97-4821-XXXX-9901
+RegisteredUser=Noah Wright
+RegisteredOrganization=Home
+
+[sounds]
+SystemStart=C:\\SYSTEM\\sounds\\startup.wav
+SystemExit=C:\\SYSTEM\\sounds\\shutdown.wav
+SystemHand=C:\\SYSTEM\\sounds\\error.wav
+
+[mci extensions]
+wav=waveaudio
+mid=sequencer
+`;
+
+const SYSTEM_INI = `[boot]
+shell=nsdoors.exe
+mouse.drv=C:\\SYSTEM\\DRIVERS\\mouse.drv
+display.drv=C:\\SYSTEM\\DRIVERS\\svga256.drv
+sound.drv=C:\\SYSTEM\\DRIVERS\\sound.drv
+comm.drv=C:\\SYSTEM\\DRIVERS\\comm.drv
+
+[386Enh]
+woafont=dosapp.fon
+EGA80WOA.FON=EGA80WOA.FON
+MinTimeSlice=20
+WinTimeSlice=100,50
+mouse=*vmouse
+keyboard=*vkd
+MaxBPs=768
+`;
+
+const HELL_README = `HELL v0.3 — SHAREWARE
+======================
+© 1994 Ego Software Inc.
+1-800-HELL-EGO  |  BBS: 614-555-0139
+
+SYSTEM REQUIREMENTS:
+  486 DX2/66 or faster
+  4 MB RAM (8 MB recommended)
+  VGA 320x200, 256 colors
+  Sound Blaster or compatible
+
+IMPORTANT: Must be launched from NS-TOS.
+  Type HELL.EXE at the C: prompt.
+  Double-clicking will NOT work.
+
+CONTROLS:
+  Arrow keys or WASD — Move / Turn
+  Space or Left Mouse — Fire
+  M                  — Toggle map
+  Shift              — Sprint
+  F1 / ?             — Help
+  Esc                — Return to title
+
+TO REGISTER THE FULL GAME ($29.99):
+  Call 1-800-HELL-EGO or mail check/MO to:
+  Ego Software Inc.
+  PO Box 1994, Columbus OH 43215
+
+Registration includes Episodes 2 and 3,
+cheat codes, and an Ego Software sticker.
+
+WARNING: HELL contains extreme violence
+and demonic imagery. Not for children.
+Ego Software is not responsible for
+nightmares or sinful thoughts.
+`;
+
+const RECYCLE_DRAFT = `Draft letter - never sent
+
+June 3, 1997
+
+To whom it may concern at Noahsoft Corporation,
+
+I am writing to express my frustration with NS Doors 95.
+The hourglass cursor appears for no reason. My files rearrange
+themselves. The computer told me I performed an "illegal operation"
+and I have done nothing of the sort.
+
+I demand to speak with someone in charge.
+
+Sincerely,
+A Very Patient Customer
+
+---
+[NOTE TO SELF: Don't send this. Gerald has been very nice.
+And NS Doors 97 is actually pretty good. Delete this.]
+`;
+
+// ── Seed function ─────────────────────────────────────────────────────────────
+
+export function seedFileSystem(store: FileSystemStore): void {
+  // Root
+  store.createFolder(null, "C:\\", { id: ROOT_ID, system: true });
+
+  // ── Desktop ──────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "Desktop", { id: DESKTOP_ID });
+  store.createShortcut(DESKTOP_ID, "My Doors",  { targetAppId: "files",    system: true, id: "fs:sc-mydoors" });
+  store.createShortcut(DESKTOP_ID, "Dumpster",  { targetAppId: "dumpster", system: true, id: "fs:sc-dumpster" });
+  store.createFile(DESKTOP_ID, "README.txt", {
+    fileType: "text",
+    content: DESKTOP_README,
+    id: "fs:desktop-readme",
+  });
+
+  // ── Documents ─────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "Documents", { id: DOCUMENTS_ID });
+  store.createFile(DOCUMENTS_ID, "readme.txt",         { fileType: "text", content: README        });
+  store.createFile(DOCUMENTS_ID, "Letter to Mom.txt",  { fileType: "text", content: LETTER_MOM    });
+  store.createFile(DOCUMENTS_ID, "Todo.txt",           { fileType: "text", content: TODO          });
+  store.createFile(DOCUMENTS_ID, "Budget 1997.txt",    { fileType: "text", content: BUDGET        });
+  store.createFile(DOCUMENTS_ID, "Secret Diary.txt",   { fileType: "text", content: DIARY         });
+
+  // ── Programs ──────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "Programs", { id: PROGRAMS_ID });
+
+  // Programs > Games (each game gets its own folder)
+  store.createFolder(PROGRAMS_ID, "Games", { id: GAMES_ID });
+
+  const hellDir = store.createFolder(GAMES_ID, "HELL");
+  store.createFile(hellDir.id, "HELL.EXE",   { fileType: "exe", appId: "tos-only" });
+  store.createFile(hellDir.id, "README.TXT", { fileType: "text", content: HELL_README, readonly: true });
+
+  const tttDir = store.createFolder(GAMES_ID, "Tic-Tac-Toe");
+  store.createFile(tttDir.id, "Tic-Tac-Toe.exe", { fileType: "exe", appId: "tictactoe" });
+  store.createFile(tttDir.id, "SCORES.DAT",       { fileType: "dat", content: "" });
+
+  const wwDir = store.createFolder(GAMES_ID, "Word Whirlwind");
+  store.createFile(wwDir.id, "Word Whirlwind.exe", { fileType: "exe", appId: "wordwhirlwind" });
+  store.createFile(wwDir.id, "SCORES.DAT",         { fileType: "dat", content: "" });
+
+  const crDir = store.createFolder(GAMES_ID, "Chain Reaction");
+  store.createFile(crDir.id, "Chain Reaction.exe", { fileType: "exe", appId: "chain-reaction" });
+  store.createFile(crDir.id, "SCORES.DAT",         { fileType: "dat", content: "" });
+
+  const nmDir = store.createFolder(GAMES_ID, "Number Muncher");
+  store.createFile(nmDir.id, "Number Muncher.exe", { fileType: "exe", appId: "nomnom" });
+  store.createFile(nmDir.id, "SCORES.DAT",         { fileType: "dat", content: "" });
+
+  const cardsDir = store.createFolder(GAMES_ID, "Cards");
+  store.createFile(cardsDir.id, "Cards.exe", { fileType: "exe", appId: "cards" });
+
+  const poolDir = store.createFolder(GAMES_ID, "8-Ball Pool");
+  store.createFile(poolDir.id, "Pool.exe", { fileType: "exe", appId: "pool" });
+
+  const dhDir = store.createFolder(GAMES_ID, "Duck & Learn");
+  store.createFile(dhDir.id, "Duck & Learn.exe", { fileType: "exe", appId: "duckhunt" });
+  store.createFile(dhDir.id, "SCORES.DAT",       { fileType: "dat", content: "" });
+
+  const bfDir = store.createFolder(GAMES_ID, "Bomb Finder");
+  store.createFile(bfDir.id, "Bomb Finder.exe", { fileType: "exe", appId: "bombfinder" });
+
+  const wordsDir = store.createFolder(GAMES_ID, "WORDS");
+  store.createFile(wordsDir.id, "WORDS.exe",  { fileType: "exe", appId: "words" });
+  store.createFile(wordsDir.id, "SCORES.DAT", { fileType: "dat", content: "" });
+
+  const pegDir = store.createFolder(GAMES_ID, "Peg Solitaire");
+  store.createFile(pegDir.id, "Peg Solitaire.exe", { fileType: "exe", appId: "peg-solitaire" });
+
+  // Stub / unimplemented games (no appId — opens "not a valid NS Doors application")
+  store.createFile(GAMES_ID, "Solitaire.exe",   { fileType: "exe" });
+  store.createFile(GAMES_ID, "Minesweeper.exe", { fileType: "exe" });
+  store.createFile(GAMES_ID, "SkiFree.exe",     { fileType: "exe" });
+
+  // Programs > Accessories
+  store.createFolder(PROGRAMS_ID, "Accessories", { id: ACC_ID });
+
+  const notebookDir = store.createFolder(ACC_ID, "Notebook");
+  store.createFile(notebookDir.id, "Notebook.exe", { fileType: "exe", appId: "notebook" });
+
+  const nsartDir = store.createFolder(ACC_ID, "NS Art");
+  store.createFile(nsartDir.id, "NS Art.exe", { fileType: "exe", appId: "nsart" });
+
+  const soundDir = store.createFolder(ACC_ID, "Sound Recorder");
+  store.createFile(soundDir.id, "Sound Recorder.exe", { fileType: "exe", appId: "sound-recorder" });
+
+  const midiDir = store.createFolder(ACC_ID, "MIDI Editor");
+  store.createFile(midiDir.id, "MIDI Editor.exe", { fileType: "exe", appId: "midi-editor" });
+
+  // Programs > Internet
+  const internetDir = store.createFolder(PROGRAMS_ID, "Internet");
+  store.createFile(internetDir.id, "Internet Explorer.exe",  { fileType: "exe", appId: "internet" });
+  store.createFile(internetDir.id, "Netscape Navigator.exe", { fileType: "exe" });
+  store.createFile(internetDir.id, "WinZip.exe",             { fileType: "exe" });
+
+  // Programs > Screensavers
+  const ssDir = store.createFolder(PROGRAMS_ID, "Screensavers");
+  store.createFile(ssDir.id, "Starfield.scr",       { fileType: "scr", appId: "screensavers" });
+  store.createFile(ssDir.id, "Fireworks.scr",       { fileType: "scr", appId: "screensavers" });
+  store.createFile(ssDir.id, "Bouncing Shapes.scr", { fileType: "scr", appId: "screensavers" });
+  store.createFile(ssDir.id, "Flying Toasters.scr", { fileType: "scr" });
+
+  // ── System ────────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "System", { id: SYSTEM_ID });
+  store.createFile(SYSTEM_ID, "config.sys",   { fileType: "sys", content: CONFIG_SYS, readonly: true });
+  store.createFile(SYSTEM_ID, "autoexec.bat", { fileType: "bat", content: AUTOEXEC,   readonly: true });
+  store.createFile(SYSTEM_ID, "win.ini",      { fileType: "ini", content: WIN_INI,    readonly: true });
+  store.createFile(SYSTEM_ID, "system.ini",   { fileType: "ini", content: SYSTEM_INI, readonly: true });
+
+  const driversDir = store.createFolder(SYSTEM_ID, "Drivers");
+  store.createFile(driversDir.id, "mouse.drv",   { fileType: "drv" });
+  store.createFile(driversDir.id, "display.drv", { fileType: "drv" });
+  store.createFile(driversDir.id, "sound.drv",   { fileType: "drv" });
+  store.createFile(driversDir.id, "comm.drv",    { fileType: "drv" });
+
+  const tempDir = store.createFolder(SYSTEM_ID, "Temp");
+  store.createFile(tempDir.id, "~tmp0001.tmp", { fileType: "tmp" });
+  store.createFile(tempDir.id, "~tmp0002.tmp", { fileType: "tmp" });
+  store.createFile(tempDir.id, "~tmp0087.tmp", { fileType: "tmp" });
+
+  // ── Downloads ─────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "Downloads", { id: DOWNLOADS_ID });
+  store.createFile(DOWNLOADS_ID, "netscape_40_setup.exe",    { fileType: "exe" });
+  store.createFile(DOWNLOADS_ID, "clipart_pack_vol2.zip",    { fileType: "zip" });
+  store.createFile(DOWNLOADS_ID, "cool_space_wallpaper.bmp", { fileType: "bmp" });
+  store.createFile(DOWNLOADS_ID, "AUTORUN.INF",              { fileType: "ini" });
+
+  // ── EGO ───────────────────────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "EGO", { id: EGO_ID });
+  store.createFile(EGO_ID, "HELL.EXE",    { fileType: "exe",  appId: "tos-only" });
+  store.createFile(EGO_ID, "README.TXT",  { fileType: "text", content: HELL_README, readonly: true });
+  store.createFile(EGO_ID, "INSTALL.BAT", {
+    fileType: "bat",
+    content: "@ECHO OFF\nECHO HELL is already installed.\nECHO Launch NS-TOS and type HELL.EXE to play.\n",
+    readonly: true,
+  });
+
+  // ── Recycle Bin (Dumpster) ────────────────────────────────────────────────
+  store.createFolder(ROOT_ID, "Recycle Bin", { id: DUMPSTER_ID, system: true });
+  store.createFile(DUMPSTER_ID, "old_draft.txt",       { fileType: "text", content: RECYCLE_DRAFT });
+  store.createFile(DUMPSTER_ID, "budget_old_1996.txt", {
+    fileType: "text",
+    content: "1996 budget - SUPERSEDED\n\nSee Budget 1997.txt for current version.\n",
+  });
+  store.createFile(DUMPSTER_ID, "ns95_uninstall.exe",  { fileType: "exe" });
+}

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -2,7 +2,7 @@ import type { FileSystemStore } from "./FileSystemStore";
 import {
   ROOT_ID, DESKTOP_ID, DUMPSTER_ID, DOCUMENTS_ID,
   PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
-  NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID,
+  NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
 } from "./types";
 
 // ── Text content (preserved from original fileSystem.ts) ─────────────────────
@@ -192,38 +192,17 @@ MODE CON RATE=32 DELAY=1
 ECHO Welcome to NS Doors 97.
 `;
 
-const WIN_INI = `[windows]
-spooler=yes
-load=
-run=
-Beep=yes
-NullPort=None
-BorderWidth=3
-CursorBlinkRate=530
-DoubleClickSpeed=452
-Programs=com exe bat pif
-Documents=txt doc
-
-[Desktop]
-Wallpaper=(None)
-TileWallpaper=0
-WallpaperStyle=0
-Pattern=(None)
-
-[Noahsoft]
-Version=97.2.1
-SerialNumber=NS97-4821-XXXX-9901
-RegisteredUser=Noah Wright
-RegisteredOrganization=Home
-
-[sounds]
-SystemStart=C:\\SYSTEM\\sounds\\startup.wav
-SystemExit=C:\\SYSTEM\\sounds\\shutdown.wav
-SystemHand=C:\\SYSTEM\\sounds\\error.wav
-
-[mci extensions]
-wav=waveaudio
-mid=sequencer
+const DOORS_INI = `; doors.ini — Noahsoft configuration placeholder
+; Future home of user preferences, registered app associations,
+; and other settings too important to put in system.ini but
+; too silly not to customize.
+;
+; "A mind is like a computer: it works best when you clear the cache." — Gerald
+;
+; Coming in NS Doors 98:
+;   [FavoriteJokes]   JokeCount=0
+;   [WallpaperMood]   Monday=sad  Friday=happy
+;   [Gerald]          CalledToday=no
 `;
 
 const SYSTEM_INI = `[boot]
@@ -241,6 +220,25 @@ WinTimeSlice=100,50
 mouse=*vmouse
 keyboard=*vkd
 MaxBPs=768
+
+[Desktop]
+; Background: noahsoft, solid, or wallpaper
+Background=solid
+; Color used when Background=solid
+Color=#cc4400
+; Wallpaper preset: sunset, arch, or (None)
+Wallpaper=(None)
+; WallpaperFit: cover or contain
+WallpaperFit=cover
+
+[Screen]
+; ScreenSaverActive: 0=off, 1=on
+ScreenSaverActive=0
+; ScreenSaverTimeout in minutes (0=disabled)
+ScreenSaverTimeout=1
+; ScreenSaver: starfield, fireworks, bouncing-shapes, scrolling-text,
+;              bouncing-polygons, raining-emojis, or (None)
+ScreenSaver=(None)
 `;
 
 const HELL_README = `HELL v0.3 — SHAREWARE
@@ -413,8 +411,8 @@ export function seedFileSystem(store: FileSystemStore): void {
   store.createFolder(ROOT_ID, "System", { id: SYSTEM_ID });
   store.createFile(SYSTEM_ID, "config.sys",   { fileType: "sys", content: CONFIG_SYS, readonly: true });
   store.createFile(SYSTEM_ID, "autoexec.bat", { fileType: "bat", content: AUTOEXEC,   readonly: true });
-  store.createFile(SYSTEM_ID, "win.ini",      { fileType: "ini", content: WIN_INI,    readonly: true });
-  store.createFile(SYSTEM_ID, "system.ini",   { fileType: "ini", content: SYSTEM_INI, readonly: true });
+  store.createFile(SYSTEM_ID, "doors.ini",    { fileType: "ini", content: DOORS_INI });
+  store.createFile(SYSTEM_ID, "system.ini",   { id: SYSTEM_INI_ID, fileType: "ini", content: SYSTEM_INI });
 
   const driversDir = store.createFolder(SYSTEM_ID, "Drivers");
   store.createFile(driversDir.id, "mouse.drv",   { fileType: "drv" });
@@ -446,17 +444,35 @@ export function seedFileSystem(store: FileSystemStore): void {
 
   const spritesDir = store.createFolder(EGO_ID, "SPRITES");
   const spriteNames = [
-    "ENEMY0.BMP", "ENEMY1.BMP", "ENEMY2.BMP", "ENEMY_DEAD.BMP",
-    "GUN_PISTOL.BMP", "GUN_CLAWS.BMP", "GUN_FLAMET.BMP",
-    "GUN_WOOFER.BMP", "GUN_TENNIS.BMP",
-    "KEY_RED.BMP", "KEY_BLUE.BMP", "KEY_GREEN.BMP",
-    "KEY_ORANGE.BMP", "KEY_PURPLE.BMP", "KEY_YELLOW.BMP",
-    "PICKUP_HP.BMP", "PICKUP_AMM.BMP", "PICKUP_FUEL.BMP",
-    "FLAME.BMP", "IMPACT_W.BMP", "IMPACT_E.BMP",
-    "TARGET.BMP", "TARGET_D.BMP",
+    "enemy-0.png", "enemy-1.png", "enemy-2.png", "enemy-dead.png",
+    "gun-pistol.png", "gun-claws.png", "gun-flamethrower.png",
+    "gun-subwoofer.png", "gun-woofer.png", "gun-tennis.png",
+    "key-red.png", "key-blue.png", "key-green.png",
+    "key-orange.png", "key-purple.png", "key-yellow.png",
+    "pickup-health.png", "pickup-ammo.png", "pickup-fuel.png",
+    "pickup-bullets.png", "pickup-balls.png",
+    "pickup-weapon-woofer.png", "pickup-weapon-tennis.png", "pickup-weapon-flamethrower.png",
+    "flame-particle.png", "projectile-tennis.png",
+    "impact-wall.png", "impact-enemy.png",
+    "target-dummy.png", "target-dummy-dead.png",
+    "wall-rock.png", "wall-lava.png",
   ];
   for (const name of spriteNames) {
-    store.createFile(spritesDir.id, name, { fileType: "bmp", readonly: true });
+    store.createFile(spritesDir.id, name, { fileType: "png" });
+  }
+
+  const soundsDir = store.createFolder(EGO_ID, "SOUNDS");
+  const soundNames = [
+    "intro.wav", "shoot.wav", "hit-wall.wav", "hit-enemy.wav",
+    "hurt.wav", "death.wav", "level-complete.wav",
+    "pickup.wav", "pickup-weapon.wav", "weapon-switch.wav",
+    "alert.wav", "door-open.wav",
+    "shoot-subwoofer.wav", "shoot-woofer.wav", "swipe-claws.wav", "hit-claws.wav",
+    "shoot-tennis.wav", "bounce-tennis.wav",
+    "shoot-flamethrower.wav", "burning.wav",
+  ];
+  for (const name of soundNames) {
+    store.createFile(soundsDir.id, name, { fileType: "wav" });
   }
 
   // ── Recycle Bin (Dumpster) ────────────────────────────────────────────────

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -458,7 +458,7 @@ export function seedFileSystem(store: FileSystemStore): void {
     "wall-rock.png", "wall-lava.png",
   ];
   for (const name of spriteNames) {
-    store.createFile(spritesDir.id, name, { fileType: "png" });
+    store.createFile(spritesDir.id, name, { fileType: "png", appId: "nsart" });
   }
 
   const soundsDir = store.createFolder(EGO_ID, "SOUNDS");
@@ -472,7 +472,7 @@ export function seedFileSystem(store: FileSystemStore): void {
     "shoot-flamethrower.wav", "burning.wav",
   ];
   for (const name of soundNames) {
-    store.createFile(soundsDir.id, name, { fileType: "wav" });
+    store.createFile(soundsDir.id, name, { fileType: "wav", appId: "sound-recorder" });
   }
 
   // ── Recycle Bin (Dumpster) ────────────────────────────────────────────────

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -2,6 +2,7 @@ import type { FileSystemStore } from "./FileSystemStore";
 import {
   ROOT_ID, DESKTOP_ID, DUMPSTER_ID, DOCUMENTS_ID,
   PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
+  NS_ART_BACKUP_ID,
 } from "./types";
 
 // ── Text content (preserved from original fileSystem.ts) ─────────────────────
@@ -383,6 +384,7 @@ export function seedFileSystem(store: FileSystemStore): void {
 
   const nsartDir = store.createFolder(ACC_ID, "NS Art");
   store.createFile(nsartDir.id, "NS Art.exe", { fileType: "exe", appId: "nsart" });
+  store.createFile(nsartDir.id, "Untitled.nsart", { id: NS_ART_BACKUP_ID, fileType: "dat", appId: "nsart" });
 
   const soundDir = store.createFolder(ACC_ID, "Sound Recorder");
   store.createFile(soundDir.id, "Sound Recorder.exe", { fileType: "exe", appId: "sound-recorder" });

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -1,0 +1,79 @@
+// Well-known folder IDs — stable across reloads, used for direct navigation
+export const ROOT_ID      = "fs:root";
+export const DESKTOP_ID   = "fs:desktop";
+export const DUMPSTER_ID  = "fs:dumpster";
+export const DOCUMENTS_ID = "fs:documents";
+export const PROGRAMS_ID  = "fs:programs";
+export const GAMES_ID     = "fs:games";
+export const ACC_ID       = "fs:accessories";
+export const SYSTEM_ID    = "fs:system";
+export const DOWNLOADS_ID = "fs:downloads";
+export const EGO_ID       = "fs:ego";
+
+export type FSFileType =
+  | "text" | "exe" | "bat" | "sys" | "scr" | "drv"
+  | "tmp"  | "zip" | "bmp" | "png" | "ini" | "wav" | "dat" | "lnk";
+
+export interface FSFile {
+  id: string;
+  kind: "file";
+  name: string;
+  parentId: string;
+  createdAt: number;
+  modifiedAt: number;
+  fileType: FSFileType;
+  content: string;
+  mimeType: string;
+  system: boolean;
+  readonly: boolean;
+  appId?: string;
+}
+
+export interface FSFolder {
+  id: string;
+  kind: "folder";
+  name: string;
+  parentId: string | null;
+  createdAt: number;
+  modifiedAt: number;
+  system: boolean;
+}
+
+export interface FSShortcut {
+  id: string;
+  kind: "shortcut";
+  name: string;
+  parentId: string;
+  createdAt: number;
+  modifiedAt: number;
+  system: boolean;
+  targetAppId?: string;
+  targetFilePath?: string;
+}
+
+export type FSNode = FSFile | FSFolder | FSShortcut;
+
+export const FILE_TYPE_ICONS: Record<FSFileType | "folder" | "shortcut", string> = {
+  folder:   "📁",
+  shortcut: "🔗",
+  text:     "📄",
+  exe:      "⚙️",
+  bat:      "📜",
+  sys:      "🔧",
+  scr:      "🖥️",
+  drv:      "🔩",
+  tmp:      "🗒️",
+  zip:      "📦",
+  bmp:      "🖼️",
+  png:      "🖼️",
+  ini:      "📋",
+  wav:      "🎵",
+  dat:      "💾",
+  lnk:      "🔗",
+};
+
+export function getNodeIcon(node: FSNode): string {
+  if (node.kind === "folder")   return FILE_TYPE_ICONS.folder;
+  if (node.kind === "shortcut") return FILE_TYPE_ICONS.shortcut;
+  return FILE_TYPE_ICONS[node.fileType] ?? "📄";
+}

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -11,6 +11,8 @@ export const DOWNLOADS_ID     = "fs:downloads";
 export const EGO_ID           = "fs:ego";
 // Stable IDs for app-owned files that need reliable direct access
 export const NS_ART_BACKUP_ID = "fs:nsart-backup";
+export const DH_SCORES_ID     = "fs:scores-dh";
+export const TR_SCORES_ID     = "fs:scores-tr";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -1,14 +1,16 @@
 // Well-known folder IDs — stable across reloads, used for direct navigation
-export const ROOT_ID      = "fs:root";
-export const DESKTOP_ID   = "fs:desktop";
-export const DUMPSTER_ID  = "fs:dumpster";
-export const DOCUMENTS_ID = "fs:documents";
-export const PROGRAMS_ID  = "fs:programs";
-export const GAMES_ID     = "fs:games";
-export const ACC_ID       = "fs:accessories";
-export const SYSTEM_ID    = "fs:system";
-export const DOWNLOADS_ID = "fs:downloads";
-export const EGO_ID       = "fs:ego";
+export const ROOT_ID          = "fs:root";
+export const DESKTOP_ID       = "fs:desktop";
+export const DUMPSTER_ID      = "fs:dumpster";
+export const DOCUMENTS_ID     = "fs:documents";
+export const PROGRAMS_ID      = "fs:programs";
+export const GAMES_ID         = "fs:games";
+export const ACC_ID           = "fs:accessories";
+export const SYSTEM_ID        = "fs:system";
+export const DOWNLOADS_ID     = "fs:downloads";
+export const EGO_ID           = "fs:ego";
+// Stable IDs for app-owned files that need reliable direct access
+export const NS_ART_BACKUP_ID = "fs:nsart-backup";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -13,6 +13,7 @@ export const EGO_ID           = "fs:ego";
 export const NS_ART_BACKUP_ID = "fs:nsart-backup";
 export const DH_SCORES_ID     = "fs:scores-dh";
 export const TR_SCORES_ID     = "fs:scores-tr";
+export const SYSTEM_INI_ID    = "fs:system-ini";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"

--- a/src/experiences/NsDoors97/screensaverSettings.ts
+++ b/src/experiences/NsDoors97/screensaverSettings.ts
@@ -1,3 +1,7 @@
+import { fsStore } from "./filesystem/FileSystemStore";
+import { SYSTEM_INI_ID } from "./filesystem/types";
+import { parseIni, updateIniSection } from "./filesystem/ini";
+
 export type ScreensaverId =
   | "starfield"
   | "fireworks"
@@ -71,12 +75,55 @@ export interface FullScreensaverConfig {
 
 const LS_KEY = "ns-screensaver-config";
 
+const VALID_SS_IDS = new Set<ScreensaverId>([
+  "starfield", "fireworks", "bouncing-shapes",
+  "scrolling-text", "bouncing-polygons", "raining-emojis",
+]);
+
+function parseScreensaverFromIni(content: string): Pick<FullScreensaverConfig, "screensaver" | "waitMinutes"> {
+  const ini = parseIni(content);
+  const s = ini["Screen"] ?? {};
+  const active = s["ScreenSaverActive"] !== "0";
+  const timeout = parseInt(s["ScreenSaverTimeout"] ?? "1", 10);
+  const rawId = s["ScreenSaver"] ?? "(None)";
+  const screensaver: ScreensaverId | null = VALID_SS_IDS.has(rawId as ScreensaverId) ? rawId as ScreensaverId : null;
+  return {
+    screensaver,
+    waitMinutes: active && screensaver ? (isNaN(timeout) ? 1 : timeout) : 0,
+  };
+}
+
 export function loadScreensaverConfig(): FullScreensaverConfig {
   const dflt: FullScreensaverConfig = {
     screensaver: null,
     waitMinutes: 1,
     settings: { ...DEFAULT_SETTINGS },
   };
+  // If system.ini has been explicitly modified, use it for screensaver selection/timeout
+  const sysIni = fsStore.getFile(SYSTEM_INI_ID);
+  if (sysIni && sysIni.modifiedAt > sysIni.createdAt) {
+    const { screensaver, waitMinutes } = parseScreensaverFromIni(sysIni.content);
+    // Per-screensaver settings (speed, count, etc.) remain in localStorage
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      const p = raw ? JSON.parse(raw) as Partial<FullScreensaverConfig & { settings: Partial<AllScreensaverSettings> }> : {};
+      return {
+        screensaver,
+        waitMinutes,
+        settings: {
+          starfield: { ...DEFAULT_SETTINGS.starfield, ...(p.settings?.starfield ?? {}) },
+          fireworks: { ...DEFAULT_SETTINGS.fireworks, ...(p.settings?.fireworks ?? {}) },
+          "bouncing-shapes": { ...DEFAULT_SETTINGS["bouncing-shapes"], ...(p.settings?.["bouncing-shapes"] ?? {}) },
+          "scrolling-text": { ...DEFAULT_SETTINGS["scrolling-text"], ...(p.settings?.["scrolling-text"] ?? {}) },
+          "bouncing-polygons": { ...DEFAULT_SETTINGS["bouncing-polygons"], ...(p.settings?.["bouncing-polygons"] ?? {}) },
+          "raining-emojis": { ...DEFAULT_SETTINGS["raining-emojis"], ...(p.settings?.["raining-emojis"] ?? {}) },
+        },
+      };
+    } catch {
+      return { ...dflt, screensaver, waitMinutes };
+    }
+  }
+  // Fall back to localStorage
   try {
     const raw = localStorage.getItem(LS_KEY);
     if (!raw) return dflt;
@@ -99,6 +146,19 @@ export function loadScreensaverConfig(): FullScreensaverConfig {
 }
 
 export function saveScreensaverConfig(config: FullScreensaverConfig): void {
+  // Write screensaver selection and timeout to system.ini
+  const sysIni = fsStore.getFile(SYSTEM_INI_ID);
+  if (sysIni) {
+    const active = config.screensaver !== null && config.waitMinutes > 0;
+    const kvs: Record<string, string> = {
+      ScreenSaverActive:  active ? "1" : "0",
+      ScreenSaverTimeout: String(config.waitMinutes),
+      ScreenSaver:        config.screensaver ?? "(None)",
+    };
+    const updated = updateIniSection(sysIni.content, "Screen", kvs);
+    fsStore.writeFile(SYSTEM_INI_ID, updated);
+  }
+  // Also keep localStorage (holds per-screensaver settings)
   try {
     localStorage.setItem(LS_KEY, JSON.stringify(config));
   } catch {}

--- a/src/experiences/NsToS/NsToS.tsx
+++ b/src/experiences/NsToS/NsToS.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { ROOT, type FsFolder, type FsFile } from "../NsDoors97/fileSystem";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { ROOT_ID, type FSFile } from "../NsDoors97/filesystem/types";
 import "./NsToS.css";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -10,7 +11,7 @@ interface TerminalLine {
   error?: boolean;
 }
 
-// ── Boot sequence lines (simulates CONFIG.SYS + AUTOEXEC.BAT running) ─────────
+// ── Boot sequence lines ────────────────────────────────────────────────────────
 
 const BOOT_LINES: string[] = [
   "NS-TOS Version 7.22",
@@ -28,21 +29,8 @@ const BOOT_LINES: string[] = [
 
 // ── Filesystem helpers ────────────────────────────────────────────────────────
 
-function getFolder(cwd: string[]): FsFolder | null {
-  let node: FsFolder = ROOT;
-  for (const seg of cwd) {
-    const child = node.children.find(
-      (c) => c.kind === "folder" && c.name.toLowerCase() === seg.toLowerCase()
-    );
-    if (!child || child.kind !== "folder") return null;
-    node = child;
-  }
-  return node;
-}
-
-function promptStr(cwd: string[]): string {
-  if (cwd.length === 0) return "C:\\>";
-  return `C:\\${cwd.join("\\")}\\>`;
+function promptStr(cwdId: string): string {
+  return fsStore.getPath(cwdId) + ">";
 }
 
 // ── Retro date/time (real time, date shifted 30 years back) ──────────────────
@@ -52,19 +40,13 @@ function retroDate(): string {
   const retro = new Date(now);
   retro.setFullYear(now.getFullYear() - 30);
   return retro.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
+    weekday: "short", month: "short", day: "numeric", year: "numeric",
   });
 }
 
 function retroTime(): string {
   return new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
+    hour: "numeric", minute: "2-digit", second: "2-digit", hour12: true,
   });
 }
 
@@ -74,53 +56,42 @@ export default function NsToS() {
   const navigate = useNavigate();
   const [lines, setLines] = useState<TerminalLine[]>([]);
   const [ready, setReady] = useState(false);
-  const [cwd, setCwd] = useState<string[]>([]);
+  const [cwdId, setCwdId] = useState<string>(ROOT_ID);
   const [input, setInput] = useState("");
   const [cmdHistory, setCmdHistory] = useState<string[]>([]);
   const [historyIdx, setHistoryIdx] = useState(-1);
   const outputRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-scroll to bottom whenever lines change
   useEffect(() => {
     if (outputRef.current) {
       outputRef.current.scrollTop = outputRef.current.scrollHeight;
     }
   }, [lines]);
 
-  // Boot sequence — type out lines with small delays
+  // Boot sequence
   useEffect(() => {
     let cancelled = false;
     const timers: ReturnType<typeof setTimeout>[] = [];
-
     let delay = 0;
     for (const text of BOOT_LINES) {
       delay += 45 + Math.random() * 35;
       const d = delay;
-      timers.push(
-        setTimeout(() => {
-          if (!cancelled) setLines((prev) => [...prev, { text }]);
-        }, d)
-      );
+      timers.push(setTimeout(() => {
+        if (!cancelled) setLines((prev) => [...prev, { text }]);
+      }, d));
     }
-
-    timers.push(
-      setTimeout(() => {
-        if (!cancelled) setReady(true);
-      }, delay + 60)
-    );
-
+    timers.push(setTimeout(() => {
+      if (!cancelled) setReady(true);
+    }, delay + 60));
     return () => {
       cancelled = true;
       timers.forEach(clearTimeout);
     };
   }, []);
 
-  // Focus the input when the terminal is ready
   useEffect(() => {
-    if (ready && inputRef.current) {
-      inputRef.current.focus();
-    }
+    if (ready && inputRef.current) inputRef.current.focus();
   }, [ready]);
 
   const addLines = useCallback((newLines: TerminalLine[]) => {
@@ -133,21 +104,21 @@ export default function NsToS() {
     (raw: string) => {
       const trimmed = raw.trim();
       if (!trimmed) {
-        addLines([{ text: `${promptStr(cwd)}` }]);
+        addLines([{ text: promptStr(cwdId) }]);
         return;
       }
 
       setCmdHistory((prev) => [trimmed, ...prev].slice(0, 50));
       setHistoryIdx(-1);
-
-      // Echo the command line
-      addLines([{ text: `${promptStr(cwd)}${trimmed}` }]);
+      addLines([{ text: `${promptStr(cwdId)}${trimmed}` }]);
 
       // Normalize "CD.." → "CD .."
       const normalized = trimmed.replace(/^(cd)(\.\.+)$/i, "$1 $2");
-      const parts = normalized.split(/\s+/);
-      const cmd = parts[0].toUpperCase();
-      const args = parts.slice(1);
+      // Split on first whitespace only so "ECHO hello world" stays intact
+      const spaceIdx = normalized.indexOf(" ");
+      const cmd = (spaceIdx === -1 ? normalized : normalized.slice(0, spaceIdx)).toUpperCase();
+      const argStr = spaceIdx === -1 ? "" : normalized.slice(spaceIdx + 1);
+      const args = argStr.split(/\s+/).filter(Boolean);
 
       switch (cmd) {
         case "CLS": {
@@ -162,12 +133,16 @@ export default function NsToS() {
             { text: "Available commands:" },
             { text: "" },
             { text: "  CLS             Clear the screen" },
-            { text: "  CD [dir]        Change directory  (CD.. to go up, CD \\ for root)" },
+            { text: "  CD [dir]        Change directory  (supports multi-level: cd Programs\\Games)" },
             { text: "  DATE            Display the current date" },
+            { text: "  DEL [file]      Delete a file (moves to Recycle Bin)" },
             { text: "  DIR             List files in current directory" },
             { text: "  DOORS           Launch NS Doors 97" },
-            { text: "  ECHO [text]     Display a message" },
+            { text: "  ECHO [text]     Display a message (ECHO text > file.txt writes a file)" },
             { text: "  HELP            Display this help text" },
+            { text: "  MKDIR [dir]     Create a new directory" },
+            { text: "  REN [old] [new] Rename a file or folder" },
+            { text: "  RMDIR [dir]     Remove an empty directory" },
             { text: "  TIME            Display the current time" },
             { text: "  TYPE [file]     Display contents of a text file" },
             { text: "  VER             Display NS-TOS version" },
@@ -187,51 +162,55 @@ export default function NsToS() {
         }
 
         case "DATE": {
-          addLines([
-            { text: "" },
-            { text: `Current date is: ${retroDate()}` },
-            { text: "" },
-          ]);
+          addLines([{ text: "" }, { text: `Current date is: ${retroDate()}` }, { text: "" }]);
           break;
         }
 
         case "TIME": {
-          addLines([
-            { text: "" },
-            { text: `Current time is: ${retroTime()}` },
-            { text: "" },
-          ]);
+          addLines([{ text: "" }, { text: `Current time is: ${retroTime()}` }, { text: "" }]);
           break;
         }
 
         case "ECHO": {
-          const msg = args.join(" ");
-          addLines([{ text: msg || "ECHO is on." }, { text: "" }]);
+          // Handle ECHO text > filename
+          const redirectIdx = argStr.lastIndexOf(">");
+          if (redirectIdx !== -1) {
+            const text = argStr.slice(0, redirectIdx).trim();
+            const filename = argStr.slice(redirectIdx + 1).trim();
+            if (!filename) {
+              addLines([{ text: "Syntax error.", error: true }, { text: "" }]);
+              break;
+            }
+            const existing = fsStore.findChild(cwdId, filename);
+            if (existing && existing.kind === "file") {
+              fsStore.writeFile(existing.id, text);
+            } else if (!existing) {
+              fsStore.createFile(cwdId, filename, { fileType: "text", content: text });
+            } else {
+              addLines([{ text: `Cannot write to "${filename}": not a file.`, error: true }, { text: "" }]);
+              break;
+            }
+            addLines([{ text: "" }]);
+            break;
+          }
+          addLines([{ text: argStr || "ECHO is on." }, { text: "" }]);
           break;
         }
 
         case "DIR": {
-          const folder = getFolder(cwd);
-          if (!folder) {
-            addLines([{ text: "Invalid directory.", error: true }, { text: "" }]);
-            break;
-          }
+          const children = fsStore.getChildren(cwdId);
+          const dirPath = fsStore.getPath(cwdId) + "\\";
           const dateStr = retroDate();
-          const dirPath = cwd.length === 0 ? "C:\\" : `C:\\${cwd.join("\\")}\\`;
-          addLines([
-            { text: "" },
-            { text: ` Directory of ${dirPath}` },
-            { text: "" },
-          ]);
-          for (const node of folder.children) {
+          addLines([{ text: "" }, { text: ` Directory of ${dirPath}` }, { text: "" }]);
+          for (const node of children) {
             if (node.kind === "folder") {
               addLines([{ text: `${dateStr}    <DIR>    ${node.name}` }]);
             } else {
               addLines([{ text: `${dateStr}             ${node.name}` }]);
             }
           }
-          const dirCount = folder.children.filter((n) => n.kind === "folder").length;
-          const fileCount = folder.children.filter((n) => n.kind === "file").length;
+          const dirCount = children.filter((n) => n.kind === "folder").length;
+          const fileCount = children.length - dirCount;
           addLines([
             { text: "" },
             { text: `       ${fileCount} file(s)     ${dirCount} dir(s)` },
@@ -241,70 +220,68 @@ export default function NsToS() {
         }
 
         case "CD": {
-          const arg = args[0] ?? "";
+          const arg = argStr.trim();
 
           if (!arg || arg === ".") {
             addLines([{ text: "" }]);
             break;
           }
 
-          // Go to root
+          // Root shortcuts
           if (arg === "\\" || arg.toUpperCase() === "C:\\" || arg.toUpperCase() === "C:") {
-            setCwd([]);
+            setCwdId(ROOT_ID);
             addLines([{ text: "" }]);
             break;
           }
 
-          // Go up
-          if (arg === ".." || arg.startsWith("..")) {
-            setCwd((prev) => prev.slice(0, -1));
-            addLines([{ text: "" }]);
-            break;
+          // Walk through path segments (supports multi-level: Programs\Games)
+          const isAbsolute = /^C:[\\\/]/i.test(arg) || arg.startsWith("\\");
+          const segments = arg
+            .replace(/^C:[\\\/]/i, "")
+            .replace(/^[\\\/]/, "")
+            .split(/[\\\/]/);
+
+          let currentId = isAbsolute ? ROOT_ID : cwdId;
+          let failed = false;
+
+          for (const seg of segments) {
+            if (!seg || seg === ".") continue;
+            if (seg === "..") {
+              const node = fsStore.getNode(currentId);
+              currentId = node?.parentId ?? ROOT_ID;
+              continue;
+            }
+            const child = fsStore.findChild(currentId, seg);
+            if (!child || child.kind !== "folder") {
+              failed = true;
+              break;
+            }
+            currentId = child.id;
           }
 
-          // Navigate into a child folder
-          const folder = getFolder(cwd);
-          const target = folder?.children.find(
-            (c) => c.kind === "folder" && c.name.toLowerCase() === arg.toLowerCase()
-          );
-          if (!target || target.kind !== "folder") {
-            addLines([
-              { text: `Invalid directory - "${arg}"`, error: true },
-              { text: "" },
-            ]);
+          if (failed) {
+            addLines([{ text: `Invalid directory - "${arg}"`, error: true }, { text: "" }]);
             break;
           }
-          setCwd((prev) => [...prev, target.name]);
+          setCwdId(currentId);
           addLines([{ text: "" }]);
           break;
         }
 
         case "TYPE": {
-          const filename = args.join(" ");
+          const filename = argStr.trim();
           if (!filename) {
-            addLines([
-              { text: "Required parameter missing.", error: true },
-              { text: "" },
-            ]);
+            addLines([{ text: "Required parameter missing.", error: true }, { text: "" }]);
             break;
           }
-          const folder = getFolder(cwd);
-          const file = folder?.children.find(
-            (c): c is FsFile =>
-              c.kind === "file" && c.name.toLowerCase() === filename.toLowerCase()
-          );
-          if (!file) {
-            addLines([
-              { text: `File not found - "${filename}"`, error: true },
-              { text: "" },
-            ]);
+          const child = fsStore.findChild(cwdId, filename);
+          if (!child || child.kind !== "file") {
+            addLines([{ text: `File not found - "${filename}"`, error: true }, { text: "" }]);
             break;
           }
+          const file = child as FSFile;
           if (!file.content) {
-            addLines([
-              { text: "This file type cannot be displayed.", error: true },
-              { text: "" },
-            ]);
+            addLines([{ text: "This file type cannot be displayed.", error: true }, { text: "" }]);
             break;
           }
           addLines([
@@ -312,6 +289,94 @@ export default function NsToS() {
             ...file.content.split("\n").map((t) => ({ text: t })),
             { text: "" },
           ]);
+          break;
+        }
+
+        case "MKDIR":
+        case "MD": {
+          const dirname = argStr.trim();
+          if (!dirname) {
+            addLines([{ text: "Required parameter missing.", error: true }, { text: "" }]);
+            break;
+          }
+          if (fsStore.findChild(cwdId, dirname)) {
+            addLines([{ text: `A subdirectory or file "${dirname}" already exists.`, error: true }, { text: "" }]);
+            break;
+          }
+          fsStore.createFolder(cwdId, dirname);
+          addLines([{ text: "" }]);
+          break;
+        }
+
+        case "RMDIR":
+        case "RD": {
+          const dirname = argStr.trim();
+          if (!dirname) {
+            addLines([{ text: "Required parameter missing.", error: true }, { text: "" }]);
+            break;
+          }
+          const rmdirTarget = fsStore.findChild(cwdId, dirname);
+          if (!rmdirTarget || rmdirTarget.kind !== "folder") {
+            addLines([{ text: `Directory not found - "${dirname}"`, error: true }, { text: "" }]);
+            break;
+          }
+          if (rmdirTarget.system) {
+            addLines([{ text: "Access denied.", error: true }, { text: "" }]);
+            break;
+          }
+          if (fsStore.getChildren(rmdirTarget.id).length > 0) {
+            addLines([{ text: "Directory is not empty.", error: true }, { text: "" }]);
+            break;
+          }
+          fsStore.deleteNode(rmdirTarget.id);
+          addLines([{ text: "" }]);
+          break;
+        }
+
+        case "DEL":
+        case "ERASE": {
+          const filename = argStr.trim();
+          if (!filename) {
+            addLines([{ text: "Required parameter missing.", error: true }, { text: "" }]);
+            break;
+          }
+          const delTarget = fsStore.findChild(cwdId, filename);
+          if (!delTarget) {
+            addLines([{ text: `File not found - "${filename}"`, error: true }, { text: "" }]);
+            break;
+          }
+          if (delTarget.system) {
+            addLines([{ text: "Access denied.", error: true }, { text: "" }]);
+            break;
+          }
+          if (delTarget.kind === "folder") {
+            addLines([{ text: `Cannot delete directory with DEL. Use RMDIR.`, error: true }, { text: "" }]);
+            break;
+          }
+          fsStore.deleteNode(delTarget.id);
+          addLines([{ text: "" }]);
+          break;
+        }
+
+        case "REN":
+        case "RENAME": {
+          if (args.length < 2) {
+            addLines([{ text: "Required parameter missing.", error: true }, { text: "" }]);
+            break;
+          }
+          const oldName = args[0];
+          const newName = args.slice(1).join(" ");
+          const renTarget = fsStore.findChild(cwdId, oldName);
+          if (!renTarget) {
+            addLines([{ text: `File not found - "${oldName}"`, error: true }, { text: "" }]);
+            break;
+          }
+          if (renTarget.system) {
+            addLines([{ text: "Access denied.", error: true }, { text: "" }]);
+            break;
+          }
+          fsStore.renameNode(renTarget.id, newName);
+          addLines([{ text: "" }]);
           break;
         }
 
@@ -326,11 +391,7 @@ export default function NsToS() {
         }
 
         case "DELTREE": {
-          addLines([
-            { text: "" },
-            { text: "Delete everything? Let's not." },
-            { text: "" },
-          ]);
+          addLines([{ text: "" }, { text: "Delete everything? Let's not." }, { text: "" }]);
           break;
         }
 
@@ -348,18 +409,21 @@ export default function NsToS() {
         }
 
         case "DOORS": {
-          addLines([
-            { text: "" },
-            { text: "Loading NS Doors 97..." },
-            { text: "" },
-          ]);
-          setTimeout(() => {
-            navigate("/", { state: { fromTos: true } });
-          }, 800);
+          addLines([{ text: "" }, { text: "Loading NS Doors 97..." }, { text: "" }]);
+          setTimeout(() => navigate("/", { state: { fromTos: true } }), 800);
           break;
         }
 
         case "HELL.EXE": {
+          const hellFile = fsStore.findChild(cwdId, "HELL.EXE");
+          if (!hellFile || hellFile.kind !== "file") {
+            addLines([
+              { text: `Bad command or file name - "${trimmed}"` },
+              { text: `HINT: Navigate to the EGO folder first. Try: cd EGO` },
+              { text: "" },
+            ]);
+            break;
+          }
           addLines([
             { text: "" },
             { text: "HELL v0.3 — EGO SOFTWARE INC." },
@@ -380,15 +444,12 @@ export default function NsToS() {
         }
 
         default: {
-          addLines([
-            { text: `Bad command or file name - "${trimmed}"` },
-            { text: "" },
-          ]);
+          addLines([{ text: `Bad command or file name - "${trimmed}"` }, { text: "" }]);
           break;
         }
       }
     },
-    [cwd, addLines, navigate]
+    [cwdId, addLines, navigate]
   );
 
   // ── Keyboard handling ─────────────────────────────────────────────────────
@@ -416,12 +477,12 @@ export default function NsToS() {
         setHistoryIdx(-1);
       } else if (e.key === "c" && e.ctrlKey) {
         e.preventDefault();
-        addLines([{ text: `${promptStr(cwd)}${input}^C` }, { text: "" }]);
+        addLines([{ text: `${promptStr(cwdId)}${input}^C` }, { text: "" }]);
         setInput("");
         setHistoryIdx(-1);
       }
     },
-    [input, processCommand, historyIdx, cmdHistory, cwd, addLines]
+    [input, processCommand, historyIdx, cmdHistory, cwdId, addLines]
   );
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -434,13 +495,13 @@ export default function NsToS() {
             key={i}
             className={`ns-tos__line${line.error ? " ns-tos__line--error" : ""}`}
           >
-            {line.text || " "}
+            {line.text || " "}
           </div>
         ))}
       </div>
       {ready && (
         <div className="ns-tos__input-row">
-          <span className="ns-tos__prompt">{promptStr(cwd)}</span>
+          <span className="ns-tos__prompt">{promptStr(cwdId)}</span>
           <input
             ref={inputRef}
             className="ns-tos__input"

--- a/src/experiences/TypingRacer/TypingRacer.tsx
+++ b/src/experiences/TypingRacer/TypingRacer.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { TR_SCORES_ID } from "../NsDoors97/filesystem/types";
 import "./TypingRacer.css";
+
+const TR_LS_KEY = "typeemup-highscore";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -312,8 +316,17 @@ export default function TypingRacer() {
   const [difficulty, setDifficulty] = useState<Difficulty>("medium");
   const [finalStats, setFinalStats] = useState<FinalStats | null>(null);
   const [highScore, setHighScore]   = useState<number>(() => {
-    const s = localStorage.getItem("typeemup-highscore");
-    return s ? parseInt(s, 10) : 0;
+    // Prefer FS SCORES.DAT; fall back to legacy localStorage
+    const fsContent = fsStore.getFile(TR_SCORES_ID)?.content;
+    if (fsContent) return parseInt(fsContent, 10) || 0;
+    const ls = localStorage.getItem(TR_LS_KEY);
+    if (ls) {
+      // One-time migration: move to FS
+      fsStore.writeFile(TR_SCORES_ID, ls);
+      localStorage.removeItem(TR_LS_KEY);
+      return parseInt(ls, 10) || 0;
+    }
+    return 0;
   });
   // gamePaused drives the "tap to play" strip; gamePausedRef is readable inside
   // the RAF loop without a stale-closure issue.
@@ -504,7 +517,7 @@ export default function TypingRacer() {
         const isNewRecord = state.score > highScoreRef.current;
         setFinalStats({ score: state.score, wpm: finalWpm, wordsDestroyed: state.wordsDestroyed, isNewRecord });
         if (isNewRecord) {
-          localStorage.setItem("typeemup-highscore", String(state.score));
+          try { fsStore.writeFile(TR_SCORES_ID, String(state.score)); } catch { /* ignore */ }
           setHighScore(state.score);
         }
         gameRef.current = null;

--- a/src/pages/NsDoors97Page.tsx
+++ b/src/pages/NsDoors97Page.tsx
@@ -1,10 +1,13 @@
 import NsDoors97 from "../experiences/NsDoors97/NsDoors97";
 import { OsDialogProvider } from "../experiences/NsDoors97/OsDialog";
+import { FSProvider } from "../experiences/NsDoors97/filesystem";
 
 export default function NsDoors97Page() {
   return (
-    <OsDialogProvider>
-      <NsDoors97 />
-    </OsDialogProvider>
+    <FSProvider>
+      <OsDialogProvider>
+        <NsDoors97 />
+      </OsDialogProvider>
+    </FSProvider>
   );
 }


### PR DESCRIPTION
Introduces the FileSystemStore singleton that replaces the old
read-only fake filesystem tree with a real persistent store backed
by localStorage (swappable to IndexedDB later via StorageAdapter).

- types.ts: FSFile / FSFolder / FSShortcut node types + well-known
  folder IDs (ROOT, DESKTOP, DUMPSTER, DOCUMENTS, PROGRAMS, …)
- StorageAdapter.ts: interface + LocalStorageAdapter implementation
- FileSystemStore.ts: flat Map<id, FSNode> store with CRUD, path
  resolution, event subscriptions, batching, and auto-seed on
  first load
- seed.ts: populates default C:\ tree from original fileSystem.ts
  content; adds Desktop folder, per-game subdirectories under
  Programs\Games, per-app subdirectories under Programs\Accessories
- FSContext.tsx: FSProvider wraps NsDoors97 subtree; useFS() hook
  subscribes components to store changes
- index.ts: barrel re-export

https://claude.ai/code/session_014q9MH7VRtRX1VLU8CvxFJp