### PR TITLE
Add pitch bend (sliding notes) to MIDI editor

### DIFF
--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -7,6 +7,7 @@ export interface MenuBarItem {
   separator?: true;
   disabled?: boolean;
   checked?: boolean;
+  radioGroup?: string; // when set, renders • instead of ✓ (consumer manages exclusivity)
 }
 
 export interface MenuBarMenu {
@@ -68,7 +69,7 @@ export default function MenuBar({ menus }: MenuBarProps) {
                       disabled={item.disabled}
                     >
                       <span className="win95-menubar__check">
-                        {item.checked ? "✓" : ""}
+                        {item.checked ? (item.radioGroup ? "•" : "✓") : ""}
                       </span>
                       <span className="win95-menubar__option-label">
                         {item.label}

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -584,12 +584,13 @@
   flex-shrink: 0;
 }
 
-/* In edit mode, tell the browser not to intercept touches for scrolling.
+/* In edit/select mode, tell the browser not to intercept touches for scrolling.
    This must be on the grid container itself (not just children) so iOS Safari
    doesn't steal the touch for the scrollable .me-outer ancestor. */
 .me-note-grid--edit,
 .me-note-grid--edit .me-cell,
-.me-note-grid--edit .me-note-rect {
+.me-note-grid--edit .me-note-rect,
+.me-note-grid--select {
   touch-action: none;
 }
 

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -1054,3 +1054,95 @@
   flex-shrink: 0;
   border: 1px solid rgba(0,0,0,0.3);
 }
+
+/* ── Tool palette (bottom of piano roll) ───────────────────────────────────── */
+.me-tool-palette {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: #c0c0c0;
+  border-top: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.me-tool-palette__group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.me-tool-palette__divider {
+  width: 4px;
+  height: 36px;
+  flex-shrink: 0;
+  margin: 0 2px;
+  border-left: 2px solid #808080;
+  border-right: 2px solid #ffffff;
+}
+
+.me-tool-btn {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.me-tool-btn:active,
+.me-tool-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
+/* ── Note states for bend/erase tools ─────────────────────────────────────── */
+.me-note-rect--bend-mode {
+  opacity: 0.55;
+  filter: brightness(0.65);
+  z-index: 1;
+}
+
+.me-note-rect--bend-source {
+  opacity: 1;
+  filter: brightness(1.1);
+  outline: 2px solid #ffffff;
+  outline-offset: -1px;
+  z-index: 3;
+}
+
+.me-note-rect--bend-target {
+  opacity: 1;
+  filter: brightness(1.05);
+  outline: 3px solid #228833;
+  outline-offset: -1px;
+  transform: scale(1.04);
+  z-index: 3;
+}
+
+.me-note-rect--erase-hover {
+  outline: 3px solid #cc0000;
+  outline-offset: -1px;
+  filter: brightness(1.1);
+  z-index: 4;
+}
+
+/* Bend SVG overlay */
+.me-bend-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 5;
+  overflow: visible;
+}
+
+.me-bend-svg--active {
+  pointer-events: all;
+}

--- a/src/experiences/MidiEditor/MidiEditor.css
+++ b/src/experiences/MidiEditor/MidiEditor.css
@@ -584,8 +584,10 @@
   flex-shrink: 0;
 }
 
-/* In edit mode, give every touchable element its own touch-action:none so
-   mobile browsers don't intercept the pointer events for scrolling */
+/* In edit mode, tell the browser not to intercept touches for scrolling.
+   This must be on the grid container itself (not just children) so iOS Safari
+   doesn't steal the touch for the scrollable .me-outer ancestor. */
+.me-note-grid--edit,
 .me-note-grid--edit .me-cell,
 .me-note-grid--edit .me-note-rect {
   touch-action: none;
@@ -684,6 +686,7 @@
   flex-shrink: 0;
 }
 
+.me-drum-grid--edit,
 .me-drum-grid--edit .me-drum-cell {
   touch-action: none;
 }

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -2,14 +2,20 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useWindowMenus } from '../../components/Window/useWindowMenus';
 import type { MenuBarMenu } from '../../components/MenuBar/MenuBar';
 import {
-  type Song, type Clip, type SongBlock, type Track, type Note,
+  type Song, type Clip, type SongBlock, type Track, type Note, type Bend,
   type DrumType, type OscWaveform, type EditTool, type AppView,
   DRUM_LABELS, DRUM_PITCHES, PIANO_MIN, PIANO_MAX,
-  isBlackPitch, pitchName, makeNoteId, createInitialSong, TRACK_COLORS,
+  isBlackPitch, pitchName, makeNoteId, makeBendId, createInitialSong, TRACK_COLORS,
   drumPitchLabel, DEFAULT_DRUM_ROWS, GM_PROGRAMS, makeDefaultTracks,
 } from './types';
-import { resumeAudio, playNote, playDrum, loadSoundFont, isSoundFontReady, startSustainedNote } from './audio';
+import { resumeAudio, playNote, playDrum, loadSoundFont, isSoundFontReady, startSustainedNote, shapedCurve } from './audio';
 import SongView, { SONG_LEFT_W, SONG_BAR_W } from './SongView';
+import selectIcon    from './icons/select.svg';
+import drawIcon      from './icons/draw.svg';
+import paintIcon     from './icons/paint.svg';
+import eraseNoteIcon from './icons/erase-note.svg';
+import bendIcon      from './icons/bend.svg';
+import eraseBendIcon from './icons/erase-bend.svg';
 import './MidiEditor.css';
 
 // ── Layout & zoom constants ────────────────────────────────────────────────────
@@ -41,6 +47,8 @@ type ResizeState  = { noteId: string; trackId: string; startX: number; origDurat
 type MoveNote     = { trackId: string; origPitch: number; origStep: number };
 type MoveState    = { startClientX: number; startClientY: number; notes: Map<string, MoveNote> };
 type ClipboardNote = { trackId: string; note: Note };
+type BendDisplay  = 'all' | 'lines' | 'indicator';
+type KnobDragState = { bendId: string; trackId: string; startX: number; startCurvature: number };
 
 interface SaveEntry { name: string; song?: Song; pattern?: unknown; savedAt: string }
 
@@ -61,7 +69,7 @@ const STORAGE_SAVES = 'midi-editor-saves';
 const STORAGE_ZOOM  = 'midi-editor-zoom';
 
 function migrateTrack(t: Track): Track {
-  const defaults: Partial<Track> = { volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0 };
+  const defaults: Partial<Track> = { volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0, bends: [] };
   if (t.isDrum && !t.drumRows) defaults.drumRows = [...DEFAULT_DRUM_ROWS];
   return { ...defaults, ...t } as Track;
 }
@@ -141,13 +149,14 @@ function downloadJson(song: Song) {
   URL.revokeObjectURL(url);
 }
 
+const MIDI_BEND_RANGE = 48; // semitones; set via RPN at start of each melodic track
+
 function exportToMidi(song: Song, selectedClipId: string): void {
   const PPQ = 480;
   const { stepsPerBeat, beatsPerBar, bpm } = song;
   const stepsPerBar = stepsPerBeat * beatsPerBar;
   const microsecondsPerBeat = Math.round(60_000_000 / bpm);
 
-  // If arrangement is empty, treat selected clip as placed at bar 0
   const blocks: Array<{ clipId: string; startBar: number }> =
     song.arrangement.length > 0
       ? song.arrangement
@@ -156,18 +165,17 @@ function exportToMidi(song: Song, selectedClipId: string): void {
   const maxSlots = Math.max(...song.clips.map(c => c.tracks.length), 0);
   if (maxSlots === 0) return;
 
-  type SlotMeta = { isDrum: boolean; gmProgram?: number; name: string };
+  type SlotMeta = { isDrum: boolean; gmProgram?: number; name: string; hasBends: boolean };
   const slotMeta: SlotMeta[] = Array.from({ length: maxSlots }, (_, i) => {
     for (const clip of song.clips) {
       if (i < clip.tracks.length) {
         const t = clip.tracks[i];
-        return { isDrum: t.isDrum, gmProgram: t.gmProgram, name: t.name };
+        return { isDrum: t.isDrum, gmProgram: t.gmProgram, name: t.name, hasBends: t.bends.length > 0 };
       }
     }
-    return { isDrum: false, name: `Track ${i + 1}` };
+    return { isDrum: false, name: `Track ${i + 1}`, hasBends: false };
   });
 
-  // Assign MIDI channels — drums always on 9, melodic on 0-8, 10-15
   const slotChannel: number[] = [];
   let melodicCh = 0;
   for (let s = 0; s < maxSlots; s++) {
@@ -179,7 +187,9 @@ function exportToMidi(song: Song, selectedClipId: string): void {
     }
   }
 
-  type MidiEv = { tick: number; isOff: boolean; pitch: number; velocity: number; ch: number };
+  type NoteEv = { kind: 'note'; tick: number; isOff: boolean; pitch: number; velocity: number; ch: number };
+  type BendEv = { kind: 'bend'; tick: number; value: number; ch: number };
+  type MidiEv = NoteEv | BendEv;
   const slotEvents: MidiEv[][] = Array.from({ length: maxSlots }, () => []);
 
   for (const block of blocks) {
@@ -191,18 +201,39 @@ function exportToMidi(song: Song, selectedClipId: string): void {
       if (slot >= maxSlots || track.muted) return;
       const ch    = slotChannel[slot];
       const shift = track.isDrum ? 0 : (track.octaveOffset ?? 0);
+      const noteById = new Map(track.notes.map(n => [n.id, n]));
+
       for (const note of track.notes) {
         const t0 = Math.round((blockStartStep + note.startStep) * PPQ / stepsPerBeat);
         const t1 = Math.round((blockStartStep + note.startStep + note.durationSteps) * PPQ / stepsPerBeat);
         const p  = Math.max(0, Math.min(127, note.pitch + shift));
-        slotEvents[slot].push({ tick: t0, isOff: false, pitch: p, velocity: note.velocity & 0x7F, ch });
-        slotEvents[slot].push({ tick: t1, isOff: true,  pitch: p, velocity: 64,                  ch });
+        slotEvents[slot].push({ kind: 'note', tick: t0, isOff: false, pitch: p, velocity: note.velocity & 0x7F, ch });
+        slotEvents[slot].push({ kind: 'note', tick: t1, isOff: true,  pitch: p, velocity: 64, ch });
+
+        const bend = track.bends.find(b => b.fromNoteId === note.id);
+        if (bend) {
+          const toNote = noteById.get(bend.toNoteId);
+          if (toNote) {
+            const semDelta = (toNote.pitch + shift) - p;
+            const N = 16;
+            const durTicks = t1 - t0;
+            for (let i = 0; i < N; i++) {
+              const q = shapedCurve(i / (N - 1), bend.curvature);
+              const bendVal = Math.round(8192 + (semDelta * q / MIDI_BEND_RANGE) * 8192);
+              const clampedVal = Math.max(0, Math.min(16383, bendVal));
+              slotEvents[slot].push({ kind: 'bend', tick: t0 + Math.round(i * durTicks / (N - 1)), value: clampedVal, ch });
+            }
+            // Reset bend after note ends
+            slotEvents[slot].push({ kind: 'bend', tick: t1 + 1, value: 8192, ch });
+          }
+        }
       }
     });
   }
 
-  // Sort by tick; note-offs before note-ons at the same tick
-  slotEvents.forEach(evs => evs.sort((a, b) => a.tick - b.tick || (a.isOff ? -1 : 1)));
+  slotEvents.forEach(evs => evs.sort((a, b) =>
+    a.tick - b.tick || (a.kind === 'bend' ? -1 : b.kind === 'bend' ? 1 : (a.kind === 'note' && a.isOff ? -1 : 1))
+  ));
 
   function vlq(n: number): number[] {
     const out: number[] = [n & 0x7F];
@@ -233,10 +264,25 @@ function exportToMidi(song: Song, selectedClipId: string): void {
     if (!meta.isDrum && meta.gmProgram !== undefined) {
       data.push(...vlq(0), 0xC0 | ch, meta.gmProgram & 0x7F);
     }
+    // Set pitch bend range via RPN 0 if this track has bends
+    if (!meta.isDrum && meta.hasBends) {
+      data.push(
+        ...vlq(0), 0xB0 | ch, 101, 0,    // RPN MSB
+        ...vlq(0), 0xB0 | ch, 100, 0,    // RPN LSB → selects pitch bend sensitivity
+        ...vlq(0), 0xB0 | ch,   6, MIDI_BEND_RANGE,  // data entry MSB = semitones
+        ...vlq(0), 0xB0 | ch,  38, 0,    // data entry LSB
+        ...vlq(0), 0xB0 | ch, 101, 127,  // deselect RPN
+        ...vlq(0), 0xB0 | ch, 100, 127,
+      );
+    }
     let curTick = 0;
     for (const ev of evs) {
       const delta = ev.tick - curTick; curTick = ev.tick;
-      data.push(...vlq(delta), (ev.isOff ? 0x80 : 0x90) | ch, ev.pitch, ev.velocity);
+      if (ev.kind === 'bend') {
+        data.push(...vlq(delta), 0xE0 | ch, ev.value & 0x7F, (ev.value >> 7) & 0x7F);
+      } else {
+        data.push(...vlq(delta), (ev.isOff ? 0x80 : 0x90) | ch, ev.pitch, ev.velocity);
+      }
     }
     data.push(...vlq(0), 0xFF, 0x2F, 0x00);
     return mtrk(data);
@@ -512,7 +558,6 @@ interface TransportProps {
   selectedClipId: string;
   isPlaying: boolean;
   zoomIdx: number;
-  tool: EditTool;
   view: AppView;
   onPlay: () => void;
   onStop: () => void;
@@ -521,24 +566,18 @@ interface TransportProps {
   onStepsPerBeatChange: (spb: number) => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
-  onToolChange: (t: EditTool) => void;
   onViewChange: (v: AppView) => void;
   onSelectClip: (clipId: string) => void;
 }
 
 function Transport({
-  song, selectedClipId, isPlaying, zoomIdx, tool, view,
+  song, selectedClipId, isPlaying, zoomIdx, view,
   onPlay, onStop, onBpmChange, onBarsChange, onStepsPerBeatChange,
-  onZoomIn, onZoomOut, onToolChange, onViewChange, onSelectClip,
+  onZoomIn, onZoomOut, onViewChange, onSelectClip,
 }: TransportProps) {
   function nudge(delta: number) { onBpmChange(Math.max(40, Math.min(240, song.bpm + delta))); }
 
   const selectedClip = song.clips.find(c => c.id === selectedClipId) ?? song.clips[0];
-  const TOOLS: { key: EditTool; label: string }[] = [
-    { key: 'select', label: 'SEL' },
-    { key: 'draw',   label: 'DRAW' },
-    { key: 'paint',  label: 'PAINT' },
-  ];
 
   return (
     <div className="me-transport">
@@ -564,16 +603,6 @@ function Transport({
               <select className="me-select" value={selectedClipId} onChange={e => onSelectClip(e.target.value)}>
                 {song.clips.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
               </select>
-            </div>
-
-            <div className="me-transport__sep" />
-
-            {/* Tools */}
-            <div className="me-tool-group">
-              {TOOLS.map(t => (
-                <button key={t.key} className={`me-btn me-btn--sm${tool === t.key ? ' me-btn--primary' : ''}`}
-                  onPointerDown={() => onToolChange(t.key)}>{t.label}</button>
-              ))}
             </div>
 
             <div className="me-transport__sep" />
@@ -613,7 +642,58 @@ function Transport({
           <button className="me-btn me-btn--sm" onPointerDown={() => nudge(5)}>+</button>
         </div>
 
-        <span className="me-label me-label--dim">SPC=play{view === 'pattern' ? ' S/D/P=tool' : ''}</span>
+        <span className="me-label me-label--dim">SPC=play</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Tool palette ───────────────────────────────────────────────────────────────
+
+const NOTE_TOOLS: { key: EditTool; icon: string; title: string }[] = [
+  { key: 'select',     icon: selectIcon,    title: 'Select (S)' },
+  { key: 'draw',       icon: drawIcon,      title: 'Draw (D)' },
+  { key: 'paint',      icon: paintIcon,     title: 'Paint (P)' },
+  { key: 'erase',      icon: eraseNoteIcon, title: 'Erase Note (E)' },
+];
+
+const BEND_TOOLS: { key: EditTool; icon: string; title: string }[] = [
+  { key: 'bend',       icon: bendIcon,      title: 'Add Bend (B)' },
+  { key: 'erase-bend', icon: eraseBendIcon, title: 'Erase Bend' },
+];
+
+interface ToolPaletteProps {
+  tool: EditTool;
+  onToolChange: (t: EditTool) => void;
+}
+
+function ToolPalette({ tool, onToolChange }: ToolPaletteProps) {
+  return (
+    <div className="me-tool-palette">
+      <div className="me-tool-palette__group">
+        {NOTE_TOOLS.map(t => (
+          <button
+            key={t.key}
+            className={`me-tool-btn${tool === t.key ? ' me-tool-btn--active' : ''}`}
+            onPointerDown={() => onToolChange(t.key)}
+            title={t.title}
+          >
+            <img src={t.icon} alt={t.title} width="24" height="24" draggable={false} />
+          </button>
+        ))}
+      </div>
+      <div className="me-tool-palette__divider" />
+      <div className="me-tool-palette__group">
+        {BEND_TOOLS.map(t => (
+          <button
+            key={t.key}
+            className={`me-tool-btn${tool === t.key ? ' me-tool-btn--active' : ''}`}
+            onPointerDown={() => onToolChange(t.key)}
+            title={t.title}
+          >
+            <img src={t.icon} alt={t.title} width="24" height="24" draggable={false} />
+          </button>
+        ))}
       </div>
     </div>
   );
@@ -632,6 +712,10 @@ interface MelodicGridProps {
   selectedIds: ReadonlySet<string>;
   paintModeRef: React.MutableRefObject<PaintState>;
   lastNoteDurationRef: React.MutableRefObject<number>;
+  bendDraft: { fromNoteId: string; trackId: string } | null;
+  bendDisplay: BendDisplay;
+  eraseHoverNoteId: string | null;
+  eraseBendHoverId: string | null;
   onAddNote: (pitch: number, step: number, duration?: number, noteId?: string) => void;
   onRemoveNote: (noteId: string) => void;
   onStartResize: (noteId: string, startX: number, origDur: number, noteStart: number) => void;
@@ -639,13 +723,21 @@ interface MelodicGridProps {
   onSelectNote: (noteId: string, addToSelection: boolean) => void;
   onDeselectAll: () => void;
   onStartMove: (noteId: string, clientX: number, clientY: number) => void;
+  onNoteClickBend: (noteId: string) => void;
+  onEraseNoteHover: (noteId: string | null) => void;
+  onEraseBendHover: (bendId: string | null) => void;
+  onBendKnobDragStart: (bendId: string, startX: number) => void;
+  onRemoveBend: (bendId: string) => void;
 }
 
 function MelodicGrid({
   track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, tool,
   selectedIds, paintModeRef, lastNoteDurationRef,
+  bendDraft, bendDisplay, eraseHoverNoteId, eraseBendHoverId,
   onAddNote, onRemoveNote, onStartResize, onPreviewPitch,
   onSelectNote, onDeselectAll, onStartMove,
+  onNoteClickBend, onEraseNoteHover, onEraseBendHover,
+  onBendKnobDragStart, onRemoveBend,
 }: MelodicGridProps) {
   const noteMap   = useMemo(() => buildNoteMap(track), [track]);
   const gridW     = totalSteps * stepW;
@@ -653,9 +745,16 @@ function MelodicGrid({
   const noteRects = useMemo(() => track.notes.filter(n => n.startStep < totalSteps), [track.notes, totalSteps]);
 
   function cellDown(pitch: number, step: number, e: React.PointerEvent) {
-    if (tool === 'select') { onDeselectAll(); return; }
+    if (tool === 'select' || tool === 'bend' || tool === 'erase-bend') {
+      if (tool === 'select') onDeselectAll();
+      return;
+    }
     const existingId = noteMap.get(`${pitch},${step}`);
     if (existingId) {
+      if (tool === 'erase') {
+        onRemoveNote(existingId);
+        return;
+      }
       paintModeRef.current = { action: 'remove', trackId: track.id };
       onRemoveNote(existingId);
     } else if (tool === 'draw') {
@@ -664,14 +763,114 @@ function MelodicGrid({
       onAddNote(pitch, step, dur, newId);
       onPreviewPitch(pitch);
       onStartResize(newId, e.clientX, dur, step);
-    } else {
+    } else if (tool === 'paint') {
       paintModeRef.current = { action: 'add', trackId: track.id };
       onAddNote(pitch, step, lastNoteDurationRef.current);
       onPreviewPitch(pitch);
     }
   }
 
-  const editActive = tool !== 'select';
+  const isBendMode = tool === 'bend';
+  const editActive = tool !== 'select' && tool !== 'bend' && tool !== 'erase-bend';
+
+  // Compute bend SVG overlay
+  const bends = track.bends ?? [];
+  const noteById = useMemo(() => {
+    const m = new Map<string, Note>();
+    track.notes.forEach(n => m.set(n.id, n));
+    return m;
+  }, [track.notes]);
+
+  const bendOverlay = useMemo(() => {
+    if (bendDisplay === 'indicator' || bends.length === 0) return null;
+    const showKnob = bendDisplay === 'all';
+    return bends.map(bend => {
+      const fromNote = noteById.get(bend.fromNoteId);
+      const toNote   = noteById.get(bend.toNoteId);
+      if (!fromNote || !toNote) return null;
+      const fromRow = PITCH_TO_ROW.get(fromNote.pitch);
+      const toRow   = PITCH_TO_ROW.get(toNote.pitch);
+      if (fromRow === undefined || toRow === undefined) return null;
+
+      const x1 = (fromNote.startStep + Math.min(fromNote.durationSteps, totalSteps - fromNote.startStep)) * stepW;
+      const y1 = fromRow * rowH + rowH / 2;
+      const x2 = toNote.startStep * stepW;
+      const y2 = toRow * rowH + rowH / 2;
+      const mx = (x1 + x2) / 2;
+      const my = (y1 + y2) / 2;
+
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const len = Math.sqrt(dx * dx + dy * dy) || 1;
+      const maxOffset = Math.min(60, Math.max(20, len * 0.3));
+      const cpx = mx + bend.curvature * (-dy / len) * maxOffset;
+      const cpy = my + bend.curvature * ( dx / len) * maxOffset;
+      const pathD = `M ${x1} ${y1} Q ${cpx} ${cpy} ${x2} ${y2}`;
+
+      const isEraseHover = eraseBendHoverId === bend.id;
+      const isRelatedToEraseNote = eraseHoverNoteId !== null &&
+        (bend.fromNoteId === eraseHoverNoteId || bend.toNoteId === eraseHoverNoteId);
+      const stroke = (isEraseHover || isRelatedToEraseNote) ? '#cc0000' : '#1a1a1a';
+      const strokeW = (isEraseHover || isRelatedToEraseNote) ? 3 : 2;
+
+      // Knob indicator dot angle: 0 = 12 o'clock, ±1 = ±90°
+      const dotAngle = bend.curvature * (Math.PI / 2);
+      const dotX = mx + 9 * Math.sin(dotAngle);
+      const dotY = my - 9 * Math.cos(dotAngle);
+
+      const canDragKnob = tool === 'select' || tool === 'bend';
+      const canErase    = tool === 'erase-bend';
+
+      return (
+        <g key={bend.id}>
+          <path d={pathD} fill="none" stroke={stroke} strokeWidth={strokeW} strokeLinecap="round" />
+          {showKnob && (
+            <g>
+              <circle
+                cx={mx} cy={my} r={11}
+                fill={isEraseHover ? '#ffc0c0' : '#c0c0c0'}
+                stroke={stroke} strokeWidth={1.5}
+                style={{ cursor: canDragKnob ? 'ew-resize' : canErase ? 'pointer' : 'default' }}
+                onPointerEnter={() => canErase && onEraseBendHover(bend.id)}
+                onPointerLeave={() => canErase && onEraseBendHover(null)}
+                onPointerDown={e => {
+                  e.stopPropagation(); e.preventDefault();
+                  if (canErase) { onRemoveBend(bend.id); return; }
+                  if (canDragKnob) onBendKnobDragStart(bend.id, e.clientX);
+                }}
+              />
+              <circle cx={dotX} cy={dotY} r={2.5} fill="#cc4400" style={{ pointerEvents: 'none' }} />
+            </g>
+          )}
+          {/* Wide invisible hit area on line for erase-bend */}
+          {canErase && (
+            <path
+              d={pathD} fill="none" stroke="transparent" strokeWidth={12}
+              style={{ cursor: 'pointer' }}
+              onPointerEnter={() => onEraseBendHover(bend.id)}
+              onPointerLeave={() => onEraseBendHover(null)}
+              onPointerDown={e => { e.stopPropagation(); e.preventDefault(); onRemoveBend(bend.id); }}
+            />
+          )}
+        </g>
+      );
+    });
+  }, [bends, noteById, stepW, rowH, totalSteps, bendDisplay, eraseBendHoverId, eraseHoverNoteId, tool,
+      onEraseBendHover, onRemoveBend, onBendKnobDragStart]);
+
+  // Indicator arrows on right edge of notes that have bends
+  const bendIndicators = useMemo(() => {
+    if (bendDisplay !== 'indicator' || bends.length === 0) return null;
+    return bends.map(bend => {
+      const fromNote = noteById.get(bend.fromNoteId);
+      if (!fromNote) return null;
+      const fromRow = PITCH_TO_ROW.get(fromNote.pitch);
+      if (fromRow === undefined) return null;
+      const x = (fromNote.startStep + Math.min(fromNote.durationSteps, totalSteps - fromNote.startStep)) * stepW - 6;
+      const y = fromRow * rowH + rowH / 2;
+      return <text key={bend.id} x={x} y={y + 3} fontSize={8} fill="#cc4400" style={{ pointerEvents: 'none' }}>›</text>;
+    });
+  }, [bends, noteById, stepW, rowH, totalSteps, bendDisplay]);
 
   return (
     <div
@@ -711,32 +910,49 @@ function MelodicGrid({
         if (rowIdx === undefined) return null;
         const displayDur = Math.min(note.durationSteps, totalSteps - note.startStep);
         const isSelected = selectedIds.has(note.id);
+        const isEraseHover = tool === 'erase' && eraseHoverNoteId === note.id;
+        const isBendSource = isBendMode && bendDraft?.fromNoteId === note.id;
+        const isBendTarget = isBendMode && bendDraft !== null && bendDraft.trackId === track.id && bendDraft.fromNoteId !== note.id;
+        let noteClass = 'me-note-rect';
+        if (isSelected)    noteClass += ' me-note-rect--selected';
+        if (isBendMode)    noteClass += ' me-note-rect--bend-mode';
+        if (isBendSource)  noteClass += ' me-note-rect--bend-source';
+        if (isBendTarget)  noteClass += ' me-note-rect--bend-target';
+        if (isEraseHover)  noteClass += ' me-note-rect--erase-hover';
         return (
           <div
             key={note.id}
-            className={`me-note-rect${isSelected ? ' me-note-rect--selected' : ''}`}
+            className={noteClass}
             style={{ left: note.startStep * stepW, top: rowIdx * rowH, width: displayDur * stepW, height: rowH, background: track.color }}
             data-note-id={note.id} data-track-id={track.id}
             onContextMenu={(e: React.MouseEvent) => { e.preventDefault(); onRemoveNote(note.id); }}
+            onPointerEnter={() => { if (tool === 'erase') onEraseNoteHover(note.id); }}
+            onPointerLeave={() => { if (tool === 'erase') onEraseNoteHover(null); }}
             onPointerDown={(e: React.PointerEvent) => {
               e.preventDefault(); e.stopPropagation();
               if (tool === 'select') {
                 onSelectNote(note.id, e.ctrlKey || e.metaKey);
                 onStartMove(note.id, e.clientX, e.clientY);
-              } else {
+              } else if (tool === 'erase') {
+                onRemoveNote(note.id);
+              } else if (tool === 'bend') {
+                onNoteClickBend(note.id);
+              } else if (tool !== 'erase-bend') {
                 paintModeRef.current = { action: 'remove', trackId: track.id };
                 onRemoveNote(note.id);
               }
             }}
           >
-            <div
-              className="me-note-resize-handle"
-              onPointerDown={e => {
-                e.stopPropagation(); e.preventDefault();
-                paintModeRef.current = null;
-                onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
-              }}
-            />
+            {tool !== 'bend' && tool !== 'erase-bend' && tool !== 'erase' && (
+              <div
+                className="me-note-resize-handle"
+                onPointerDown={e => {
+                  e.stopPropagation(); e.preventDefault();
+                  paintModeRef.current = null;
+                  onStartResize(note.id, e.clientX, note.durationSteps, note.startStep);
+                }}
+              />
+            )}
           </div>
         );
       })}
@@ -745,6 +961,14 @@ function MelodicGrid({
           ? <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * rowH, width: gridW }} />
           : null
       )}
+      {/* Bend overlay — drawn above notes */}
+      <svg
+        style={{ position: 'absolute', inset: 0, width: gridW, height: gridH, pointerEvents: 'none', overflow: 'visible' }}
+        className={isBendMode || tool === 'erase-bend' ? 'me-bend-svg--active' : ''}
+      >
+        {bendOverlay}
+        {bendIndicators}
+      </svg>
     </div>
   );
 }
@@ -834,6 +1058,10 @@ interface TrackSectionProps {
   selectedIds: ReadonlySet<string>;
   paintModeRef: React.MutableRefObject<PaintState>;
   lastNoteDurationRef: React.MutableRefObject<number>;
+  bendDraft: { fromNoteId: string; trackId: string } | null;
+  bendDisplay: BendDisplay;
+  eraseHoverNoteId: string | null;
+  eraseBendHoverId: string | null;
   onToggleCollapse: () => void;
   onGear: () => void;
   onMute: () => void;
@@ -849,16 +1077,24 @@ interface TrackSectionProps {
   onSelectNote: (noteId: string, addToSelection: boolean) => void;
   onDeselectAll: () => void;
   onStartMove: (noteId: string, clientX: number, clientY: number) => void;
+  onNoteClickBend: (noteId: string) => void;
+  onEraseNoteHover: (noteId: string | null) => void;
+  onEraseBendHover: (bendId: string | null) => void;
+  onBendKnobDragStart: (bendId: string, startX: number) => void;
+  onRemoveBend: (bendId: string) => void;
 }
 
 function TrackSection({
   track, totalSteps, stepsPerBeat, beatsPerBar, stepW, rowH, tool,
   selectedIds, paintModeRef, lastNoteDurationRef,
+  bendDraft, bendDisplay, eraseHoverNoteId, eraseBendHoverId,
   onToggleCollapse, onGear, onMute,
   onAddNote, onAddDrumNote, onRemoveNote, onStartResize,
   onStartPreviewPitch, onStopPreviewPitch, onPreviewDrum,
   onAddDrumPiece, onRemoveDrumPiece,
   onSelectNote, onDeselectAll, onStartMove,
+  onNoteClickBend, onEraseNoteHover, onEraseBendHover,
+  onBendKnobDragStart, onRemoveBend,
 }: TrackSectionProps) {
   const [showAddPiece, setShowAddPiece] = useState(false);
 
@@ -921,9 +1157,14 @@ function TrackSection({
               : <MelodicGrid track={track} totalSteps={totalSteps} stepsPerBeat={stepsPerBeat} beatsPerBar={beatsPerBar}
                   stepW={stepW} rowH={rowH} tool={tool} selectedIds={selectedIds}
                   paintModeRef={paintModeRef} lastNoteDurationRef={lastNoteDurationRef}
+                  bendDraft={bendDraft} bendDisplay={bendDisplay}
+                  eraseHoverNoteId={eraseHoverNoteId} eraseBendHoverId={eraseBendHoverId}
                   onAddNote={onAddNote} onRemoveNote={onRemoveNote} onStartResize={onStartResize}
                   onPreviewPitch={onStartPreviewPitch}
-                  onSelectNote={onSelectNote} onDeselectAll={onDeselectAll} onStartMove={onStartMove} />
+                  onSelectNote={onSelectNote} onDeselectAll={onDeselectAll} onStartMove={onStartMove}
+                  onNoteClickBend={onNoteClickBend} onEraseNoteHover={onEraseNoteHover}
+                  onEraseBendHover={onEraseBendHover} onBendKnobDragStart={onBendKnobDragStart}
+                  onRemoveBend={onRemoveBend} />
             }
           </div>
 
@@ -971,6 +1212,11 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const [showLoad,      setShowLoad]      = useState(false);
   const [pendingAction, setPendingAction] = useState<{ fn: () => void } | null>(null);
   const [selectedIds,   setSelectedIds]   = useState<Set<string>>(new Set<string>());
+  const [bendDisplay,   setBendDisplay]   = useState<BendDisplay>('all');
+  const [bendDraft,     setBendDraft]     = useState<{ fromNoteId: string; trackId: string } | null>(null);
+  const [eraseHoverNoteId, setEraseHoverNoteId] = useState<string | null>(null);
+  const [eraseBendHoverId, setEraseBendHoverId] = useState<string | null>(null);
+  const knobDragRef = useRef<KnobDragState | null>(null);
 
   const selectedClip = song.clips.find(c => c.id === selectedClipId) ?? song.clips[0];
 
@@ -1054,6 +1300,21 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     const stepDur = 60 / s.bpm / s.stepsPerBeat;
     movePlayhead(step);
 
+    function fireNote(track: Track, note: Note) {
+      if (track.isDrum) { playDrum(note.pitch, note.velocity); return; }
+      const shift = track.octaveOffset ?? 0;
+      const bend  = track.bends.find(b => b.fromNoteId === note.id);
+      let bendToPitch: number | undefined;
+      let bendCurvature = 0;
+      if (bend) {
+        const toNote = track.notes.find(n => n.id === bend.toNoteId);
+        if (toNote) { bendToPitch = toNote.pitch + shift; bendCurvature = bend.curvature; }
+      }
+      playNote(note.pitch + shift, note.velocity, note.durationSteps * stepDur,
+        track.waveform, undefined, track.volume, track.attack, track.release,
+        track.gmProgram, bendToPitch, bendCurvature);
+    }
+
     if (viewRef.current === 'pattern') {
       // Play selected clip, looped
       const clip = s.clips.find(c => c.id === selectedClipIdRef.current) ?? s.clips[0];
@@ -1061,12 +1322,9 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       const localStep = step % clipTotalSteps;
       clip.tracks.forEach(track => {
         if (track.muted) return;
-        const shift = track.octaveOffset ?? 0;
         track.notes.forEach((note: Note) => {
           if (note.startStep !== localStep || note.startStep >= clipTotalSteps) return;
-          if (track.isDrum) playDrum(note.pitch, note.velocity);
-          else playNote(note.pitch + shift, note.velocity, note.durationSteps * stepDur,
-            track.waveform, undefined, track.volume, track.attack, track.release, track.gmProgram);
+          fireNote(track, note);
         });
       });
       stepRef.current = (step + 1) % clipTotalSteps;
@@ -1083,12 +1341,9 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         const localStep = step - block.startBar * stepsPerBar;
         clip.tracks.forEach(track => {
           if (track.muted) return;
-          const shift = track.octaveOffset ?? 0;
           track.notes.forEach((note: Note) => {
             if (note.startStep !== localStep) return;
-            if (track.isDrum) playDrum(note.pitch, note.velocity);
-            else playNote(note.pitch + shift, note.velocity, note.durationSteps * stepDur,
-              track.waveform, undefined, track.volume, track.attack, track.release, track.gmProgram);
+            fireNote(track, note);
           });
         });
       });
@@ -1207,10 +1462,26 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         const noteId = noteRect.dataset.noteId ?? '';
         if (noteId) {
           setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
-            tracks.map(t => t.id !== pm.trackId ? t : { ...t, notes: t.notes.filter(n => n.id !== noteId) })
+            tracks.map(t => t.id !== pm.trackId ? t : {
+              ...t,
+              notes: t.notes.filter(n => n.id !== noteId),
+              bends: t.bends.filter(b => b.fromNoteId !== noteId && b.toNoteId !== noteId),
+            })
           ));
         }
       }
+    }
+
+    // Knob drag
+    const kd = knobDragRef.current;
+    if (kd) {
+      const delta = (e.clientX - kd.startX) / 100;
+      const newCurvature = Math.max(-1, Math.min(1, kd.startCurvature + delta));
+      setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
+        tracks.map(t => t.id !== kd.trackId ? t : {
+          ...t, bends: t.bends.map(b => b.id !== kd.bendId ? b : { ...b, curvature: newCurvature }),
+        })
+      ));
     }
   };
 
@@ -1226,6 +1497,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     resizeStateRef.current  = null;
     isMoveActiveRef.current = false;
     moveStateRef.current    = null;
+    knobDragRef.current     = null;
     if (sustainedNoteStopRef.current) {
       sustainedNoteStopRef.current();
       sustainedNoteStopRef.current = null;
@@ -1257,9 +1529,12 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         return;
       }
       if (!inInput && !e.ctrlKey && !e.metaKey) {
-        if (e.code === 'KeyS') { setTool('select'); return; }
-        if (e.code === 'KeyD') { setTool('draw');   return; }
-        if (e.code === 'KeyP') { setTool('paint');  return; }
+        if (e.code === 'KeyS') { setTool('select'); setBendDraft(null); return; }
+        if (e.code === 'KeyD') { setTool('draw');   setBendDraft(null); return; }
+        if (e.code === 'KeyP') { setTool('paint');  setBendDraft(null); return; }
+        if (e.code === 'KeyE') { setTool('erase');  setBendDraft(null); return; }
+        if (e.code === 'KeyB') { setTool('bend');                       return; }
+        if (e.code === 'Escape') { setBendDraft(null); return; }
       }
       if ((e.code === 'Delete' || e.code === 'Backspace') && !inInput) {
         const ids = selectedIdsRef.current;
@@ -1336,8 +1611,43 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const removeNote = useCallback((trackId: string, noteId: string) => {
     setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
-      tracks.map(t => t.id !== trackId ? t : { ...t, notes: t.notes.filter(n => n.id !== noteId) })
+      tracks.map(t => t.id !== trackId ? t : {
+        ...t,
+        notes: t.notes.filter(n => n.id !== noteId),
+        bends: t.bends.filter(b => b.fromNoteId !== noteId && b.toNoteId !== noteId),
+      })
     ));
+  }, []);
+
+  const addBend = useCallback((fromTrackId: string, fromNoteId: string, toNoteId: string) => {
+    const id = makeBendId();
+    const newBend: Bend = { id, fromNoteId, toNoteId, curvature: 0 };
+    setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
+      tracks.map(t => t.id !== fromTrackId ? t : {
+        ...t, bends: [...t.bends, newBend],
+      })
+    ));
+  }, []);
+
+  const removeBend = useCallback((trackId: string, bendId: string) => {
+    setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
+      tracks.map(t => t.id !== trackId ? t : { ...t, bends: t.bends.filter(b => b.id !== bendId) })
+    ));
+  }, []);
+
+  const handleNoteClickBend = useCallback((trackId: string, noteId: string) => {
+    setBendDraft(prev => {
+      if (prev === null) return { fromNoteId: noteId, trackId };
+      if (prev.trackId !== trackId || prev.fromNoteId === noteId) return null;
+      addBend(trackId, prev.fromNoteId, noteId);
+      return null;
+    });
+  }, [addBend]);
+
+  const handleBendKnobDragStart = useCallback((trackId: string, bendId: string, startX: number) => {
+    const clip = songRef.current.clips.find(c => c.id === selectedClipIdRef.current) ?? songRef.current.clips[0];
+    const bend = clip?.tracks.find(t => t.id === trackId)?.bends.find(b => b.id === bendId);
+    if (bend) knobDragRef.current = { bendId, trackId, startX, startCurvature: bend.curvature };
   }, []);
 
   const startResize = useCallback((noteId: string, trackId: string, startX: number, origDuration: number, noteStartStep: number) => {
@@ -1390,7 +1700,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         id: makeNoteId(), name: `Track ${clip.tracks.filter(t => !t.isDrum).length + 1}`,
         color: TRACK_COLORS[idx % TRACK_COLORS.length],
         waveform: 'sine', notes: [], muted: false, isDrum: false,
-        volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0,
+        volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0, bends: [],
       };
       return { ...clip, tracks: [...clip.tracks, newTrack] };
     }));
@@ -1405,7 +1715,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         color: TRACK_COLORS[(drumCount + 3) % TRACK_COLORS.length],
         waveform: 'sine', notes: [], muted: false, isDrum: true,
         volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0,
-        drumRows: [...DEFAULT_DRUM_ROWS],
+        drumRows: [...DEFAULT_DRUM_ROWS], bends: [],
       };
       const tracks = [...clip.tracks];
       tracks.splice(lastDrumIdx + 1, 0, newTrack);
@@ -1575,7 +1885,17 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         { label: 'BPM 160', onClick: () => setSong(s => ({ ...s, bpm: 160 })) },
       ],
     },
-  ], [isPlaying, startPlayback, stopPlayback, newSong, newClip, addMelodicTrack, addDrumTrack, onQuit]);
+    {
+      label: 'Display',
+      items: [
+        { label: 'Bends', disabled: true },
+        { separator: true },
+        { label: 'Everything',  checked: bendDisplay === 'all',       radioGroup: 'bend-display', onClick: () => setBendDisplay('all') },
+        { label: 'Lines only',  checked: bendDisplay === 'lines',     radioGroup: 'bend-display', onClick: () => setBendDisplay('lines') },
+        { label: 'Indicator',   checked: bendDisplay === 'indicator', radioGroup: 'bend-display', onClick: () => setBendDisplay('indicator') },
+      ],
+    },
+  ], [isPlaying, startPlayback, stopPlayback, newSong, newClip, addMelodicTrack, addDrumTrack, onQuit, bendDisplay]);
 
   useWindowMenus(menus);
 
@@ -1602,7 +1922,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         selectedClipId={selectedClipId}
         isPlaying={isPlaying}
         zoomIdx={zoomIdx}
-        tool={tool}
         view={view}
         onPlay={startPlayback}
         onStop={stopPlayback}
@@ -1611,7 +1930,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         onStepsPerBeatChange={spb => { stopPlayback(); setSong(s => ({ ...s, stepsPerBeat: spb })); }}
         onZoomIn={() => setZoomIdx(i => Math.min(i + 1, ZOOM_PRESETS.length - 1))}
         onZoomOut={() => setZoomIdx(i => Math.max(i - 1, 0))}
-        onToolChange={setTool}
         onViewChange={v => { stopPlayback(); setView(v); }}
         onSelectClip={id => { setSelectedClipId(id); setView('pattern'); }}
       />
@@ -1656,6 +1974,10 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
                 selectedIds={selectedIds}
                 paintModeRef={paintModeRef}
                 lastNoteDurationRef={lastNoteDurationRef}
+                bendDraft={bendDraft}
+                bendDisplay={bendDisplay}
+                eraseHoverNoteId={eraseHoverNoteId}
+                eraseBendHoverId={eraseBendHoverId}
                 onToggleCollapse={() => toggleCollapse(track.id)}
                 onGear={() => {
                   modalOrigRef.current = { waveform: track.waveform, volume: track.volume, gmProgram: track.gmProgram, octaveOffset: track.octaveOffset };
@@ -1674,6 +1996,11 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
                 onSelectNote={selectNote}
                 onDeselectAll={deselectAll}
                 onStartMove={startMove}
+                onNoteClickBend={noteId => handleNoteClickBend(track.id, noteId)}
+                onEraseNoteHover={setEraseHoverNoteId}
+                onEraseBendHover={setEraseBendHoverId}
+                onBendKnobDragStart={(bendId, startX) => handleBendKnobDragStart(track.id, bendId, startX)}
+                onRemoveBend={bendId => removeBend(track.id, bendId)}
               />
             ))}
 
@@ -1690,6 +2017,9 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
           </div>
         )}
       </div>
+
+      {/* Tool palette — only in pattern view */}
+      {view === 'pattern' && <ToolPalette tool={tool} onToolChange={t => { setTool(t); setBendDraft(null); }} />}
 
       {/* Overlays */}
       {pendingAction && (

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -203,29 +203,37 @@ function exportToMidi(song: Song, selectedClipId: string): void {
       const shift = track.isDrum ? 0 : (track.octaveOffset ?? 0);
       const noteById = new Map(track.notes.map(n => [n.id, n]));
 
+      const skipNoteIds = new Set<string>(track.bends.map(b => b.toNoteId));
       for (const note of track.notes) {
+        if (skipNoteIds.has(note.id)) continue; // merged into source
+
+        const bend   = track.bends.find(b => b.fromNoteId === note.id);
+        const toNote = bend ? noteById.get(bend.toNoteId) : undefined;
+        const overlapStart = toNote ? Math.max(note.startStep, toNote.startStep) : 0;
+        const overlapEnd   = toNote ? Math.min(note.startStep + note.durationSteps, toNote.startStep + toNote.durationSteps) : 0;
+        const hasValidBend = toNote !== undefined && overlapEnd > overlapStart;
+
+        // Source note on/off spans from note.startStep to toNote.endStep when bent
+        const noteEnd = hasValidBend ? toNote!.startStep + toNote!.durationSteps : note.startStep + note.durationSteps;
         const t0 = Math.round((blockStartStep + note.startStep) * PPQ / stepsPerBeat);
-        const t1 = Math.round((blockStartStep + note.startStep + note.durationSteps) * PPQ / stepsPerBeat);
+        const t1 = Math.round((blockStartStep + noteEnd) * PPQ / stepsPerBeat);
         const p  = Math.max(0, Math.min(127, note.pitch + shift));
         slotEvents[slot].push({ kind: 'note', tick: t0, isOff: false, pitch: p, velocity: note.velocity & 0x7F, ch });
         slotEvents[slot].push({ kind: 'note', tick: t1, isOff: true,  pitch: p, velocity: 64, ch });
 
-        const bend = track.bends.find(b => b.fromNoteId === note.id);
-        if (bend) {
-          const toNote = noteById.get(bend.toNoteId);
-          if (toNote) {
-            const semDelta = (toNote.pitch + shift) - p;
-            const N = 16;
-            const durTicks = t1 - t0;
-            for (let i = 0; i < N; i++) {
-              const q = shapedCurve(i / (N - 1), bend.curvature);
-              const bendVal = Math.round(8192 + (semDelta * q / MIDI_BEND_RANGE) * 8192);
-              const clampedVal = Math.max(0, Math.min(16383, bendVal));
-              slotEvents[slot].push({ kind: 'bend', tick: t0 + Math.round(i * durTicks / (N - 1)), value: clampedVal, ch });
-            }
-            // Reset bend after note ends
-            slotEvents[slot].push({ kind: 'bend', tick: t1 + 1, value: 8192, ch });
+        if (hasValidBend && toNote) {
+          const semDelta = (toNote.pitch + shift) - p;
+          const N = 16;
+          const slideT0 = Math.round((blockStartStep + overlapStart) * PPQ / stepsPerBeat);
+          const slideT1 = Math.round((blockStartStep + overlapEnd)   * PPQ / stepsPerBeat);
+          for (let i = 0; i < N; i++) {
+            const q = shapedCurve(i / (N - 1), bend!.curvature);
+            const bendVal = Math.round(8192 + (semDelta * q / MIDI_BEND_RANGE) * 8192);
+            const clampedVal = Math.max(0, Math.min(16383, bendVal));
+            slotEvents[slot].push({ kind: 'bend', tick: slideT0 + Math.round(i * (slideT1 - slideT0) / (N - 1)), value: clampedVal, ch });
           }
+          // Reset bend after slide completes (hold at target until note-off)
+          slotEvents[slot].push({ kind: 'bend', tick: slideT1 + 1, value: 8192, ch });
         }
       }
     });
@@ -781,6 +789,13 @@ function MelodicGrid({
     return m;
   }, [track.notes]);
 
+  // Set of all note IDs already participating in a bend (source or target)
+  const usedInBend = useMemo(() => {
+    const s = new Set<string>();
+    bends.forEach(b => { s.add(b.fromNoteId); s.add(b.toNoteId); });
+    return s;
+  }, [bends]);
+
   const bendOverlay = useMemo(() => {
     if (bendDisplay === 'indicator' || bends.length === 0) return null;
     const showKnob = bendDisplay === 'all';
@@ -792,9 +807,14 @@ function MelodicGrid({
       const toRow   = PITCH_TO_ROW.get(toNote.pitch);
       if (fromRow === undefined || toRow === undefined) return null;
 
-      const x1 = (fromNote.startStep + Math.min(fromNote.durationSteps, totalSteps - fromNote.startStep)) * stepW;
+      // Line spans the overlap region: that's where the slide actually happens
+      const overlapStart = Math.max(fromNote.startStep, toNote.startStep);
+      const overlapEnd   = Math.min(fromNote.startStep + fromNote.durationSteps, toNote.startStep + toNote.durationSteps);
+      if (overlapEnd <= overlapStart) return null;
+
+      const x1 = overlapStart * stepW;
       const y1 = fromRow * rowH + rowH / 2;
-      const x2 = toNote.startStep * stepW;
+      const x2 = overlapEnd * stepW;
       const y2 = toRow * rowH + rowH / 2;
       const mx = (x1 + x2) / 2;
       const my = (y1 + y2) / 2;
@@ -830,11 +850,13 @@ function MelodicGrid({
                 cx={mx} cy={my} r={11}
                 fill={isEraseHover ? '#ffc0c0' : '#c0c0c0'}
                 stroke={stroke} strokeWidth={1.5}
-                style={{ cursor: canDragKnob ? 'ew-resize' : canErase ? 'pointer' : 'default' }}
+                style={{ cursor: canDragKnob ? 'ew-resize' : canErase ? 'pointer' : 'default',
+                         touchAction: 'none' }}
                 onPointerEnter={() => canErase && onEraseBendHover(bend.id)}
                 onPointerLeave={() => canErase && onEraseBendHover(null)}
                 onPointerDown={e => {
                   e.stopPropagation(); e.preventDefault();
+                  (e.target as Element).setPointerCapture(e.pointerId);
                   if (canErase) { onRemoveBend(bend.id); return; }
                   if (canDragKnob) onBendKnobDragStart(bend.id, e.clientX);
                 }}
@@ -858,19 +880,23 @@ function MelodicGrid({
   }, [bends, noteById, stepW, rowH, totalSteps, bendDisplay, eraseBendHoverId, eraseHoverNoteId, tool,
       onEraseBendHover, onRemoveBend, onBendKnobDragStart]);
 
-  // Indicator arrows on right edge of notes that have bends
+  // Indicator arrows at the start of the overlap region
   const bendIndicators = useMemo(() => {
     if (bendDisplay !== 'indicator' || bends.length === 0) return null;
     return bends.map(bend => {
       const fromNote = noteById.get(bend.fromNoteId);
-      if (!fromNote) return null;
+      const toNote   = noteById.get(bend.toNoteId);
+      if (!fromNote || !toNote) return null;
       const fromRow = PITCH_TO_ROW.get(fromNote.pitch);
       if (fromRow === undefined) return null;
-      const x = (fromNote.startStep + Math.min(fromNote.durationSteps, totalSteps - fromNote.startStep)) * stepW - 6;
+      const overlapStart = Math.max(fromNote.startStep, toNote.startStep);
+      const overlapEnd   = Math.min(fromNote.startStep + fromNote.durationSteps, toNote.startStep + toNote.durationSteps);
+      if (overlapEnd <= overlapStart) return null;
+      const x = overlapStart * stepW;
       const y = fromRow * rowH + rowH / 2;
       return <text key={bend.id} x={x} y={y + 3} fontSize={8} fill="#cc4400" style={{ pointerEvents: 'none' }}>›</text>;
     });
-  }, [bends, noteById, stepW, rowH, totalSteps, bendDisplay]);
+  }, [bends, noteById, stepW, rowH, bendDisplay]);
 
   return (
     <div
@@ -912,7 +938,13 @@ function MelodicGrid({
         const isSelected = selectedIds.has(note.id);
         const isEraseHover = tool === 'erase' && eraseHoverNoteId === note.id;
         const isBendSource = isBendMode && bendDraft?.fromNoteId === note.id;
-        const isBendTarget = isBendMode && bendDraft !== null && bendDraft.trackId === track.id && bendDraft.fromNoteId !== note.id;
+        const sourceNote   = bendDraft ? noteById.get(bendDraft.fromNoteId) : undefined;
+        const isBendTarget = isBendMode && bendDraft !== null && bendDraft.trackId === track.id
+          && note.id !== bendDraft.fromNoteId
+          && !usedInBend.has(note.id)
+          && sourceNote !== undefined
+          && sourceNote.startStep < note.startStep + note.durationSteps
+          && note.startStep < sourceNote.startStep + sourceNote.durationSteps;
         let noteClass = 'me-note-rect';
         if (isSelected)    noteClass += ' me-note-rect--selected';
         if (isBendMode)    noteClass += ' me-note-rect--bend-mode';
@@ -963,8 +995,8 @@ function MelodicGrid({
       )}
       {/* Bend overlay — drawn above notes */}
       <svg
-        style={{ position: 'absolute', inset: 0, width: gridW, height: gridH, pointerEvents: 'none', overflow: 'visible' }}
-        className={isBendMode || tool === 'erase-bend' ? 'me-bend-svg--active' : ''}
+        style={{ position: 'absolute', inset: 0, width: gridW, height: gridH, overflow: 'visible',
+                 pointerEvents: (isBendMode || tool === 'erase-bend') ? 'all' : 'none' }}
       >
         {bendOverlay}
         {bendIndicators}
@@ -1300,19 +1332,40 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     const stepDur = 60 / s.bpm / s.stepsPerBeat;
     movePlayhead(step);
 
-    function fireNote(track: Track, note: Note) {
+    function fireTrackNote(track: Track, note: Note, skipIds: Set<string>) {
       if (track.isDrum) { playDrum(note.pitch, note.velocity); return; }
+      if (skipIds.has(note.id)) return; // this note's audio is merged into its source's
       const shift = track.octaveOffset ?? 0;
       const bend  = track.bends.find(b => b.fromNoteId === note.id);
-      let bendToPitch: number | undefined;
-      let bendCurvature = 0;
       if (bend) {
         const toNote = track.notes.find(n => n.id === bend.toNoteId);
-        if (toNote) { bendToPitch = toNote.pitch + shift; bendCurvature = bend.curvature; }
+        if (toNote) {
+          const overlapStart = Math.max(note.startStep, toNote.startStep);
+          const overlapEnd   = Math.min(note.startStep + note.durationSteps, toNote.startStep + toNote.durationSteps);
+          if (overlapEnd > overlapStart) {
+            const totalDurSec  = (toNote.startStep + toNote.durationSteps - note.startStep) * stepDur;
+            const bendStartSec = (overlapStart - note.startStep) * stepDur;
+            const bendDurSec   = (overlapEnd - overlapStart) * stepDur;
+            playNote(note.pitch + shift, note.velocity, totalDurSec, track.waveform,
+              undefined, track.volume, track.attack, track.release,
+              track.gmProgram, toNote.pitch + shift, bend.curvature, bendStartSec, bendDurSec);
+            return;
+          }
+        }
       }
       playNote(note.pitch + shift, note.velocity, note.durationSteps * stepDur,
-        track.waveform, undefined, track.volume, track.attack, track.release,
-        track.gmProgram, bendToPitch, bendCurvature);
+        track.waveform, undefined, track.volume, track.attack, track.release, track.gmProgram);
+    }
+
+    function fireClipAtStep(clip: { bars: number; tracks: Track[] }, localStep: number, clipTotalSteps: number) {
+      clip.tracks.forEach(track => {
+        if (track.muted) return;
+        const skipIds = new Set<string>(track.bends.map(b => b.toNoteId));
+        track.notes.forEach((note: Note) => {
+          if (note.startStep !== localStep || note.startStep >= clipTotalSteps) return;
+          fireTrackNote(track, note, skipIds);
+        });
+      });
     }
 
     if (viewRef.current === 'pattern') {
@@ -1320,13 +1373,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       const clip = s.clips.find(c => c.id === selectedClipIdRef.current) ?? s.clips[0];
       const clipTotalSteps = clip.bars * s.beatsPerBar * s.stepsPerBeat;
       const localStep = step % clipTotalSteps;
-      clip.tracks.forEach(track => {
-        if (track.muted) return;
-        track.notes.forEach((note: Note) => {
-          if (note.startStep !== localStep || note.startStep >= clipTotalSteps) return;
-          fireNote(track, note);
-        });
-      });
+      fireClipAtStep(clip, localStep, clipTotalSteps);
       stepRef.current = (step + 1) % clipTotalSteps;
     } else {
       // Song mode: fire notes from all active blocks
@@ -1339,13 +1386,8 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
         if (!clip) return;
         if (globalBar < block.startBar || globalBar >= block.startBar + clip.bars) return;
         const localStep = step - block.startBar * stepsPerBar;
-        clip.tracks.forEach(track => {
-          if (track.muted) return;
-          track.notes.forEach((note: Note) => {
-            if (note.startStep !== localStep) return;
-            fireNote(track, note);
-          });
-        });
+        const clipTotalSteps = clip.bars * s.beatsPerBar * s.stepsPerBeat;
+        fireClipAtStep(clip, localStep, clipTotalSteps);
       });
 
       const nextStep = step + 1;
@@ -1637,7 +1679,14 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const handleNoteClickBend = useCallback((trackId: string, noteId: string) => {
     setBendDraft(prev => {
-      if (prev === null) return { fromNoteId: noteId, trackId };
+      if (prev === null) {
+        // Block if note already participates in any bend
+        const clip = songRef.current.clips.find(c => c.id === selectedClipIdRef.current) ?? songRef.current.clips[0];
+        const track = clip?.tracks.find(t => t.id === trackId);
+        if (!track) return null;
+        if (track.bends.some(b => b.fromNoteId === noteId || b.toNoteId === noteId)) return null;
+        return { fromNoteId: noteId, trackId };
+      }
       if (prev.trackId !== trackId || prev.fromNoteId === noteId) return null;
       addBend(trackId, prev.fromNoteId, noteId);
       return null;

--- a/src/experiences/MidiEditor/MidiEditor.tsx
+++ b/src/experiences/MidiEditor/MidiEditor.tsx
@@ -48,7 +48,6 @@ type MoveNote     = { trackId: string; origPitch: number; origStep: number };
 type MoveState    = { startClientX: number; startClientY: number; notes: Map<string, MoveNote> };
 type ClipboardNote = { trackId: string; note: Note };
 type BendDisplay  = 'all' | 'lines' | 'indicator';
-type KnobDragState = { bendId: string; trackId: string; startX: number; startCurvature: number };
 
 interface SaveEntry { name: string; song?: Song; pattern?: unknown; savedAt: string }
 
@@ -734,7 +733,7 @@ interface MelodicGridProps {
   onNoteClickBend: (noteId: string) => void;
   onEraseNoteHover: (noteId: string | null) => void;
   onEraseBendHover: (bendId: string | null) => void;
-  onBendKnobDragStart: (bendId: string, startX: number) => void;
+  onBendCurvatureChange: (bendId: string, curvature: number) => void;
   onRemoveBend: (bendId: string) => void;
 }
 
@@ -745,7 +744,7 @@ function MelodicGrid({
   onAddNote, onRemoveNote, onStartResize, onPreviewPitch,
   onSelectNote, onDeselectAll, onStartMove,
   onNoteClickBend, onEraseNoteHover, onEraseBendHover,
-  onBendKnobDragStart, onRemoveBend,
+  onBendCurvatureChange, onRemoveBend,
 }: MelodicGridProps) {
   const noteMap   = useMemo(() => buildNoteMap(track), [track]);
   const gridW     = totalSteps * stepW;
@@ -796,6 +795,14 @@ function MelodicGrid({
     return s;
   }, [bends]);
 
+  // Local knob selection state: tap selects, drag adjusts
+  const [selectedKnobId, setSelectedKnobId] = useState<string | null>(null);
+  const knobDragRef = useRef<{ bendId: string; startX: number; startCurvature: number } | null>(null);
+  // Clear selection when tool changes away from bend/select
+  useEffect(() => {
+    if (tool !== 'bend' && tool !== 'select') setSelectedKnobId(null);
+  }, [tool]);
+
   const bendOverlay = useMemo(() => {
     if (bendDisplay === 'indicator' || bends.length === 0) return null;
     const showKnob = bendDisplay === 'all';
@@ -840,26 +847,44 @@ function MelodicGrid({
 
       const canDragKnob = tool === 'select' || tool === 'bend';
       const canErase    = tool === 'erase-bend';
+      const isSelected  = selectedKnobId === bend.id;
+      const knobR       = isSelected ? 14 : 11;
+      const knobFill    = isEraseHover ? '#ffc0c0' : isSelected ? '#e8e4dc' : '#c0c0c0';
 
       return (
         <g key={bend.id}>
-          <path d={pathD} fill="none" stroke={stroke} strokeWidth={strokeW} strokeLinecap="round" />
+          <path d={pathD} fill="none" stroke={stroke} strokeWidth={strokeW} strokeLinecap="round"
+                style={{ pointerEvents: 'none' }} />
           {showKnob && (
             <g>
               <circle
-                cx={mx} cy={my} r={11}
-                fill={isEraseHover ? '#ffc0c0' : '#c0c0c0'}
-                stroke={stroke} strokeWidth={1.5}
-                style={{ cursor: canDragKnob ? 'ew-resize' : canErase ? 'pointer' : 'default',
-                         touchAction: 'none' }}
+                cx={mx} cy={my} r={knobR}
+                fill={knobFill}
+                stroke={isSelected ? '#cc4400' : stroke} strokeWidth={isSelected ? 2 : 1.5}
+                style={{ cursor: canDragKnob ? (isSelected ? 'ew-resize' : 'pointer') : canErase ? 'pointer' : 'default',
+                         touchAction: 'none', pointerEvents: 'all' }}
                 onPointerEnter={() => canErase && onEraseBendHover(bend.id)}
                 onPointerLeave={() => canErase && onEraseBendHover(null)}
                 onPointerDown={e => {
                   e.stopPropagation(); e.preventDefault();
-                  (e.target as Element).setPointerCapture(e.pointerId);
                   if (canErase) { onRemoveBend(bend.id); return; }
-                  if (canDragKnob) onBendKnobDragStart(bend.id, e.clientX);
+                  if (!canDragKnob) return;
+                  (e.target as Element).setPointerCapture(e.pointerId);
+                  if (isSelected) {
+                    // Already selected: this pointer-down starts the drag
+                    knobDragRef.current = { bendId: bend.id, startX: e.clientX, startCurvature: bend.curvature };
+                  } else {
+                    // First tap: select without dragging yet
+                    setSelectedKnobId(bend.id);
+                  }
                 }}
+                onPointerMove={e => {
+                  if (!knobDragRef.current || knobDragRef.current.bendId !== bend.id) return;
+                  const delta = (e.clientX - knobDragRef.current.startX) / 80;
+                  const newCurvature = Math.max(-1, Math.min(1, knobDragRef.current.startCurvature + delta));
+                  onBendCurvatureChange(bend.id, newCurvature);
+                }}
+                onPointerUp={() => { knobDragRef.current = null; }}
               />
               <circle cx={dotX} cy={dotY} r={2.5} fill="#cc4400" style={{ pointerEvents: 'none' }} />
             </g>
@@ -868,7 +893,7 @@ function MelodicGrid({
           {canErase && (
             <path
               d={pathD} fill="none" stroke="transparent" strokeWidth={12}
-              style={{ cursor: 'pointer' }}
+              style={{ cursor: 'pointer', pointerEvents: 'all', touchAction: 'none' }}
               onPointerEnter={() => onEraseBendHover(bend.id)}
               onPointerLeave={() => onEraseBendHover(null)}
               onPointerDown={e => { e.stopPropagation(); e.preventDefault(); onRemoveBend(bend.id); }}
@@ -878,7 +903,7 @@ function MelodicGrid({
       );
     });
   }, [bends, noteById, stepW, rowH, totalSteps, bendDisplay, eraseBendHoverId, eraseHoverNoteId, tool,
-      onEraseBendHover, onRemoveBend, onBendKnobDragStart]);
+      selectedKnobId, onEraseBendHover, onRemoveBend, onBendCurvatureChange]);
 
   // Indicator arrows at the start of the overlap region
   const bendIndicators = useMemo(() => {
@@ -902,6 +927,7 @@ function MelodicGrid({
     <div
       className={`me-note-grid${editActive ? ' me-note-grid--edit' : ' me-note-grid--select'}`}
       style={{ width: gridW, height: gridH }}
+      onPointerDown={() => { if (selectedKnobId) setSelectedKnobId(null); }}
     >
       {Array.from({ length: totalSteps }, (_, s) => {
         const isBar  = s % (stepsPerBeat * beatsPerBar) === 0;
@@ -993,10 +1019,11 @@ function MelodicGrid({
           ? <div key={`od-${pitch}`} className="me-row-divider" style={{ top: rowIdx * rowH, width: gridW }} />
           : null
       )}
-      {/* Bend overlay — drawn above notes */}
+      {/* Bend overlay — drawn above notes. SVG root is pointer-events:none so clicks
+          pass through to note divs below; only individual knob/path elements are interactive. */}
       <svg
-        style={{ position: 'absolute', inset: 0, width: gridW, height: gridH, overflow: 'visible',
-                 pointerEvents: (isBendMode || tool === 'erase-bend') ? 'all' : 'none' }}
+        style={{ position: 'absolute', inset: 0, width: gridW, height: gridH,
+                 overflow: 'visible', pointerEvents: 'none' }}
       >
         {bendOverlay}
         {bendIndicators}
@@ -1112,7 +1139,7 @@ interface TrackSectionProps {
   onNoteClickBend: (noteId: string) => void;
   onEraseNoteHover: (noteId: string | null) => void;
   onEraseBendHover: (bendId: string | null) => void;
-  onBendKnobDragStart: (bendId: string, startX: number) => void;
+  onBendCurvatureChange: (bendId: string, curvature: number) => void;
   onRemoveBend: (bendId: string) => void;
 }
 
@@ -1126,7 +1153,7 @@ function TrackSection({
   onAddDrumPiece, onRemoveDrumPiece,
   onSelectNote, onDeselectAll, onStartMove,
   onNoteClickBend, onEraseNoteHover, onEraseBendHover,
-  onBendKnobDragStart, onRemoveBend,
+  onBendCurvatureChange, onRemoveBend,
 }: TrackSectionProps) {
   const [showAddPiece, setShowAddPiece] = useState(false);
 
@@ -1195,7 +1222,7 @@ function TrackSection({
                   onPreviewPitch={onStartPreviewPitch}
                   onSelectNote={onSelectNote} onDeselectAll={onDeselectAll} onStartMove={onStartMove}
                   onNoteClickBend={onNoteClickBend} onEraseNoteHover={onEraseNoteHover}
-                  onEraseBendHover={onEraseBendHover} onBendKnobDragStart={onBendKnobDragStart}
+                  onEraseBendHover={onEraseBendHover} onBendCurvatureChange={onBendCurvatureChange}
                   onRemoveBend={onRemoveBend} />
             }
           </div>
@@ -1248,7 +1275,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
   const [bendDraft,     setBendDraft]     = useState<{ fromNoteId: string; trackId: string } | null>(null);
   const [eraseHoverNoteId, setEraseHoverNoteId] = useState<string | null>(null);
   const [eraseBendHoverId, setEraseBendHoverId] = useState<string | null>(null);
-  const knobDragRef = useRef<KnobDragState | null>(null);
 
   const selectedClip = song.clips.find(c => c.id === selectedClipId) ?? song.clips[0];
 
@@ -1514,17 +1540,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
       }
     }
 
-    // Knob drag
-    const kd = knobDragRef.current;
-    if (kd) {
-      const delta = (e.clientX - kd.startX) / 100;
-      const newCurvature = Math.max(-1, Math.min(1, kd.startCurvature + delta));
-      setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
-        tracks.map(t => t.id !== kd.trackId ? t : {
-          ...t, bends: t.bends.map(b => b.id !== kd.bendId ? b : { ...b, curvature: newCurvature }),
-        })
-      ));
-    }
   };
 
   pointerUpHandlerRef.current = (_e: PointerEvent) => {
@@ -1539,7 +1554,6 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     resizeStateRef.current  = null;
     isMoveActiveRef.current = false;
     moveStateRef.current    = null;
-    knobDragRef.current     = null;
     if (sustainedNoteStopRef.current) {
       sustainedNoteStopRef.current();
       sustainedNoteStopRef.current = null;
@@ -1661,12 +1675,18 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
     ));
   }, []);
 
-  const addBend = useCallback((fromTrackId: string, fromNoteId: string, toNoteId: string) => {
+  const addBend = useCallback((trackId: string, noteAId: string, noteBId: string) => {
     const id = makeBendId();
-    const newBend: Bend = { id, fromNoteId, toNoteId, curvature: 0 };
     setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
-      tracks.map(t => t.id !== fromTrackId ? t : {
-        ...t, bends: [...t.bends, newBend],
+      tracks.map(t => {
+        if (t.id !== trackId) return t;
+        const noteA = t.notes.find(n => n.id === noteAId);
+        const noteB = t.notes.find(n => n.id === noteBId);
+        if (!noteA || !noteB) return t;
+        // Always set fromNoteId to the earlier note regardless of tap order
+        const [from, to] = noteA.startStep <= noteB.startStep ? [noteA, noteB] : [noteB, noteA];
+        const newBend: Bend = { id, fromNoteId: from.id, toNoteId: to.id, curvature: 0 };
+        return { ...t, bends: [...t.bends, newBend] };
       })
     ));
   }, []);
@@ -1679,24 +1699,39 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
 
   const handleNoteClickBend = useCallback((trackId: string, noteId: string) => {
     setBendDraft(prev => {
+      const clip  = songRef.current.clips.find(c => c.id === selectedClipIdRef.current) ?? songRef.current.clips[0];
+      const track = clip?.tracks.find(t => t.id === trackId);
+      if (!track) return null;
+
       if (prev === null) {
         // Block if note already participates in any bend
-        const clip = songRef.current.clips.find(c => c.id === selectedClipIdRef.current) ?? songRef.current.clips[0];
-        const track = clip?.tracks.find(t => t.id === trackId);
-        if (!track) return null;
         if (track.bends.some(b => b.fromNoteId === noteId || b.toNoteId === noteId)) return null;
         return { fromNoteId: noteId, trackId };
       }
+
+      // Second click: validate the target
       if (prev.trackId !== trackId || prev.fromNoteId === noteId) return null;
+      // Target must not already be in a bend
+      if (track.bends.some(b => b.fromNoteId === noteId || b.toNoteId === noteId)) return null;
+      // Notes must overlap
+      const srcNote  = track.notes.find(n => n.id === prev.fromNoteId);
+      const tgtNote  = track.notes.find(n => n.id === noteId);
+      if (!srcNote || !tgtNote) return null;
+      const overlapEnd = Math.min(srcNote.startStep + srcNote.durationSteps, tgtNote.startStep + tgtNote.durationSteps);
+      const overlapStart = Math.max(srcNote.startStep, tgtNote.startStep);
+      if (overlapEnd <= overlapStart) return null;
+
       addBend(trackId, prev.fromNoteId, noteId);
       return null;
     });
   }, [addBend]);
 
-  const handleBendKnobDragStart = useCallback((trackId: string, bendId: string, startX: number) => {
-    const clip = songRef.current.clips.find(c => c.id === selectedClipIdRef.current) ?? songRef.current.clips[0];
-    const bend = clip?.tracks.find(t => t.id === trackId)?.bends.find(b => b.id === bendId);
-    if (bend) knobDragRef.current = { bendId, trackId, startX, startCurvature: bend.curvature };
+  const updateBendCurvature = useCallback((trackId: string, bendId: string, curvature: number) => {
+    setSong(prev => updateTracksInClip(prev, selectedClipIdRef.current, tracks =>
+      tracks.map(t => t.id !== trackId ? t : {
+        ...t, bends: t.bends.map(b => b.id !== bendId ? b : { ...b, curvature }),
+      })
+    ));
   }, []);
 
   const startResize = useCallback((noteId: string, trackId: string, startX: number, origDuration: number, noteStartStep: number) => {
@@ -2048,7 +2083,7 @@ export default function MidiEditor({ onQuit }: MidiEditorProps) {
                 onNoteClickBend={noteId => handleNoteClickBend(track.id, noteId)}
                 onEraseNoteHover={setEraseHoverNoteId}
                 onEraseBendHover={setEraseBendHoverId}
-                onBendKnobDragStart={(bendId, startX) => handleBendKnobDragStart(track.id, bendId, startX)}
+                onBendCurvatureChange={(bendId, curvature) => updateBendCurvature(track.id, bendId, curvature)}
                 onRemoveBend={bendId => removeBend(track.id, bendId)}
               />
             ))}

--- a/src/experiences/MidiEditor/audio.ts
+++ b/src/experiences/MidiEditor/audio.ts
@@ -20,6 +20,13 @@ export function midiToHz(midi: number): number {
   return 440 * Math.pow(2, (midi - 69) / 12);
 }
 
+// Applies easing to a 0–1 progress value. curvature 0=linear, >0=ease-in, <0=ease-out.
+export function shapedCurve(p: number, curvature: number): number {
+  if (curvature === 0) return p;
+  const exp = 1 + Math.abs(curvature) * 3;
+  return curvature > 0 ? Math.pow(p, exp) : 1 - Math.pow(1 - p, exp);
+}
+
 export { isSoundFontReady };
 
 export function loadSoundFont(url: string): Promise<void> {
@@ -37,12 +44,14 @@ export function playNote(
   attack = 0.01,
   release = 0.1,
   gmProgram?: number,
+  bendToPitch?: number,
+  bendCurvature = 0,
 ): void {
   const c = getCtx();
   const t = when ?? c.currentTime;
 
   if (gmProgram !== undefined && isSoundFontReady()) {
-    if (playSfNote(gmProgram, pitch, velocity, durationSec, c, t, gain)) return;
+    if (playSfNote(gmProgram, pitch, velocity, durationSec, c, t, gain, bendToPitch, bendCurvature)) return;
     // SF failed to find a zone for this pitch — fall through to oscillator
   }
   const vol = (velocity / 127) * 0.22 * Math.max(0, Math.min(1, gain));
@@ -56,7 +65,20 @@ export function playNote(
   const osc = c.createOscillator();
   const env = c.createGain();
   osc.type = waveform as OscillatorType;
-  osc.frequency.value = midiToHz(pitch);
+
+  if (bendToPitch !== undefined) {
+    const N = 32;
+    const curve = new Float32Array(N);
+    const startHz = midiToHz(pitch);
+    const endHz   = midiToHz(bendToPitch);
+    for (let i = 0; i < N; i++) {
+      curve[i] = startHz + (endHz - startHz) * shapedCurve(i / (N - 1), bendCurvature);
+    }
+    const curveDur = Math.max(durationSec - relDur - 0.01, 0.05);
+    osc.frequency.setValueCurveAtTime(curve, t, curveDur);
+  } else {
+    osc.frequency.value = midiToHz(pitch);
+  }
 
   env.gain.setValueAtTime(0, t);
   env.gain.linearRampToValueAtTime(vol, atkEnd);

--- a/src/experiences/MidiEditor/audio.ts
+++ b/src/experiences/MidiEditor/audio.ts
@@ -46,12 +46,14 @@ export function playNote(
   gmProgram?: number,
   bendToPitch?: number,
   bendCurvature = 0,
+  bendStartSec = 0,      // seconds into the note when the slide begins
+  bendDurationSec?: number, // seconds the slide lasts (defaults to near end of note)
 ): void {
   const c = getCtx();
   const t = when ?? c.currentTime;
 
   if (gmProgram !== undefined && isSoundFontReady()) {
-    if (playSfNote(gmProgram, pitch, velocity, durationSec, c, t, gain, bendToPitch, bendCurvature)) return;
+    if (playSfNote(gmProgram, pitch, velocity, durationSec, c, t, gain, bendToPitch, bendCurvature, bendStartSec, bendDurationSec)) return;
     // SF failed to find a zone for this pitch — fall through to oscillator
   }
   const vol = (velocity / 127) * 0.22 * Math.max(0, Math.min(1, gain));
@@ -74,8 +76,11 @@ export function playNote(
     for (let i = 0; i < N; i++) {
       curve[i] = startHz + (endHz - startHz) * shapedCurve(i / (N - 1), bendCurvature);
     }
-    const curveDur = Math.max(durationSec - relDur - 0.01, 0.05);
-    osc.frequency.setValueCurveAtTime(curve, t, curveDur);
+    const slideStart = t + bendStartSec;
+    const slideDur   = bendDurationSec ?? Math.max(durationSec - relDur - bendStartSec - 0.01, 0.05);
+    osc.frequency.setValueAtTime(startHz, t);
+    osc.frequency.setValueCurveAtTime(curve, slideStart, slideDur);
+    osc.frequency.setValueAtTime(endHz, slideStart + slideDur);
   } else {
     osc.frequency.value = midiToHz(pitch);
   }

--- a/src/experiences/MidiEditor/icons/bend.svg
+++ b/src/experiences/MidiEditor/icons/bend.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <line x1="4" y1="27" x2="28" y2="5" stroke="#1a1a1a" stroke-width="2"/>
+  <circle cx="16" cy="16" r="6" fill="#c0c0c0" stroke="#1a1a1a" stroke-width="1.5"/>
+  <circle cx="16" cy="11" r="2" fill="#cc4400"/>
+</svg>

--- a/src/experiences/MidiEditor/icons/draw.svg
+++ b/src/experiences/MidiEditor/icons/draw.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <g transform="translate(16,16) rotate(-45) translate(-6,-13)">
+    <rect x="2" y="2" width="8" height="4" rx="1" fill="#c0c0c0" stroke="#1a1a1a" stroke-width="1.5"/>
+    <rect x="2" y="6" width="8" height="14" fill="#f5c518" stroke="#1a1a1a" stroke-width="1.5"/>
+    <polygon points="2,20 10,20 6,27" fill="#c09000" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/src/experiences/MidiEditor/icons/erase-bend.svg
+++ b/src/experiences/MidiEditor/icons/erase-bend.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <line x1="4" y1="27" x2="28" y2="5" stroke="#808080" stroke-width="2"/>
+  <line x1="20" y1="4" x2="30" y2="14" stroke="#cc0000" stroke-width="2.5"/>
+  <line x1="30" y1="4" x2="20" y2="14" stroke="#cc0000" stroke-width="2.5"/>
+</svg>

--- a/src/experiences/MidiEditor/icons/erase-note.svg
+++ b/src/experiences/MidiEditor/icons/erase-note.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect x="3" y="10" width="26" height="14" rx="2" fill="#f5a0a0" stroke="#1a1a1a" stroke-width="1.5"/>
+  <rect x="3" y="10" width="13" height="14" rx="2" fill="#d4d0c8" stroke="#1a1a1a" stroke-width="1.5"/>
+  <line x1="16" y1="10" x2="16" y2="24" stroke="#1a1a1a" stroke-width="1.5"/>
+  <line x1="3" y1="24" x2="29" y2="24" stroke="#1a1a1a" stroke-width="1.5"/>
+</svg>

--- a/src/experiences/MidiEditor/icons/paint.svg
+++ b/src/experiences/MidiEditor/icons/paint.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <g transform="translate(16,16) rotate(-30) translate(-5,-13)">
+    <rect x="3" y="2" width="5" height="13" rx="1" fill="#8B4513" stroke="#1a1a1a" stroke-width="1.5"/>
+    <ellipse cx="5.5" cy="18" rx="5" ry="6" fill="#cc4400" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/src/experiences/MidiEditor/icons/select.svg
+++ b/src/experiences/MidiEditor/icons/select.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <polygon points="5,2 5,25 10,19 14,29 18,27 14,17 22,17" fill="#1a1a1a"/>
+</svg>

--- a/src/experiences/MidiEditor/sf2.ts
+++ b/src/experiences/MidiEditor/sf2.ts
@@ -290,6 +290,12 @@ function getBuffer(sampleIdx: number, ctx: AudioContext): AudioBuffer | null {
   return ab;
 }
 
+function sfShapedCurve(p: number, curvature: number): number {
+  if (curvature === 0) return p;
+  const exp = 1 + Math.abs(curvature) * 3;
+  return curvature > 0 ? Math.pow(p, exp) : 1 - Math.pow(1 - p, exp);
+}
+
 export function playSfNote(
   program: number,
   pitch: number,
@@ -298,6 +304,8 @@ export function playSfNote(
   ctx: AudioContext,
   when: number,
   gain: number,
+  bendToPitch?: number,
+  bendCurvature = 0,
 ): boolean {
   if (!_font) return false;
 
@@ -323,10 +331,23 @@ export function playSfNote(
   const source = ctx.createBufferSource();
   source.buffer = ab;
 
-  // Pitch shift via playbackRate
-  const rootKey = zone.overrideRootKey >= 0 ? zone.overrideRootKey : sh.originalPitch;
-  const cents   = (pitch - rootKey) * zone.scaleTuning + sh.pitchCorrection;
-  source.playbackRate.value = Math.pow(2, cents / 1200);
+  // Pitch shift via playbackRate; optionally ramp to bendToPitch
+  const rootKey   = zone.overrideRootKey >= 0 ? zone.overrideRootKey : sh.originalPitch;
+  const cents     = (pitch - rootKey) * zone.scaleTuning + sh.pitchCorrection;
+  const startRate = Math.pow(2, cents / 1200);
+
+  if (bendToPitch !== undefined) {
+    const endCents = (bendToPitch - rootKey) * zone.scaleTuning + sh.pitchCorrection;
+    const endRate  = Math.pow(2, endCents / 1200);
+    const N = 32;
+    const curve = new Float32Array(N);
+    for (let i = 0; i < N; i++) {
+      curve[i] = startRate + (endRate - startRate) * sfShapedCurve(i / (N - 1), bendCurvature);
+    }
+    source.playbackRate.setValueCurveAtTime(curve, when, Math.max(durationSec - 0.05, 0.05));
+  } else {
+    source.playbackRate.value = startRate;
+  }
 
   // Loop
   const looping = zone.loopMode === LOOP_CONTINUES || zone.loopMode === LOOP_UNTIL_OFF;

--- a/src/experiences/MidiEditor/sf2.ts
+++ b/src/experiences/MidiEditor/sf2.ts
@@ -306,6 +306,8 @@ export function playSfNote(
   gain: number,
   bendToPitch?: number,
   bendCurvature = 0,
+  bendStartSec = 0,
+  bendDurationSec?: number,
 ): boolean {
   if (!_font) return false;
 
@@ -344,7 +346,11 @@ export function playSfNote(
     for (let i = 0; i < N; i++) {
       curve[i] = startRate + (endRate - startRate) * sfShapedCurve(i / (N - 1), bendCurvature);
     }
-    source.playbackRate.setValueCurveAtTime(curve, when, Math.max(durationSec - 0.05, 0.05));
+    const slideStart = when + bendStartSec;
+    const slideDur   = bendDurationSec ?? Math.max(durationSec - bendStartSec - 0.05, 0.05);
+    source.playbackRate.setValueAtTime(startRate, when);
+    source.playbackRate.setValueCurveAtTime(curve, slideStart, slideDur);
+    source.playbackRate.setValueAtTime(endRate, slideStart + slideDur);
   } else {
     source.playbackRate.value = startRate;
   }

--- a/src/experiences/MidiEditor/types.ts
+++ b/src/experiences/MidiEditor/types.ts
@@ -1,5 +1,5 @@
 export type OscWaveform = 'sine' | 'square' | 'sawtooth' | 'triangle';
-export type EditTool = 'select' | 'draw' | 'paint';
+export type EditTool = 'select' | 'draw' | 'paint' | 'erase' | 'bend' | 'erase-bend';
 export type AppView = 'pattern' | 'song';
 
 // GM instrument names, index = program number 0–127
@@ -52,6 +52,13 @@ export interface Note {
   velocity: number;
 }
 
+export interface Bend {
+  id: string;
+  fromNoteId: string;
+  toNoteId: string;
+  curvature: number; // -1 (9 o'clock/ease-out) to 1 (3 o'clock/ease-in), 0 = linear
+}
+
 export interface Track {
   id: string;
   name: string;
@@ -59,6 +66,7 @@ export interface Track {
   waveform: OscWaveform;
   gmProgram?: number;  // 0–127; undefined = use oscillator synth
   notes: Note[];
+  bends: Bend[];
   muted: boolean;
   isDrum: boolean;
   volume: number;     // 0–1
@@ -148,9 +156,10 @@ export const PIANO_MIN = 36;  // C2
 export const PIANO_MAX = 83;  // B5
 
 let noteCounter = 0;
-export function makeNoteId(): string {
-  return `n${++noteCounter}`;
-}
+export function makeNoteId(): string { return `n${++noteCounter}`; }
+
+let bendCounter = 0;
+export function makeBendId(): string { return `b${++bendCounter}`; }
 
 export function isBlackPitch(pitch: number): boolean {
   return [1, 3, 6, 8, 10].includes(pitch % 12);
@@ -161,8 +170,8 @@ export function pitchName(pitch: number): string {
   return `${names[pitch % 12]}${Math.floor(pitch / 12) - 1}`;
 }
 
-function makeTrack(partial: Omit<Track, 'volume'|'attack'|'release'|'collapsed'|'octaveOffset'>): Track {
-  return { ...partial, volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0 };
+function makeTrack(partial: Omit<Track, 'volume'|'attack'|'release'|'collapsed'|'octaveOffset'|'bends'>): Track {
+  return { ...partial, bends: [], volume: 1, attack: 0.01, release: 0.3, collapsed: false, octaveOffset: 0 };
 }
 
 export function makeDefaultTracks(): Track[] {


### PR DESCRIPTION
Adds a full bend/portamento system to the piano roll:
- New Bend data model on Track with curvature (-1..1) and two-note linkage
- Bottom tool palette (Select/Draw/Paint/Erase | Bend/Erase-Bend) with SVG icons
- Two-click bend tool: click source note then target note; valid targets get green highlight
- Quadratic Bézier SVG overlay with Win95-style dial knob; dragging adjusts curvature
- Display > Bends menu (Everything / Lines only / Indicator) with radio-style checkmarks
- Notes darken behind bend overlay in bend/erase-bend mode; erase hover shows red outline
- Deleting a note silently deletes attached bends
- Playback: shaped pitch ramp via setValueCurveAtTime on oscillator frequency and SF2 playbackRate
- MIDI export: RPN 0 pitch bend sensitivity setup + 16 shaped bend events per bent note

https://claude.ai/code/session_013d9kwDwb1ALiCe2JZQNKXW