### PR TITLE
Add 4 new games, animations, and deck customization to Cards app

### DIFF
--- a/src/experiences/Cards/Blackjack.css
+++ b/src/experiences/Cards/Blackjack.css
@@ -3,30 +3,33 @@
 .bj {
   display: flex;
   flex-direction: column;
-  background: #c0c0c0;
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
   user-select: none;
+  flex: 1;
+  min-height: 0;
+  background: #1a4a1a; /* green felt fills the window */
 }
 
-/* Container measures width for scale */
+/* ─── Stage container (green felt, fills available space) ───────────── */
+
 .bj__stage-container {
-  margin: 8px 8px 4px;
+  flex: 1;
+  min-height: 200px;
+  position: relative;
+  background: #1a4a1a;
   overflow: hidden;
-  flex-shrink: 0;
 }
 
-/* The felt stage — isolation keeps high-z cards from bleeding above menus */
+/* Stage is absolutely centered within the container */
 .bj__stage {
   background: #1a4a1a;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
-  position: relative;
-  overflow: hidden;
   isolation: isolate;
+  /* width/height/position/transform set inline */
 }
 
-/* In-stage labels (DEALER / YOU) */
+/* ─── In-stage labels ────────────────────────────────────────────────── */
+
 .bj__stage-label {
   position: absolute;
   font-size: 6px;
@@ -38,24 +41,132 @@
   z-index: 5;
 }
 
-.bj__stage-score {
-  font-size: 8px;
-  color: #ffffff;
-}
+.bj__stage-score           { font-size: 8px; color: #ffffff; }
+.bj__stage-score--bust     { color: #ff6666; }
+.bj__stage-score--bj       { color: #ffdd44; }
 
-.bj__stage-score--bust { color: #ff6666; }
-.bj__stage-score--bj   { color: #ffdd44; }
-
-/* Shoe card count */
 .bj__shoe-label {
   position: absolute;
   font-size: 6px;
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.35);
   pointer-events: none;
   z-index: 5;
 }
 
-/* Outcome overlay — floats above the felt */
+/* Shuffling text centered in stage */
+.bj__shuffling {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.5);
+  pointer-events: none;
+  z-index: 5;
+  white-space: nowrap;
+}
+
+/* ─── In-stage action buttons ────────────────────────────────────────── */
+
+/* HIT — card-shaped dashed outline, right of player cards */
+.bj__hit-btn {
+  position: absolute;
+  width: 52px;
+  height: 72px;
+  border: 2px dashed rgba(255, 255, 255, 0.5);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  z-index: 2000;
+  transition: background 120ms, border-color 120ms;
+  padding: 0;
+}
+
+.bj__hit-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
+.bj__hit-btn:active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* STAY — pill button below player cards */
+.bj__stay-btn {
+  position: absolute;
+  width: 88px;
+  height: 42px;
+  border: 2px dashed rgba(255, 255, 255, 0.5);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: pointer;
+  z-index: 2000;
+  transition: background 120ms, border-color 120ms;
+  padding: 0;
+}
+
+.bj__stay-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
+.bj__stay-btn:active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* DOUBLE — smaller pill button */
+.bj__dbl-btn {
+  position: absolute;
+  width: 68px;
+  height: 42px;
+  border: 2px dashed rgba(200, 160, 255, 0.5);
+  border-radius: 6px;
+  background: rgba(80, 30, 120, 0.25);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: pointer;
+  z-index: 2000;
+  transition: background 120ms, border-color 120ms;
+  padding: 0;
+}
+
+.bj__dbl-btn:hover {
+  background: rgba(120, 50, 180, 0.35);
+  border-color: rgba(200, 160, 255, 0.9);
+}
+
+.bj__dbl-btn:active {
+  background: rgba(120, 50, 180, 0.5);
+}
+
+.bj__action-icon {
+  font-size: 20px;
+  line-height: 1;
+  font-family: sans-serif;
+}
+
+.bj__action-lbl {
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: "Press Start 2P", monospace;
+  letter-spacing: 1px;
+}
+
+/* ─── Outcome overlay ────────────────────────────────────────────────── */
+
 .bj__outcome {
   position: absolute;
   top: 50%;
@@ -67,7 +178,7 @@
   text-align: center;
   white-space: nowrap;
   font-size: 10px;
-  z-index: 10;
+  z-index: 3000;
   pointer-events: none;
 }
 
@@ -75,61 +186,91 @@
 .bj__outcome--push { color: #eeee44; }
 .bj__outcome--lose { color: #ee5555; }
 
-/* Controls */
+/* ─── Win95 controls bar ─────────────────────────────────────────────── */
+
 .bj__controls {
-  padding: 6px 10px 10px;
+  background: #c0c0c0;
+  border-top: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+  padding: 6px 10px 8px;
   display: flex;
   flex-direction: column;
+  gap: 5px;
+  flex-shrink: 0;
+}
+
+/* Info row: [chips chip] [bet adjusters?] [bet chip] */
+.bj__info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 6px;
 }
 
-.bj__info-row {
+.bj__chip-group {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
-.bj__chips-label {
-  font-size: 8px;
-  color: #000;
+.bj__chip-lbl {
+  font-size: 5px;
+  color: #444;
 }
 
-.bj__divider {
-  height: 0;
-  border: none;
-  border-top: 1px solid #808080;
-  border-bottom: 1px solid #ffffff;
-}
-
-/* Bet adjustment row */
-.bj__bet-row {
+/* Bet adjustment buttons row (center of info-row during betting) */
+.bj__bet-adjust {
   display: flex;
-  gap: 4px;
+  gap: 3px;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
+  flex: 1;
 }
 
-/* Shared button base */
+/* ─── Chip visual ────────────────────────────────────────────────────── */
+
+.bj-chip {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 3px dashed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+
+/* Stack shadow: suggests a pile of chips beneath */
+.bj-chip--stack {
+  box-shadow: 3px 4px 0 rgba(0, 0, 0, 0.45), 5px 7px 0 rgba(0, 0, 0, 0.25);
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────────────── */
+
 .bj__btn {
   font-family: "Press Start 2P", monospace;
   font-size: 7px;
-  padding: 5px 9px;
+  padding: 4px 8px;
   border: 2px solid;
   cursor: pointer;
   white-space: nowrap;
 }
 
-/* Small neutral (bet controls) */
 .bj__btn--sm {
   background: #c0c0c0;
   color: #000;
   border-color: #ffffff #808080 #808080 #ffffff;
 }
-.bj__btn--sm:hover:not(:disabled) { background: #d4d0c8; }
+.bj__btn--sm:hover:not(:disabled)  { background: #d4d0c8; }
 .bj__btn--sm:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
-.bj__btn--sm:disabled { color: #808080; cursor: default; }
+.bj__btn--sm:disabled              { color: #808080; cursor: default; }
 
-/* Deal / New Hand — orange primary */
 .bj__btn--deal {
   background: #cc4400;
   color: #fff;
@@ -137,52 +278,22 @@
   font-size: 9px;
   padding: 7px 14px;
 }
-.bj__btn--deal:hover { background: #ee5500; }
-.bj__btn--deal:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
-.bj__btn--deal:disabled { background: #994400; cursor: default; }
+.bj__btn--deal:hover           { background: #ee5500; }
+.bj__btn--deal:active          { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+.bj__btn--deal:disabled        { background: #994400; cursor: default; }
 
-/* Hit — orange */
-.bj__btn--hit {
-  background: #cc4400;
-  color: #fff;
-  border-color: #ffcc88 #664400 #664400 #ffcc88;
-}
-.bj__btn--hit:hover { background: #ee5500; }
-.bj__btn--hit:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+/* ─── Action row ─────────────────────────────────────────────────────── */
 
-/* Stand — neutral */
-.bj__btn--stand {
-  background: #c0c0c0;
-  color: #000;
-  border-color: #ffffff #808080 #808080 #ffffff;
-}
-.bj__btn--stand:active { border-color: #808080 #ffffff #ffffff #808080; }
-
-/* Double — purple */
-.bj__btn--double {
-  background: #5b2d8e;
-  color: #fff;
-  border-color: #9966cc #331155 #331155 #9966cc;
-}
-.bj__btn--double:hover { background: #7b3dbe; }
-.bj__btn--double:active { border-color: #331155 #9966cc #9966cc #331155; }
-
-/* Action row */
 .bj__action-row {
   display: flex;
   gap: 6px;
   align-items: center;
   justify-content: center;
+  min-height: 28px;
 }
 
 .bj__waiting {
   font-size: 7px;
   color: #808080;
   font-style: italic;
-}
-
-.bj__notice {
-  font-size: 6px;
-  color: #808080;
-  text-align: right;
 }

--- a/src/experiences/Cards/Blackjack.css
+++ b/src/experiences/Cards/Blackjack.css
@@ -11,21 +11,18 @@
   background: #1a4a1a; /* green felt fills the window */
 }
 
-/* ─── Stage container (green felt, fills available space) ───────────── */
+/* ─── Stage container (height set in JS = STAGE_H * scale) ─────────── */
 
 .bj__stage-container {
-  flex: 1;
-  min-height: 200px;
-  position: relative;
-  background: #1a4a1a;
+  flex-shrink: 0;
   overflow: hidden;
 }
 
-/* Stage is absolutely centered within the container */
 .bj__stage {
   background: #1a4a1a;
   isolation: isolate;
-  /* width/height/position/transform set inline */
+  position: relative;
+  overflow: hidden;
 }
 
 /* ─── In-stage labels ────────────────────────────────────────────────── */
@@ -71,8 +68,8 @@
 /* HIT — card-shaped dashed outline, right of player cards */
 .bj__hit-btn {
   position: absolute;
-  width: 52px;
-  height: 72px;
+  width: 72px;
+  height: 100px;
   border: 2px dashed rgba(255, 255, 255, 0.5);
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.18);

--- a/src/experiences/Cards/Blackjack.css
+++ b/src/experiences/Cards/Blackjack.css
@@ -9,51 +9,50 @@
   user-select: none;
 }
 
-/* Felt table area */
-.bj__table {
-  background: #1a4a1a;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
+/* Container measures width for scale */
+.bj__stage-container {
   margin: 8px 8px 4px;
-  padding: 12px;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-height: 256px;
-}
-
-/* Hand section (dealer or player) */
-.bj__section-label {
-  font-size: 7px;
-  color: rgba(255, 255, 255, 0.55);
-  margin-bottom: 4px;
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-}
-
-.bj__score {
-  font-size: 9px;
-  color: #ffffff;
-}
-
-.bj__score--bust { color: #ff6666; }
-.bj__score--bj   { color: #ffdd44; }
-
-/* Card row with overlap */
-.bj__hand {
-  display: flex;
-  flex-wrap: nowrap;
-  min-height: 104px; /* card height + shadow */
-}
-
-.bj__card {
+  overflow: hidden;
   flex-shrink: 0;
 }
 
-.bj__card + .bj__card {
-  margin-left: -14px;
+/* The felt stage — isolation keeps high-z cards from bleeding above menus */
+.bj__stage {
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* In-stage labels (DEALER / YOU) */
+.bj__stage-label {
+  position: absolute;
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.55);
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.bj__stage-score {
+  font-size: 8px;
+  color: #ffffff;
+}
+
+.bj__stage-score--bust { color: #ff6666; }
+.bj__stage-score--bj   { color: #ffdd44; }
+
+/* Shoe card count */
+.bj__shoe-label {
+  position: absolute;
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+  z-index: 5;
 }
 
 /* Outcome overlay — floats above the felt */

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -121,7 +121,13 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
   const [playerHand,    setPlayerHand]    = useState<Card[]>([]);
   const [dealerHand,    setDealerHand]    = useState<Card[]>([]);
   const [holeRevealed,  setHoleRevealed]  = useState(false);
-  const [chips,         setChips]         = useState(STARTING_CHIPS);
+  const [chips,         setChips]         = useState<number>(() => {
+    try {
+      const v = parseInt(localStorage.getItem("cards-bj-chips") ?? "", 10);
+      if (!isNaN(v) && v > 0) return v;
+    } catch {}
+    return STARTING_CHIPS;
+  });
   const [bet,           setBet]           = useState(10);
   const [outcome,       setOutcome]       = useState<Outcome | null>(null);
   const [chipDelta,     setChipDelta]     = useState(0);
@@ -148,6 +154,10 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
   }, []);
 
   useEffect(() => () => clearTimers(), [clearTimers]);
+
+  useEffect(() => {
+    try { localStorage.setItem("cards-bj-chips", String(chips)); } catch {}
+  }, [chips]);
 
   // ── Layout helper ─────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -11,27 +11,35 @@ import { DeckModal } from "./DeckModal";
 
 // ── Stage layout ──────────────────────────────────────────────────────────────
 
-const STAGE_W  = 480;
-const STAGE_H  = 280;
-const DEAL_Y   = 80;   // dealer hand center y
-const PLAY_Y   = 204;  // player hand center y
-const HAND_X   = 48;   // first card center x for both hands
-const FAN_X    = 24;   // horizontal offset per card in hand
-const SHOE_X   = 446;  // shoe pile center x
-const SHOE_Y   = 140;  // shoe pile center y
-const DISC_X   = -80;  // discard pile (off-screen left)
-const DISC_Y   = 140;
+const STAGE_W = 480;
+const STAGE_H = 300;
+const DEAL_Y  = 72;   // dealer hand y center
+const PLAY_Y  = 178;  // player hand y center
+const HAND_X  = 44;   // first card center x for both hands
+const FAN_X   = 24;   // per-card horizontal fan offset
+const SHOE_X  = 452;  // shoe pile center x (right of dealer row)
+const SHOE_Y  = 72;   // shoe pile center y (same level as dealer)
+const DISC_X  = -80;  // discard pile off-screen left
+const DISC_Y  = 125;
+
+// In-stage action button anchors
+const HIT_L   = 390;              // HIT card button left edge
+const HIT_T   = PLAY_Y - 36;     // 142 — aligns top of HIT card with player cards
+const STAY_T  = PLAY_Y + 54;     // 232 — below player card bottoms (PLAY_Y+36=214)
+const DBL_L   = 152;
+const DBL_T   = STAY_T;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type Phase = "betting" | "player-turn" | "dealer-turn" | "resolved";
+type Phase = "shuffling" | "betting" | "player-turn" | "dealer-turn" | "resolved";
 type Outcome = "blackjack" | "win" | "push" | "dealer-blackjack" | "bust" | "lose";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const STARTING_CHIPS      = 500;
-const DEALER_HIT_DELAY_MS = 700;
+const STARTING_CHIPS        = 500;
+const DEALER_HIT_DELAY_MS   = 700;
 const DEALER_STAND_DELAY_MS = 400;
+const SHUFFLE_CYCLES        = 2;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -65,6 +73,29 @@ function scoreLabel(cards: Card[], holeRevealed: boolean, isDealer: boolean): st
   return String(total);
 }
 
+// ── Chip visual ───────────────────────────────────────────────────────────────
+
+function ChipView({ amount, stack }: { amount: number; stack?: boolean }) {
+  const bg = amount >= 500 ? "#5b2d8e"
+           : amount >= 100 ? "#111122"
+           : amount >= 50  ? "#cc4400"
+           : amount >= 25  ? "#1a5a22"
+           : amount >= 10  ? "#003388"
+           :                 "#992222";
+  const hl = amount >= 500 ? "#9966cc"
+           : amount >= 100 ? "#5555aa"
+           : amount >= 50  ? "#ff8844"
+           : amount >= 25  ? "#44aa55"
+           : amount >= 10  ? "#4477cc"
+           :                 "#ff5555";
+  const label = amount >= 1000 ? `${(amount / 1000).toFixed(1)}k` : `$${amount}`;
+  return (
+    <div className={`bj-chip${stack ? " bj-chip--stack" : ""}`} style={{ background: bg, borderColor: hl }}>
+      {label}
+    </div>
+  );
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface BlackjackProps {
@@ -74,24 +105,19 @@ interface BlackjackProps {
 }
 
 export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProps) {
-  // All cards for this shoe (persists until explicit new game)
-  const allCards   = useRef<Card[]>([]);
-  const holeIdRef  = useRef<string | null>(null);
+  const allCards  = useRef<Card[]>([]);
+  const holeIdRef = useRef<string | null>(null);
 
-  // CardStacks (pure logic refs)
-  const shoe   = useRef(new CardStack({ zTier: 5, baseX: SHOE_X, baseY: SHOE_Y, offsetX: 0.15, offsetY: -0.35 }));
-  const disc   = useRef(new CardStack({ zTier: 1, baseX: DISC_X, baseY: DISC_Y }));
+  const shoe     = useRef(new CardStack({ zTier: 5, baseX: SHOE_X, baseY: SHOE_Y, offsetX: 0.08, offsetY: -0.3 }));
+  const disc     = useRef(new CardStack({ zTier: 1, baseX: DISC_X, baseY: DISC_Y }));
   const dealerSt = useRef(new CardStack({ zTier: 9, baseX: HAND_X, baseY: DEAL_Y, offsetX: FAN_X }));
   const playerSt = useRef(new CardStack({ zTier: 10, baseX: HAND_X, baseY: PLAY_Y, offsetX: FAN_X }));
 
-  // Visual state
   const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
   const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [scale,         setScale]         = useState(1);
-
-  // Game state
-  const [phase,         setPhase]         = useState<Phase>("betting");
+  const [phase,         setPhase]         = useState<Phase>("shuffling");
   const [playerHand,    setPlayerHand]    = useState<Card[]>([]);
   const [dealerHand,    setDealerHand]    = useState<Card[]>([]);
   const [holeRevealed,  setHoleRevealed]  = useState(false);
@@ -103,8 +129,84 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
   const [shoeCount,     setShoeCount]     = useState(0);
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearTimers = useCallback(() => { timers.current.forEach(clearTimeout); timers.current = []; }, []);
+  const after = useCallback((ms: number, fn: () => void) => { timers.current.push(setTimeout(fn, ms)); }, []);
 
-  // ── One-time shoe initialization ───────────────────────────────────────────
+  // ── Scale observer ────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const { width, height } = entries[0].contentRect;
+      const s = Math.min(width / STAGE_W, height / STAGE_H);
+      setScale(Math.max(0.4, s));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  // ── Layout helper ─────────────────────────────────────────────────────────
+
+  const allLayouts = useCallback((ms = 350): Record<string, CardVisualState> => ({
+    ...shoe.current.layout(ms),
+    ...disc.current.layout(ms),
+    ...dealerSt.current.layout(ms),
+    ...playerSt.current.layout(ms),
+  }), []);
+
+  // ── Shuffle animation ─────────────────────────────────────────────────────
+
+  const performShuffle = useCallback((onComplete: () => void) => {
+    setPhase("shuffling");
+    let t = 0;
+
+    for (let cycle = 0; cycle < SHUFFLE_CYCLES; cycle++) {
+      after(t, () => {
+        const cards = shoe.current.cards;
+        const mid   = Math.floor(cards.length / 2);
+        const split: Record<string, CardVisualState> = {};
+        for (let i = 0; i < mid; i++) {
+          split[cards[i].id] = {
+            x: SHOE_X - 30, y: SHOE_Y - i * 0.3,
+            z: 500 + i, rotation: 0, faceDown: true, transitionMs: 180,
+          };
+        }
+        for (let i = mid; i < cards.length; i++) {
+          split[cards[i].id] = {
+            x: SHOE_X + 30, y: SHOE_Y - (i - mid) * 0.3,
+            z: 500 + i, rotation: 0, faceDown: true, transitionMs: 180,
+          };
+        }
+        setCardStates(prev => ({ ...prev, ...split }));
+      });
+      t += 240;
+
+      after(t, () => {
+        const cards    = shoe.current.cards;
+        const combined: Record<string, CardVisualState> = {};
+        for (let i = 0; i < cards.length; i++) {
+          combined[cards[i].id] = {
+            x: SHOE_X, y: SHOE_Y - i * 0.3,
+            z: 500 + i, rotation: 0, faceDown: true,
+            transitionMs: 280, transitionDelay: (i % 2 === 0 ? 0 : 40),
+          };
+        }
+        setCardStates(prev => ({ ...prev, ...combined }));
+      });
+      t += 400;
+    }
+
+    after(t, () => {
+      setCardStates(allLayouts(0));
+      onComplete();
+    });
+  }, [after, allLayouts]);
+
+  // ── Initialization ────────────────────────────────────────────────────────
 
   useEffect(() => {
     const cards = buildDeck(settings);
@@ -116,49 +218,13 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     for (const c of cards) shoe.current.addCard(c, { toTop: true, faceDown: true });
     setShoeCount(shoe.current.size);
     setCardStates(shoe.current.layout(0));
+    performShuffle(() => setPhase("betting"));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // ── Scale stage to fit narrow containers ──────────────────────────────────
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const obs = new ResizeObserver(entries => {
-      const w = entries[0].contentRect.width;
-      setScale(Math.min(1, w / STAGE_W));
-    });
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-
-  // ── Layout helpers ────────────────────────────────────────────────────────
-
-  const allLayouts = useCallback((ms = 350): Record<string, CardVisualState> => ({
-    ...shoe.current.layout(ms),
-    ...disc.current.layout(ms),
-    ...dealerSt.current.layout(ms),
-    ...playerSt.current.layout(ms),
-  }), []);
-
-  // ── Reshuffle helper ──────────────────────────────────────────────────────
-
-  const reshuffleIfNeeded = useCallback(() => {
-    const threshold = Math.max(15, Math.floor(allCards.current.length * 0.25));
-    if (shoe.current.size >= threshold) return;
-    // Collect all disc cards back into shoe
-    const discCards = disc.current.cards;
-    disc.current.clear();
-    const reshuffled = shuffle([...discCards]);
-    for (const c of reshuffled) shoe.current.addCard(c, { toTop: false, faceDown: true });
   }, []);
 
   // ── Deal ─────────────────────────────────────────────────────────────────
 
-  const deal = useCallback(() => {
-    reshuffleIfNeeded();
-
-    // Pull 4 cards: p1, d1, p2, d2(hole)
+  const dealCards = useCallback(() => {
     const p1 = shoe.current.removeTop()!;
     const d1 = shoe.current.removeTop()!;
     const p2 = shoe.current.removeTop()!;
@@ -166,14 +232,12 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
 
     playerSt.current.clear();
     dealerSt.current.clear();
-
     playerSt.current.addCard(p1, { toTop: true, faceDown: false });
     dealerSt.current.addCard(d1, { toTop: true, faceDown: false });
     playerSt.current.addCard(p2, { toTop: true, faceDown: false });
     dealerSt.current.addCard(d2, { toTop: true, faceDown: true });
     holeIdRef.current = d2.id;
 
-    // Layout with stagger delays flying from shoe
     const layouts = allLayouts(550);
     layouts[p1.id] = { ...layouts[p1.id], transitionDelay: 0 };
     layouts[d1.id] = { ...layouts[d1.id], transitionDelay: 140 };
@@ -190,8 +254,7 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setShoeCount(shoe.current.size);
 
     if (isNaturalBlackjack([p1, p2])) {
-      // Reveal hole after cards land
-      setTimeout(() => {
+      after(800, () => {
         dealerSt.current.setFaceDown(d2.id, false);
         setHoleRevealed(true);
         setCardStates(allLayouts(400));
@@ -205,11 +268,27 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
           setChipDelta(win);
         }
         setPhase("resolved");
-      }, 800);
+      });
     } else {
       setPhase("player-turn");
     }
-  }, [bet, reshuffleIfNeeded, allLayouts]);
+  }, [bet, allLayouts, after]);
+
+  const deal = useCallback(() => {
+    const threshold = Math.max(15, Math.floor(allCards.current.length * 0.25));
+    if (shoe.current.size < threshold) {
+      // Gather disc cards into shoe then animate shuffle
+      const discCards = disc.current.cards;
+      disc.current.clear();
+      const reshuffled = shuffle([...discCards]);
+      for (const c of reshuffled) shoe.current.addCard(c, { toTop: false, faceDown: true });
+      setShoeCount(shoe.current.size);
+      setCardStates(allLayouts(300));
+      after(350, () => performShuffle(dealCards));
+    } else {
+      dealCards();
+    }
+  }, [dealCards, allLayouts, after, performShuffle]);
 
   // ── Hit ───────────────────────────────────────────────────────────────────
 
@@ -266,7 +345,6 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setPlayerHand(newHand);
     setBet(newBet);
     setShoeCount(shoe.current.size);
-
     dealerSt.current.setFaceDown(holeIdRef.current!, false);
     setHoleRevealed(true);
 
@@ -326,7 +404,7 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setPhase("resolved");
   }, [dealerDone, bet, playerHand, dealerHand]);
 
-  // ── New hand (clear hands → disc) ────────────────────────────────────────
+  // ── New hand ──────────────────────────────────────────────────────────────
 
   const newHand = useCallback(() => {
     const handCards = [...playerSt.current.cards, ...dealerSt.current.cards];
@@ -347,13 +425,12 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
   // ── Reset game ────────────────────────────────────────────────────────────
 
   const resetGame = useCallback(() => {
-    const allInPlay = [
-      ...disc.current.cards,
-      ...shoe.current.cards,
-      ...dealerSt.current.cards,
-      ...playerSt.current.cards,
+    clearTimers();
+    const all = [
+      ...disc.current.cards, ...shoe.current.cards,
+      ...dealerSt.current.cards, ...playerSt.current.cards,
     ];
-    const reshuffled = shuffle(allInPlay.length > 0 ? allInPlay : [...allCards.current]);
+    const reshuffled = shuffle(all.length > 0 ? all : [...allCards.current]);
     disc.current.clear();
     dealerSt.current.clear();
     playerSt.current.clear();
@@ -367,10 +444,10 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setOutcome(null);
     setDealerDone(false);
     setChipDelta(0);
-    setPhase("betting");
     setShoeCount(shoe.current.size);
     setCardStates(shoe.current.layout(0));
-  }, []);
+    performShuffle(() => setPhase("betting"));
+  }, [clearTimers, performShuffle]);
 
   // ── Menus ─────────────────────────────────────────────────────────────────
 
@@ -388,13 +465,14 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
 
   useWindowMenus(bjMenus);
 
-  // ── Derived display ───────────────────────────────────────────────────────
+  // ── Derived ───────────────────────────────────────────────────────────────
 
-  const dealerScore = scoreLabel(dealerHand, holeRevealed, true);
-  const playerScore = scoreLabel(playerHand, true, false);
-  const playerTotal = handTotal(playerHand);
+  const dealerScore        = scoreLabel(dealerHand, holeRevealed, true);
+  const playerScore        = scoreLabel(playerHand, true, false);
+  const playerTotal        = handTotal(playerHand);
   const dealerTotalForClass = holeRevealed ? handTotal(dealerHand) : 0;
-  const gameOver    = chips < 5 && phase === "betting";
+  const gameOver           = chips < 5 && phase === "betting";
+  const canDouble          = phase === "player-turn" && playerHand.length === 2 && chips >= bet * 2;
 
   function outcomeText(): string {
     if (!outcome) return "";
@@ -421,41 +499,31 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
   return (
     <div className="bj">
       {showDeckModal && (
-        <DeckModal
-          appearance={appearance}
-          onUpdate={setAppearance}
-          onClose={() => setShowDeckModal(false)}
-        />
+        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
 
-      {/* Stage container — measures width for scaling */}
+      {/* Green felt area — fills all available space */}
       <div className="bj__stage-container" ref={containerRef}>
         <div
           className="bj__stage"
           style={{
-            width:           STAGE_W,
-            height:          STAGE_H,
-            transform:       scale < 1 ? `scale(${scale})` : undefined,
-            transformOrigin: "top left",
+            width:  STAGE_W,
+            height: STAGE_H,
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: `translate(-50%, -50%) scale(${scale})`,
           }}
         >
-          {/* Render all cards as permanent DOM elements */}
+          {/* All cards: permanent DOM, positions driven by cardStates */}
           {allCards.current.map(card => {
             const cs = cardStates[card.id];
             if (!cs) return null;
-            return (
-              <PermCard
-                key={card.id}
-                card={card}
-                cs={cs}
-                appearance={appearance}
-                size="sm"
-              />
-            );
+            return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} size="sm" />;
           })}
 
-          {/* Dealer label + score */}
-          <div className="bj__stage-label" style={{ top: 10, left: 10 }}>
+          {/* DEALER label */}
+          <div className="bj__stage-label" style={{ top: 8, left: 8 }}>
             DEALER
             {dealerHand.length > 0 && (
               <span className={`bj__stage-score${dealerTotalForClass > 21 ? " bj__stage-score--bust" : dealerTotalForClass === 21 && dealerHand.length === 2 ? " bj__stage-score--bj" : ""}`}>
@@ -464,8 +532,8 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
             )}
           </div>
 
-          {/* Player label + score */}
-          <div className="bj__stage-label" style={{ top: 148, left: 10 }}>
+          {/* YOU label */}
+          <div className="bj__stage-label" style={{ top: HIT_T - 12, left: 8 }}>
             YOU
             {playerHand.length > 0 && (
               <span className={`bj__stage-score${playerTotal > 21 ? " bj__stage-score--bust" : playerTotal === 21 && playerHand.length === 2 ? " bj__stage-score--bj" : ""}`}>
@@ -475,9 +543,36 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
           </div>
 
           {/* Shoe count */}
-          <div className="bj__shoe-label" style={{ right: 10, top: 10 }}>
-            {shoeCount} left
-          </div>
+          <div className="bj__shoe-label" style={{ top: 8, right: 8 }}>{shoeCount} left</div>
+
+          {/* Shuffling indicator */}
+          {phase === "shuffling" && (
+            <div className="bj__shuffling">Shuffling...</div>
+          )}
+
+          {/* HIT — card-shaped tap zone right of player cards */}
+          {phase === "player-turn" && (
+            <button className="bj__hit-btn" style={{ left: HIT_L, top: HIT_T }} onClick={hit}>
+              <span className="bj__action-icon">👇</span>
+              <span className="bj__action-lbl">HIT</span>
+            </button>
+          )}
+
+          {/* STAY — wave gesture below player cards */}
+          {phase === "player-turn" && (
+            <button className="bj__stay-btn" style={{ left: 50, top: STAY_T }} onClick={stand}>
+              <span className="bj__action-icon">✋</span>
+              <span className="bj__action-lbl">STAY</span>
+            </button>
+          )}
+
+          {/* DOUBLE */}
+          {canDouble && (
+            <button className="bj__dbl-btn" style={{ left: DBL_L, top: DBL_T }} onClick={doubleDown}>
+              <span className="bj__action-icon">×2</span>
+              <span className="bj__action-lbl">DBL</span>
+            </button>
+          )}
 
           {/* Outcome overlay */}
           {phase === "resolved" && outcome && (
@@ -486,52 +581,44 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
         </div>
       </div>
 
-      {/* Controls */}
+      {/* Win95 controls bar */}
       <div className="bj__controls">
         <div className="bj__info-row">
-          <span className="bj__chips-label">Chips: ${chips}</span>
-          <span className="bj__chips-label">Bet: ${bet}</span>
+          <div className="bj__chip-group">
+            <ChipView amount={chips} stack />
+            <span className="bj__chip-lbl">Chips</span>
+          </div>
+
+          {phase === "betting" && !gameOver && (
+            <div className="bj__bet-adjust">
+              <button className="bj__btn bj__btn--sm" disabled={bet <= 5}           onClick={() => setBet(p => Math.max(5,     p - 5))}>-$5</button>
+              <button className="bj__btn bj__btn--sm" disabled={bet + 5  > chips}   onClick={() => setBet(p => Math.min(chips, p + 5))}>+$5</button>
+              <button className="bj__btn bj__btn--sm" disabled={bet + 25 > chips}   onClick={() => setBet(p => Math.min(chips, p + 25))}>+$25</button>
+              <button className="bj__btn bj__btn--sm" disabled={bet === 5}          onClick={() => setBet(5)}>Min</button>
+              <button className="bj__btn bj__btn--sm" disabled={bet === chips}      onClick={() => setBet(chips)}>All In</button>
+            </div>
+          )}
+
+          <div className="bj__chip-group">
+            <ChipView amount={bet} />
+            <span className="bj__chip-lbl">Bet</span>
+          </div>
         </div>
 
-        <div className="bj__divider" />
-
-        {phase === "betting" && !gameOver && (
-          <div className="bj__bet-row">
-            <span className="bj__chips-label">Adjust:</span>
-            <button className="bj__btn bj__btn--sm" disabled={bet <= 5}           onClick={() => setBet(p => Math.max(5, p - 5))}>−$5</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet + 5 > chips}    onClick={() => setBet(p => Math.min(chips, p + 5))}>+$5</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet + 25 > chips}   onClick={() => setBet(p => Math.min(chips, p + 25))}>+$25</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet === 5}          onClick={() => setBet(5)}>Min</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet === chips}      onClick={() => setBet(chips)}>All In</button>
-          </div>
-        )}
-
         <div className="bj__action-row">
+          {phase === "shuffling" && <span className="bj__waiting">Shuffling deck...</span>}
           {phase === "betting" && !gameOver && (
-            <button className="bj__btn bj__btn--deal" onClick={deal} disabled={bet < 5 || allCards.current.length === 0}>
+            <button className="bj__btn bj__btn--deal" onClick={deal} disabled={allCards.current.length === 0}>
               ▶ DEAL
             </button>
           )}
-          {phase === "player-turn" && (
-            <>
-              <button className="bj__btn bj__btn--hit"    onClick={hit}>Hit</button>
-              <button className="bj__btn bj__btn--stand"  onClick={stand}>Stand</button>
-              {playerHand.length === 2 && chips >= bet * 2 && (
-                <button className="bj__btn bj__btn--double" onClick={doubleDown}>Double</button>
-              )}
-            </>
-          )}
-          {phase === "dealer-turn" && (
-            <span className="bj__waiting">Dealer playing...</span>
-          )}
+          {phase === "dealer-turn" && <span className="bj__waiting">Dealer playing...</span>}
           {phase === "resolved" && (
             chips >= 5
               ? <button className="bj__btn bj__btn--deal" onClick={newHand}>New Hand</button>
               : <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
           )}
-          {gameOver && (
-            <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
-          )}
+          {gameOver && <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>}
         </div>
       </div>
     </div>

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -1,26 +1,39 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Blackjack.css";
-import { PlayingCard } from "./PlayingCard";
-import { FlippableCard } from "./FlippableCard";
+import { PermCard } from "./PermCard";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
 import type { Card, CardAppearance, DeckSettings } from "./types";
-import { buildDeck } from "./deckUtils";
+import { buildDeck, shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
-// ── Types ────────────────────────────────────────────────────────────────────
+// ── Stage layout ──────────────────────────────────────────────────────────────
+
+const STAGE_W  = 480;
+const STAGE_H  = 280;
+const DEAL_Y   = 80;   // dealer hand center y
+const PLAY_Y   = 204;  // player hand center y
+const HAND_X   = 48;   // first card center x for both hands
+const FAN_X    = 24;   // horizontal offset per card in hand
+const SHOE_X   = 446;  // shoe pile center x
+const SHOE_Y   = 140;  // shoe pile center y
+const DISC_X   = -80;  // discard pile (off-screen left)
+const DISC_Y   = 140;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 type Phase = "betting" | "player-turn" | "dealer-turn" | "resolved";
 type Outcome = "blackjack" | "win" | "push" | "dealer-blackjack" | "bust" | "lose";
 
-// ── Constants ────────────────────────────────────────────────────────────────
+// ── Constants ─────────────────────────────────────────────────────────────────
 
-const STARTING_CHIPS = 500;
-const RESHUFFLE_AT = 15;
+const STARTING_CHIPS      = 500;
 const DEALER_HIT_DELAY_MS = 700;
 const DEALER_STAND_DELAY_MS = 400;
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function cardPoints(rank: Card["rank"]): number {
   if (rank === "A") return 11;
@@ -31,15 +44,12 @@ function cardPoints(rank: Card["rank"]): number {
 
 function handTotal(cards: Card[]): number {
   let total = 0;
-  let aces = 0;
+  let aces  = 0;
   for (const c of cards) {
     if (c.rank === "A") aces++;
     total += cardPoints(c.rank);
   }
-  while (total > 21 && aces > 0) {
-    total -= 10;
-    aces--;
-  }
+  while (total > 21 && aces > 0) { total -= 10; aces--; }
   return total;
 }
 
@@ -49,181 +59,281 @@ function isNaturalBlackjack(cards: Card[]): boolean {
 
 function scoreLabel(cards: Card[], holeRevealed: boolean, isDealer: boolean): string {
   if (cards.length === 0) return "";
-  if (isDealer && !holeRevealed) {
-    return `${cardPoints(cards[0].rank)} + ?`;
-  }
+  if (isDealer && !holeRevealed) return `${cardPoints(cards[0].rank)} + ?`;
   const total = handTotal(cards);
   if (total > 21) return `BUST (${total})`;
   return String(total);
 }
 
-// ── Component ────────────────────────────────────────────────────────────────
+// ── Component ─────────────────────────────────────────────────────────────────
 
 interface BlackjackProps {
   onNewGame?: () => void;
-  onQuit?: () => void;
-  settings: DeckSettings;
+  onQuit?:    () => void;
+  settings:   DeckSettings;
 }
 
 export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProps) {
-  const [deck, setDeck] = useState<Card[]>(() => buildDeck(settings));
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
-  const [showDeckModal, setShowDeckModal] = useState(false);
-  const [dealKey, setDealKey] = useState(0);
-  const [playerHand, setPlayerHand] = useState<Card[]>([]);
-  const [dealerHand, setDealerHand] = useState<Card[]>([]);
-  const [holeRevealed, setHoleRevealed] = useState(false);
-  const [phase, setPhase] = useState<Phase>("betting");
-  const [chips, setChips] = useState(STARTING_CHIPS);
-  const [bet, setBet] = useState(10);
-  const [outcome, setOutcome] = useState<Outcome | null>(null);
-  const [chipDelta, setChipDelta] = useState(0);
-  const [dealerDone, setDealerDone] = useState(false);
+  // All cards for this shoe (persists until explicit new game)
+  const allCards   = useRef<Card[]>([]);
+  const holeIdRef  = useRef<string | null>(null);
 
-  // ── Actions ────────────────────────────────────────────────────────────────
+  // CardStacks (pure logic refs)
+  const shoe   = useRef(new CardStack({ zTier: 5, baseX: SHOE_X, baseY: SHOE_Y, offsetX: 0.15, offsetY: -0.35 }));
+  const disc   = useRef(new CardStack({ zTier: 1, baseX: DISC_X, baseY: DISC_Y }));
+  const dealerSt = useRef(new CardStack({ zTier: 9, baseX: HAND_X, baseY: DEAL_Y, offsetX: FAN_X }));
+  const playerSt = useRef(new CardStack({ zTier: 10, baseX: HAND_X, baseY: PLAY_Y, offsetX: FAN_X }));
+
+  // Visual state
+  const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
+  const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
+  const [showDeckModal, setShowDeckModal] = useState(false);
+  const [scale,         setScale]         = useState(1);
+
+  // Game state
+  const [phase,         setPhase]         = useState<Phase>("betting");
+  const [playerHand,    setPlayerHand]    = useState<Card[]>([]);
+  const [dealerHand,    setDealerHand]    = useState<Card[]>([]);
+  const [holeRevealed,  setHoleRevealed]  = useState(false);
+  const [chips,         setChips]         = useState(STARTING_CHIPS);
+  const [bet,           setBet]           = useState(10);
+  const [outcome,       setOutcome]       = useState<Outcome | null>(null);
+  const [chipDelta,     setChipDelta]     = useState(0);
+  const [dealerDone,    setDealerDone]    = useState(false);
+  const [shoeCount,     setShoeCount]     = useState(0);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // ── One-time shoe initialization ───────────────────────────────────────────
+
+  useEffect(() => {
+    const cards = buildDeck(settings);
+    allCards.current = cards;
+    shoe.current.clear();
+    disc.current.clear();
+    dealerSt.current.clear();
+    playerSt.current.clear();
+    for (const c of cards) shoe.current.addCard(c, { toTop: true, faceDown: true });
+    setShoeCount(shoe.current.size);
+    setCardStates(shoe.current.layout(0));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Scale stage to fit narrow containers ──────────────────────────────────
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // ── Layout helpers ────────────────────────────────────────────────────────
+
+  const allLayouts = useCallback((ms = 350): Record<string, CardVisualState> => ({
+    ...shoe.current.layout(ms),
+    ...disc.current.layout(ms),
+    ...dealerSt.current.layout(ms),
+    ...playerSt.current.layout(ms),
+  }), []);
+
+  // ── Reshuffle helper ──────────────────────────────────────────────────────
+
+  const reshuffleIfNeeded = useCallback(() => {
+    const threshold = Math.max(15, Math.floor(allCards.current.length * 0.25));
+    if (shoe.current.size >= threshold) return;
+    // Collect all disc cards back into shoe
+    const discCards = disc.current.cards;
+    disc.current.clear();
+    const reshuffled = shuffle([...discCards]);
+    for (const c of reshuffled) shoe.current.addCard(c, { toTop: false, faceDown: true });
+  }, []);
+
+  // ── Deal ─────────────────────────────────────────────────────────────────
 
   const deal = useCallback(() => {
-    const workDeck = deck.length < RESHUFFLE_AT ? buildDeck(settings) : deck;
-    const [c1, c2, c3, c4, ...rest] = workDeck;
-    const pHand = [c1, c3];
-    const dHand = [c2, c4];
+    reshuffleIfNeeded();
 
-    setDeck(rest);
-    setPlayerHand(pHand);
-    setDealerHand(dHand);
+    // Pull 4 cards: p1, d1, p2, d2(hole)
+    const p1 = shoe.current.removeTop()!;
+    const d1 = shoe.current.removeTop()!;
+    const p2 = shoe.current.removeTop()!;
+    const d2 = shoe.current.removeTop()!;
+
+    playerSt.current.clear();
+    dealerSt.current.clear();
+
+    playerSt.current.addCard(p1, { toTop: true, faceDown: false });
+    dealerSt.current.addCard(d1, { toTop: true, faceDown: false });
+    playerSt.current.addCard(p2, { toTop: true, faceDown: false });
+    dealerSt.current.addCard(d2, { toTop: true, faceDown: true });
+    holeIdRef.current = d2.id;
+
+    // Layout with stagger delays flying from shoe
+    const layouts = allLayouts(550);
+    layouts[p1.id] = { ...layouts[p1.id], transitionDelay: 0 };
+    layouts[d1.id] = { ...layouts[d1.id], transitionDelay: 140 };
+    layouts[p2.id] = { ...layouts[p2.id], transitionDelay: 280 };
+    layouts[d2.id] = { ...layouts[d2.id], transitionDelay: 420 };
+
+    setCardStates(layouts);
+    setPlayerHand([p1, p2]);
+    setDealerHand([d1, d2]);
     setHoleRevealed(false);
-    setDealKey((k) => k + 1);
     setOutcome(null);
     setChipDelta(0);
     setDealerDone(false);
+    setShoeCount(shoe.current.size);
 
-    if (isNaturalBlackjack(pHand)) {
-      setHoleRevealed(true);
-      if (isNaturalBlackjack(dHand)) {
-        setOutcome("push");
-        setChipDelta(0);
-      } else {
-        const win = Math.floor(bet * 1.5);
-        setChips((c) => c + win);
-        setOutcome("blackjack");
-        setChipDelta(win);
-      }
-      setPhase("resolved");
+    if (isNaturalBlackjack([p1, p2])) {
+      // Reveal hole after cards land
+      setTimeout(() => {
+        dealerSt.current.setFaceDown(d2.id, false);
+        setHoleRevealed(true);
+        setCardStates(allLayouts(400));
+        if (isNaturalBlackjack([d1, d2])) {
+          setOutcome("push");
+          setChipDelta(0);
+        } else {
+          const win = Math.floor(bet * 1.5);
+          setChips(c => c + win);
+          setOutcome("blackjack");
+          setChipDelta(win);
+        }
+        setPhase("resolved");
+      }, 800);
     } else {
       setPhase("player-turn");
     }
-  }, [deck, bet, settings]);
+  }, [bet, reshuffleIfNeeded, allLayouts]);
+
+  // ── Hit ───────────────────────────────────────────────────────────────────
 
   const hit = useCallback(() => {
     if (phase !== "player-turn") return;
-    const [nextCard, ...rest] = deck;
-    const newHand = [...playerHand, nextCard];
-    const total = handTotal(newHand);
-
-    setDeck(rest);
+    const card = shoe.current.removeTop();
+    if (!card) return;
+    playerSt.current.addCard(card, { toTop: true, faceDown: false });
+    const newHand = [...playerHand, card];
+    const total   = handTotal(newHand);
     setPlayerHand(newHand);
+    setShoeCount(shoe.current.size);
 
     if (total > 21) {
-      setChips((c) => c - bet);
+      dealerSt.current.setFaceDown(holeIdRef.current!, false);
+      setHoleRevealed(true);
+      setCardStates(allLayouts(350));
+      setChips(c => c - bet);
       setOutcome("bust");
       setChipDelta(-bet);
-      setHoleRevealed(true);
       setPhase("resolved");
     } else if (total === 21) {
-      // Auto-stand at 21
+      dealerSt.current.setFaceDown(holeIdRef.current!, false);
       setHoleRevealed(true);
+      setCardStates(allLayouts(350));
       setDealerDone(false);
       setPhase("dealer-turn");
+    } else {
+      setCardStates(allLayouts(350));
     }
-  }, [phase, deck, playerHand, bet]);
+  }, [phase, playerHand, bet, allLayouts]);
+
+  // ── Stand ─────────────────────────────────────────────────────────────────
 
   const stand = useCallback(() => {
     if (phase !== "player-turn") return;
+    dealerSt.current.setFaceDown(holeIdRef.current!, false);
     setHoleRevealed(true);
+    setCardStates(allLayouts(350));
     setDealerDone(false);
     setPhase("dealer-turn");
-  }, [phase]);
+  }, [phase, allLayouts]);
+
+  // ── Double Down ───────────────────────────────────────────────────────────
 
   const doubleDown = useCallback(() => {
     if (phase !== "player-turn" || playerHand.length !== 2 || chips < bet * 2) return;
     const newBet = bet * 2;
-    const [nextCard, ...rest] = deck;
-    const newHand = [...playerHand, nextCard];
-    const total = handTotal(newHand);
-
-    setDeck(rest);
+    const card   = shoe.current.removeTop();
+    if (!card) return;
+    playerSt.current.addCard(card, { toTop: true, faceDown: false });
+    const newHand = [...playerHand, card];
+    const total   = handTotal(newHand);
     setPlayerHand(newHand);
     setBet(newBet);
+    setShoeCount(shoe.current.size);
+
+    dealerSt.current.setFaceDown(holeIdRef.current!, false);
+    setHoleRevealed(true);
 
     if (total > 21) {
-      setChips((c) => c - newBet);
+      setCardStates(allLayouts(350));
+      setChips(c => c - newBet);
       setOutcome("bust");
       setChipDelta(-newBet);
-      setHoleRevealed(true);
       setPhase("resolved");
     } else {
-      setHoleRevealed(true);
+      setCardStates(allLayouts(350));
       setDealerDone(false);
       setPhase("dealer-turn");
     }
-  }, [phase, playerHand, deck, bet, chips]);
+  }, [phase, playerHand, bet, chips, allLayouts]);
 
-  // ── Dealer auto-play ───────────────────────────────────────────────────────
+  // ── Dealer auto-play ──────────────────────────────────────────────────────
 
-  // Each time dealerHand changes during dealer-turn, check whether to hit or stand.
   useEffect(() => {
     if (phase !== "dealer-turn" || dealerDone) return;
-
     const total = handTotal(dealerHand);
     const timer = setTimeout(() => {
       if (total < 17) {
-        setDeck((prevDeck) => {
-          const [nextCard, ...rest] = prevDeck;
-          setDealerHand((prev) => [...prev, nextCard]);
-          return rest;
-        });
+        const card = shoe.current.removeTop();
+        if (!card) return;
+        dealerSt.current.addCard(card, { toTop: true, faceDown: false });
+        setDealerHand(prev => [...prev, card]);
+        setShoeCount(shoe.current.size);
+        setCardStates(allLayouts(400));
       } else {
         setDealerDone(true);
       }
     }, total < 17 ? DEALER_HIT_DELAY_MS : DEALER_STAND_DELAY_MS);
-
     return () => clearTimeout(timer);
-  }, [phase, dealerHand, dealerDone]);
+  }, [phase, dealerHand, dealerDone, allLayouts]);
 
-  // Resolve outcome once dealer is done
+  // ── Resolve outcome ───────────────────────────────────────────────────────
+
   useEffect(() => {
     if (!dealerDone) return;
-
     const pTotal = handTotal(playerHand);
     const dTotal = handTotal(dealerHand);
-
     let o: Outcome;
     let delta: number;
-
     if (isNaturalBlackjack(dealerHand)) {
-      o = "dealer-blackjack";
-      delta = -bet;
+      o = "dealer-blackjack"; delta = -bet;
     } else if (dTotal > 21 || pTotal > dTotal) {
-      o = "win";
-      delta = bet;
+      o = "win";             delta = bet;
     } else if (pTotal === dTotal) {
-      o = "push";
-      delta = 0;
+      o = "push";            delta = 0;
     } else {
-      o = "lose";
-      delta = -bet;
+      o = "lose";            delta = -bet;
     }
-
-    setChips((c) => c + delta);
+    setChips(c => c + delta);
     setOutcome(o);
     setChipDelta(delta);
     setPhase("resolved");
   }, [dealerDone, bet, playerHand, dealerHand]);
 
-  // ── New round / reset ──────────────────────────────────────────────────────
+  // ── New hand (clear hands → disc) ────────────────────────────────────────
 
   const newHand = useCallback(() => {
-    setBet((prev) => Math.min(prev, Math.max(5, chips)));
+    const handCards = [...playerSt.current.cards, ...dealerSt.current.cards];
+    playerSt.current.clear();
+    dealerSt.current.clear();
+    for (const c of handCards) disc.current.addCard(c, { toTop: true, faceDown: true });
+    setBet(prev => Math.min(prev, Math.max(5, chips)));
     setPlayerHand([]);
     setDealerHand([]);
     setHoleRevealed(false);
@@ -231,12 +341,26 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setDealerDone(false);
     setChipDelta(0);
     setPhase("betting");
-  }, [chips]);
+    setCardStates(allLayouts(400));
+  }, [chips, allLayouts]);
+
+  // ── Reset game ────────────────────────────────────────────────────────────
 
   const resetGame = useCallback(() => {
+    const allInPlay = [
+      ...disc.current.cards,
+      ...shoe.current.cards,
+      ...dealerSt.current.cards,
+      ...playerSt.current.cards,
+    ];
+    const reshuffled = shuffle(allInPlay.length > 0 ? allInPlay : [...allCards.current]);
+    disc.current.clear();
+    dealerSt.current.clear();
+    playerSt.current.clear();
+    shoe.current.clear();
+    for (const c of reshuffled) shoe.current.addCard(c, { toTop: true, faceDown: true });
     setChips(STARTING_CHIPS);
     setBet(10);
-    setDeck(buildDeck(settings));
     setPlayerHand([]);
     setDealerHand([]);
     setHoleRevealed(false);
@@ -244,7 +368,9 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setDealerDone(false);
     setChipDelta(0);
     setPhase("betting");
-  }, [settings]);
+    setShoeCount(shoe.current.size);
+    setCardStates(shoe.current.layout(0));
+  }, []);
 
   // ── Menus ─────────────────────────────────────────────────────────────────
 
@@ -255,19 +381,20 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
       ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
     ];
     return [
-      { label: "Game", items },
+      { label: "Game",    items },
       { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
   }, [resetGame, onNewGame, onQuit]);
 
   useWindowMenus(bjMenus);
 
-  // ── Derived display values ─────────────────────────────────────────────────
+  // ── Derived display ───────────────────────────────────────────────────────
 
   const dealerScore = scoreLabel(dealerHand, holeRevealed, true);
   const playerScore = scoreLabel(playerHand, true, false);
   const playerTotal = handTotal(playerHand);
-  const gameOver = chips < 5 && phase === "betting";
+  const dealerTotalForClass = holeRevealed ? handTotal(dealerHand) : 0;
+  const gameOver    = chips < 5 && phase === "betting";
 
   function outcomeText(): string {
     if (!outcome) return "";
@@ -289,9 +416,7 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     return "bj__outcome--lose";
   }
 
-  const dealerTotalForClass = holeRevealed ? handTotal(dealerHand) : 0;
-
-  // ── Render ─────────────────────────────────────────────────────────────────
+  // ── Render ────────────────────────────────────────────────────────────────
 
   return (
     <div className="bj">
@@ -302,70 +427,63 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
           onClose={() => setShowDeckModal(false)}
         />
       )}
-      {/* Felt table */}
-      <div className="bj__table">
 
-        {/* Dealer hand */}
-        <div>
-          <div className="bj__section-label">
+      {/* Stage container — measures width for scaling */}
+      <div className="bj__stage-container" ref={containerRef}>
+        <div
+          className="bj__stage"
+          style={{
+            width:           STAGE_W,
+            height:          STAGE_H,
+            transform:       scale < 1 ? `scale(${scale})` : undefined,
+            transformOrigin: "top left",
+          }}
+        >
+          {/* Render all cards as permanent DOM elements */}
+          {allCards.current.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            return (
+              <PermCard
+                key={card.id}
+                card={card}
+                cs={cs}
+                appearance={appearance}
+                size="sm"
+              />
+            );
+          })}
+
+          {/* Dealer label + score */}
+          <div className="bj__stage-label" style={{ top: 10, left: 10 }}>
             DEALER
             {dealerHand.length > 0 && (
-              <span className={`bj__score${dealerTotalForClass > 21 ? " bj__score--bust" : dealerTotalForClass === 21 && dealerHand.length === 2 ? " bj__score--bj" : ""}`}>
+              <span className={`bj__stage-score${dealerTotalForClass > 21 ? " bj__stage-score--bust" : dealerTotalForClass === 21 && dealerHand.length === 2 ? " bj__stage-score--bj" : ""}`}>
                 {dealerScore}
               </span>
             )}
           </div>
-          <div className="bj__hand">
-            {dealerHand.map((card, i) => (
-              <div key={card.id} className="bj__card">
-                {i === 1 ? (
-                  <FlippableCard
-                    card={card}
-                    faceDown={!holeRevealed}
-                    appearance={appearance}
-                    dealIndex={dealKey > 0 ? i : undefined}
-                  />
-                ) : (
-                  <PlayingCard
-                    card={card}
-                    appearance={appearance}
-                    dealIndex={dealKey > 0 ? i : undefined}
-                  />
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
 
-        {/* Player hand */}
-        <div>
-          <div className="bj__section-label">
+          {/* Player label + score */}
+          <div className="bj__stage-label" style={{ top: 148, left: 10 }}>
             YOU
             {playerHand.length > 0 && (
-              <span className={`bj__score${playerTotal > 21 ? " bj__score--bust" : playerTotal === 21 && playerHand.length === 2 ? " bj__score--bj" : ""}`}>
+              <span className={`bj__stage-score${playerTotal > 21 ? " bj__stage-score--bust" : playerTotal === 21 && playerHand.length === 2 ? " bj__stage-score--bj" : ""}`}>
                 {playerScore}
               </span>
             )}
           </div>
-          <div className="bj__hand">
-            {playerHand.map((card, i) => (
-              <div key={card.id} className="bj__card">
-                <PlayingCard
-                  card={card}
-                  appearance={appearance}
-                  dealIndex={dealKey > 0 ? i + 2 : undefined}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
 
-        {/* Outcome overlay */}
-        {phase === "resolved" && outcome && (
-          <div className={`bj__outcome ${outcomeClass()}`}>
-            {outcomeText()}
+          {/* Shoe count */}
+          <div className="bj__shoe-label" style={{ right: 10, top: 10 }}>
+            {shoeCount} left
           </div>
-        )}
+
+          {/* Outcome overlay */}
+          {phase === "resolved" && outcome && (
+            <div className={`bj__outcome ${outcomeClass()}`}>{outcomeText()}</div>
+          )}
+        </div>
       </div>
 
       {/* Controls */}
@@ -377,26 +495,23 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
 
         <div className="bj__divider" />
 
-        {/* Bet row — only during betting phase */}
         {phase === "betting" && !gameOver && (
           <div className="bj__bet-row">
             <span className="bj__chips-label">Adjust:</span>
-            <button className="bj__btn bj__btn--sm" disabled={bet <= 5}      onClick={() => setBet((p) => Math.max(5, p - 5))}>−$5</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet + 5 > chips} onClick={() => setBet((p) => Math.min(chips, p + 5))}>+$5</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet + 25 > chips} onClick={() => setBet((p) => Math.min(chips, p + 25))}>+$25</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet === 5}       onClick={() => setBet(5)}>Min</button>
-            <button className="bj__btn bj__btn--sm" disabled={bet === chips}   onClick={() => setBet(chips)}>All In</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet <= 5}           onClick={() => setBet(p => Math.max(5, p - 5))}>−$5</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet + 5 > chips}    onClick={() => setBet(p => Math.min(chips, p + 5))}>+$5</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet + 25 > chips}   onClick={() => setBet(p => Math.min(chips, p + 25))}>+$25</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet === 5}          onClick={() => setBet(5)}>Min</button>
+            <button className="bj__btn bj__btn--sm" disabled={bet === chips}      onClick={() => setBet(chips)}>All In</button>
           </div>
         )}
 
-        {/* Action row */}
         <div className="bj__action-row">
           {phase === "betting" && !gameOver && (
-            <button className="bj__btn bj__btn--deal" onClick={deal} disabled={bet < 5}>
+            <button className="bj__btn bj__btn--deal" onClick={deal} disabled={bet < 5 || allCards.current.length === 0}>
               ▶ DEAL
             </button>
           )}
-
           {phase === "player-turn" && (
             <>
               <button className="bj__btn bj__btn--hit"    onClick={hit}>Hit</button>
@@ -406,25 +521,18 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
               )}
             </>
           )}
-
           {phase === "dealer-turn" && (
             <span className="bj__waiting">Dealer playing...</span>
           )}
-
           {phase === "resolved" && (
             chips >= 5
               ? <button className="bj__btn bj__btn--deal" onClick={newHand}>New Hand</button>
               : <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
           )}
-
           {gameOver && (
             <button className="bj__btn bj__btn--deal" onClick={resetGame}>New Game</button>
           )}
         </div>
-
-        {deck.length < RESHUFFLE_AT && phase === "betting" && (
-          <div className="bj__notice">Shuffling next hand</div>
-        )}
       </div>
     </div>
   );

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import "./Blackjack.css";
 import { PlayingCard } from "./PlayingCard";
+import { FlippableCard } from "./FlippableCard";
 import type { Card, CardAppearance, DeckSettings } from "./types";
 import { buildDeck } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
@@ -317,12 +318,20 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
           <div className="bj__hand">
             {dealerHand.map((card, i) => (
               <div key={card.id} className="bj__card">
-                <PlayingCard
-                  card={card}
-                  faceDown={i === 1 && !holeRevealed}
-                  appearance={appearance}
-                  dealIndex={dealKey > 0 ? i : undefined}
-                />
+                {i === 1 ? (
+                  <FlippableCard
+                    card={card}
+                    faceDown={!holeRevealed}
+                    appearance={appearance}
+                    dealIndex={dealKey > 0 ? i : undefined}
+                  />
+                ) : (
+                  <PlayingCard
+                    card={card}
+                    appearance={appearance}
+                    dealIndex={dealKey > 0 ? i : undefined}
+                  />
+                )}
               </div>
             ))}
           </div>

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import "./Blackjack.css";
 import { PlayingCard } from "./PlayingCard";
-import type { Card, DeckSettings } from "./types";
+import type { Card, CardAppearance, DeckSettings } from "./types";
 import { buildDeck } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
@@ -66,8 +66,9 @@ interface BlackjackProps {
 
 export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProps) {
   const [deck, setDeck] = useState<Card[]>(() => buildDeck(settings));
-  const [cardBack, setCardBack] = useState(settings.cardBack);
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
+  const [dealKey, setDealKey] = useState(0);
   const [playerHand, setPlayerHand] = useState<Card[]>([]);
   const [dealerHand, setDealerHand] = useState<Card[]>([]);
   const [holeRevealed, setHoleRevealed] = useState(false);
@@ -90,6 +91,7 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     setPlayerHand(pHand);
     setDealerHand(dHand);
     setHoleRevealed(false);
+    setDealKey((k) => k + 1);
     setOutcome(null);
     setChipDelta(0);
     setDealerDone(false);
@@ -253,7 +255,7 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     ];
     return [
       { label: "Game", items },
-      { label: "Options", items: [{ label: "Deck…", onClick: () => setShowDeckModal(true) }] },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
   }, [resetGame, onNewGame, onQuit]);
 
@@ -294,8 +296,8 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     <div className="bj">
       {showDeckModal && (
         <DeckModal
-          cardBack={cardBack}
-          onSelect={setCardBack}
+          appearance={appearance}
+          onUpdate={setAppearance}
           onClose={() => setShowDeckModal(false)}
         />
       )}
@@ -318,7 +320,8 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
                 <PlayingCard
                   card={card}
                   faceDown={i === 1 && !holeRevealed}
-                  backColor={cardBack}
+                  appearance={appearance}
+                  dealIndex={dealKey > 0 ? i : undefined}
                 />
               </div>
             ))}
@@ -336,9 +339,13 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
             )}
           </div>
           <div className="bj__hand">
-            {playerHand.map((card) => (
+            {playerHand.map((card, i) => (
               <div key={card.id} className="bj__card">
-                <PlayingCard card={card} backColor={cardBack} />
+                <PlayingCard
+                  card={card}
+                  appearance={appearance}
+                  dealIndex={dealKey > 0 ? i + 2 : undefined}
+                />
               </div>
             ))}
           </div>

--- a/src/experiences/Cards/Blackjack.tsx
+++ b/src/experiences/Cards/Blackjack.tsx
@@ -12,20 +12,20 @@ import { DeckModal } from "./DeckModal";
 // ── Stage layout ──────────────────────────────────────────────────────────────
 
 const STAGE_W = 480;
-const STAGE_H = 300;
+const STAGE_H = 360;
 const DEAL_Y  = 72;   // dealer hand y center
-const PLAY_Y  = 178;  // player hand y center
+const PLAY_Y  = 230;  // player hand y center
 const HAND_X  = 44;   // first card center x for both hands
 const FAN_X   = 24;   // per-card horizontal fan offset
-const SHOE_X  = 452;  // shoe pile center x (right of dealer row)
+const SHOE_X  = 440;  // shoe pile center x (right of dealer row)
 const SHOE_Y  = 72;   // shoe pile center y (same level as dealer)
 const DISC_X  = -80;  // discard pile off-screen left
-const DISC_Y  = 125;
+const DISC_Y  = 145;
 
 // In-stage action button anchors
 const HIT_L   = 390;              // HIT card button left edge
-const HIT_T   = PLAY_Y - 36;     // 142 — aligns top of HIT card with player cards
-const STAY_T  = PLAY_Y + 54;     // 232 — below player card bottoms (PLAY_Y+36=214)
+const HIT_T   = PLAY_Y - 50;     // aligns top of HIT zone with top of player cards
+const STAY_T  = PLAY_Y + 60;     // below player card bottoms
 const DBL_L   = 152;
 const DBL_T   = STAY_T;
 
@@ -145,9 +145,8 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
     const el = containerRef.current;
     if (!el) return;
     const obs = new ResizeObserver(entries => {
-      const { width, height } = entries[0].contentRect;
-      const s = Math.min(width / STAGE_W, height / STAGE_H);
-      setScale(Math.max(0.4, s));
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
     });
     obs.observe(el);
     return () => obs.disconnect();
@@ -512,24 +511,22 @@ export default function Blackjack({ settings, onNewGame, onQuit }: BlackjackProp
         <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
 
-      {/* Green felt area — fills all available space */}
-      <div className="bj__stage-container" ref={containerRef}>
+      {/* Green felt area — fixed height derived from scale so window self-sizes */}
+      <div className="bj__stage-container" ref={containerRef} style={{ height: Math.round(STAGE_H * scale) }}>
         <div
           className="bj__stage"
           style={{
             width:  STAGE_W,
             height: STAGE_H,
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: `translate(-50%, -50%) scale(${scale})`,
+            transform: scale < 1 ? `scale(${scale})` : undefined,
+            transformOrigin: "top left",
           }}
         >
           {/* All cards: permanent DOM, positions driven by cardStates */}
           {allCards.current.map(card => {
             const cs = cardStates[card.id];
             if (!cs) return null;
-            return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} size="sm" />;
+            return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} />;
           })}
 
           {/* DEALER label */}

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -1,3 +1,33 @@
+/* ─── Animations ─────────────────────────────────────────────────────── */
+
+@keyframes card-deal-in {
+  from {
+    transform: translateY(-28px) scale(0.88);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes card-reveal {
+  from {
+    transform: translateY(-10px) scale(0.92);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes win-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(68, 204, 68, 0.6); }
+  50%  { box-shadow: 0 0 12px 4px rgba(68, 204, 68, 0.35); }
+  100% { box-shadow: 0 0 0 0 rgba(68, 204, 68, 0); }
+}
+
 /* ─── Playing Card ──────────────────────────────────────────────────── */
 
 .playing-card {
@@ -10,6 +40,11 @@
   flex-shrink: 0;
   user-select: none;
   box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+.playing-card--deal {
+  animation: card-deal-in 0.28s ease backwards;
+  animation-delay: calc(var(--deal-index, 0) * 55ms);
 }
 
 /* Small variant for pyramid layout */
@@ -40,31 +75,92 @@
   right: 3px;
 }
 
-/* Back face — color comes from inline style --card-back */
+/* Back face — primary color from --cbp, pattern color from --cbs */
 .playing-card--back {
-  background-color: var(--card-back, #cc4400);
+  background-color: var(--cbp, #cc4400);
   cursor: default;
 }
 
 .playing-card__back-inner {
   position: absolute;
   inset: 5px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  overflow: hidden;
+}
+
+/* Pattern: crosshatch (default) */
+.playing-card--back[data-pattern="crosshatch"] .playing-card__back-inner,
+.playing-card--back:not([data-pattern]) .playing-card__back-inner {
   background:
     repeating-linear-gradient(
       45deg,
       transparent,
       transparent 5px,
-      rgba(255, 255, 255, 0.12) 5px,
-      rgba(255, 255, 255, 0.12) 6px
+      var(--cbs, rgba(255, 255, 255, 0.15)) 5px,
+      var(--cbs, rgba(255, 255, 255, 0.15)) 6px
     ),
     repeating-linear-gradient(
       -45deg,
       transparent,
       transparent 5px,
-      rgba(255, 255, 255, 0.12) 5px,
-      rgba(255, 255, 255, 0.12) 6px
+      var(--cbs, rgba(255, 255, 255, 0.15)) 5px,
+      var(--cbs, rgba(255, 255, 255, 0.15)) 6px
     );
+}
+
+/* Pattern: diagonal */
+.playing-card--back[data-pattern="diagonal"] .playing-card__back-inner {
+  background:
+    repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 7px,
+      var(--cbs, rgba(255, 255, 255, 0.25)) 7px,
+      var(--cbs, rgba(255, 255, 255, 0.25)) 9px
+    );
+}
+
+/* Pattern: diamonds (tight crosshatch makes diamond shapes) */
+.playing-card--back[data-pattern="diamonds"] .playing-card__back-inner {
+  background:
+    repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 3px,
+      var(--cbs, rgba(255, 255, 255, 0.2)) 3px,
+      var(--cbs, rgba(255, 255, 255, 0.2)) 4px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 3px,
+      var(--cbs, rgba(255, 255, 255, 0.2)) 3px,
+      var(--cbs, rgba(255, 255, 255, 0.2)) 4px
+    );
+}
+
+/* Pattern: noahsoft (wide diagonal stripes + NS watermark) */
+.playing-card--back[data-pattern="noahsoft"] .playing-card__back-inner {
+  background:
+    repeating-linear-gradient(
+      135deg,
+      transparent,
+      transparent 10px,
+      var(--cbs, rgba(255, 255, 255, 0.18)) 10px,
+      var(--cbs, rgba(255, 255, 255, 0.18)) 12px
+    );
+}
+
+.playing-card__back-ns {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: "Press Start 2P", monospace;
+  font-size: 10px;
+  color: var(--cbs, rgba(255, 255, 255, 0.4));
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 /* Front face */
@@ -114,12 +210,35 @@
   pointer-events: none;
 }
 
-.playing-card--red { color: #cc0000; }
+/* Suit colors */
+.playing-card--red   { color: #cc0000; }
 .playing-card--black { color: #111111; }
+.playing-card--blue  { color: #1a1a8a; }
+.playing-card--green { color: #1a5c1a; }
+
 .playing-card--joker {
   color: #5b2d8e;
   font-family: "Press Start 2P", monospace;
 }
+
+/* ─── Large-index face style ─────────────────────────────────────────── */
+
+.playing-card--large-idx .playing-card__large-rank {
+  font-family: "Press Start 2P", monospace;
+  font-size: 18px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -58%);
+  line-height: 1;
+  pointer-events: none;
+}
+
+.playing-card--large-idx.playing-card--sm .playing-card__large-rank {
+  font-size: 12px;
+}
+
+/* ─── Empty slot ─────────────────────────────────────────────────────── */
 
 .playing-card--empty {
   width: 72px;
@@ -258,11 +377,18 @@
   opacity: 1;
 }
 
-/* Jokers checkbox */
+/* Checkbox */
 .cards-launcher__checkbox-wrap {
   display: flex;
   align-items: center;
   gap: 6px;
+  cursor: pointer;
+}
+
+.cards-launcher__checkbox {
+  accent-color: #cc4400;
+  width: 14px;
+  height: 14px;
   cursor: pointer;
 }
 

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -242,19 +242,38 @@
 
 /* ─── Large-index face style ─────────────────────────────────────────── */
 
-.playing-card--large-idx .playing-card__large-rank {
-  font-family: "Press Start 2P", monospace;
-  font-size: 18px;
+.playing-card--large-idx .playing-card__li-center {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -58%);
-  line-height: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
   pointer-events: none;
 }
 
-.playing-card--large-idx.playing-card--sm .playing-card__large-rank {
-  font-size: 12px;
+/* Standard card (72×100): max rank size where "10" still fits the 64px usable width */
+.playing-card--large-idx .playing-card__li-rank {
+  font-family: "Press Start 2P", monospace;
+  font-size: 28px;
+  line-height: 1;
+  display: block;
+}
+
+.playing-card--large-idx .playing-card__li-suit {
+  font-size: 30px;
+  line-height: 1;
+  display: block;
+}
+
+/* sm card (52×72): scaled to fit "10" in the 44px usable width */
+.playing-card--large-idx.playing-card--sm .playing-card__li-rank {
+  font-size: 20px;
+}
+
+.playing-card--large-idx.playing-card--sm .playing-card__li-suit {
+  font-size: 22px;
 }
 
 /* ─── Empty slot ─────────────────────────────────────────────────────── */

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -536,3 +536,34 @@
 .no-game__btn--reshuffle:active {
   border-color: #331155 #9966cc #9966cc #331155;
 }
+
+/* ─── FlippableCard 3D flip ─────────────────────────────────────────── */
+
+.flippable {
+  perspective: 600px;
+  display: inline-block;
+}
+
+.flippable__inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transform: rotateY(0deg);
+  transition: transform 260ms ease-in-out;
+}
+
+.flippable__inner--face-up {
+  transform: rotateY(180deg);
+}
+
+.flippable__face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+.flippable__face--front {
+  transform: rotateY(180deg);
+}

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -211,10 +211,12 @@
 }
 
 /* Suit colors */
-.playing-card--red   { color: #cc0000; }
-.playing-card--black { color: #111111; }
-.playing-card--blue  { color: #1a1a8a; }
-.playing-card--green { color: #1a5c1a; }
+.playing-card--red    { color: #cc0000; }
+.playing-card--black  { color: #111111; }
+.playing-card--pink   { color: #dd2277; }
+.playing-card--orange { color: #cc5500; }
+.playing-card--blue   { color: #1133aa; }
+.playing-card--green  { color: #117733; }
 
 .playing-card--joker {
   color: #5b2d8e;

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -210,13 +210,30 @@
   pointer-events: none;
 }
 
-/* Suit colors */
-.playing-card--red    { color: #cc0000; }
-.playing-card--black  { color: #111111; }
-.playing-card--pink   { color: #dd2277; }
-.playing-card--orange { color: #cc5500; }
-.playing-card--blue   { color: #1133aa; }
-.playing-card--green  { color: #117733; }
+/* Suit colors — standard */
+.playing-card--red   { color: #cc0000; }
+.playing-card--black { color: #111111; }
+
+/* Suit colors — four-color mode (closest to traditional) */
+.playing-card--pink  { color: #cc0055; }   /* hearts */
+.playing-card--navy  { color: #1133aa; }   /* spades */
+.playing-card--green { color: #117733; }   /* clubs */
+/* diamonds stay --red */
+
+/* Suit colors — high-contrast mode (maximally distinct) */
+.playing-card--orange { color: #ee5500; }  /* diamonds: vivid orange */
+.playing-card--blue   { color: #0055ee; }  /* spades: vivid blue */
+/* hearts stay --pink, clubs stay --green */
+
+/* ─── Card text size ────────────────────────────────────────────────────── */
+
+.playing-card--text-lg:not(.playing-card--sm) .playing-card__rank { font-size: 9px; }
+.playing-card--text-lg:not(.playing-card--sm) .playing-card__suit-pip { font-size: 10px; }
+.playing-card--text-lg:not(.playing-card--sm) .playing-card__center { font-size: 30px; }
+
+.playing-card--text-xl:not(.playing-card--sm) .playing-card__rank { font-size: 12px; }
+.playing-card--text-xl:not(.playing-card--sm) .playing-card__suit-pip { font-size: 13px; }
+.playing-card--text-xl:not(.playing-card--sm) .playing-card__center { font-size: 36px; }
 
 .playing-card--joker {
   color: #5b2d8e;

--- a/src/experiences/Cards/Cards.css
+++ b/src/experiences/Cards/Cards.css
@@ -227,6 +227,7 @@
 
 /* ─── Card text size ────────────────────────────────────────────────────── */
 
+/* Full-size cards (72×100) */
 .playing-card--text-lg:not(.playing-card--sm) .playing-card__rank { font-size: 9px; }
 .playing-card--text-lg:not(.playing-card--sm) .playing-card__suit-pip { font-size: 10px; }
 .playing-card--text-lg:not(.playing-card--sm) .playing-card__center { font-size: 30px; }
@@ -234,6 +235,15 @@
 .playing-card--text-xl:not(.playing-card--sm) .playing-card__rank { font-size: 12px; }
 .playing-card--text-xl:not(.playing-card--sm) .playing-card__suit-pip { font-size: 13px; }
 .playing-card--text-xl:not(.playing-card--sm) .playing-card__center { font-size: 36px; }
+
+/* Small cards (52×72) — proportionally scaled sizes */
+.playing-card--text-lg.playing-card--sm .playing-card__rank { font-size: 7px; }
+.playing-card--text-lg.playing-card--sm .playing-card__suit-pip { font-size: 8px; }
+.playing-card--text-lg.playing-card--sm .playing-card__center { font-size: 22px; }
+
+.playing-card--text-xl.playing-card--sm .playing-card__rank { font-size: 9px; }
+.playing-card--text-xl.playing-card--sm .playing-card__suit-pip { font-size: 10px; }
+.playing-card--text-xl.playing-card--sm .playing-card__center { font-size: 26px; }
 
 .playing-card--joker {
   color: #5b2d8e;

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_DECK_SETTINGS,
   type CardsGame,
   type DeckSettings,
+  type MemoryDifficulty,
   type Suit,
   type WarSpeed,
 } from "./types";
@@ -23,6 +24,12 @@ const WAR_SPEEDS: { value: WarSpeed; label: string }[] = [
   { value: "slow",   label: "Slow (2s)"    },
   { value: "normal", label: "Normal (0.9s)" },
   { value: "fast",   label: "Fast (0.25s)" },
+];
+
+const MEMORY_DIFFICULTIES: { value: MemoryDifficulty; label: string }[] = [
+  { value: "easy",   label: "Easy (4×4)"  },
+  { value: "medium", label: "Medium (4×6)" },
+  { value: "hard",   label: "Hard (6×6)"  },
 ];
 
 interface CardsLauncherProps {
@@ -68,6 +75,13 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
 
   useWindowMenus(launcherMenus);
 
+  const showDeckCount = game === "blackjack";
+  const showSuits     = game === "war";
+  const showOptions   = showDeckCount || showSuits;
+  const showWarOpts   = game === "war";
+  const showMemOpts   = game === "memory";
+  const showKlonOpts  = game === "klondike";
+
   return (
     <div className="cards-launcher">
       {/* Game picker */}
@@ -80,20 +94,22 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
         >
           <option value="war">War</option>
           <option value="blackjack">Blackjack</option>
-          <option value="pyramid">Pyramid</option>
-          <option disabled>── More Coming Soon ──</option>
+          <option value="pyramid">Pyramid Solitaire</option>
+          <option value="memory">Memory</option>
+          <option value="klondike">Klondike Solitaire</option>
+          <option value="freecell">FreeCell</option>
+          <option value="hearts">Hearts</option>
         </select>
       </div>
 
-      {/* Per-game options */}
-      {(game === "war" || game === "blackjack") && (
+      {/* Deck options (War suits, Blackjack deck count) */}
+      {showOptions && (
         <>
           <div className="cards-launcher__divider" />
           <div>
             <div className="cards-launcher__section-title">Options:</div>
 
-            {/* Deck count — Blackjack only */}
-            {game === "blackjack" && (
+            {showDeckCount && (
               <div className="cards-launcher__row">
                 <span className="cards-launcher__option-label">Number of Decks:</span>
                 <div className="cards-launcher__stepper">
@@ -104,8 +120,7 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
               </div>
             )}
 
-            {/* Suits — War only */}
-            {game === "war" && (
+            {showSuits && (
               <div className="cards-launcher__row">
                 <span className="cards-launcher__option-label">Suits:</span>
                 <div className="cards-launcher__suits">
@@ -132,8 +147,8 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
         </>
       )}
 
-      {/* War-specific settings */}
-      {game === "war" && (
+      {/* War settings */}
+      {showWarOpts && (
         <>
           <div className="cards-launcher__divider" />
           <div>
@@ -144,6 +159,7 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
               <label className="cards-launcher__checkbox-wrap">
                 <input
                   type="checkbox"
+                  className="cards-launcher__checkbox"
                   checked={settings.warAutoPlay}
                   onChange={(e) => setSettings((prev) => ({ ...prev, warAutoPlay: e.target.checked }))}
                 />
@@ -170,6 +186,51 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
         </>
       )}
 
+      {/* Memory difficulty */}
+      {showMemOpts && (
+        <>
+          <div className="cards-launcher__divider" />
+          <div>
+            <div className="cards-launcher__section-title">Memory Options:</div>
+            <div className="cards-launcher__row">
+              <span className="cards-launcher__option-label">Difficulty:</span>
+              <select
+                className="cards-launcher__select"
+                style={{ width: "auto" }}
+                value={settings.memoryDifficulty}
+                onChange={(e) => setSettings((prev) => ({ ...prev, memoryDifficulty: e.target.value as MemoryDifficulty }))}
+              >
+                {MEMORY_DIFFICULTIES.map((d) => (
+                  <option key={d.value} value={d.value}>{d.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Klondike draw mode */}
+      {showKlonOpts && (
+        <>
+          <div className="cards-launcher__divider" />
+          <div>
+            <div className="cards-launcher__section-title">Klondike Options:</div>
+            <div className="cards-launcher__row">
+              <span className="cards-launcher__option-label">Draw:</span>
+              <select
+                className="cards-launcher__select"
+                style={{ width: "auto" }}
+                value={settings.klondikeDraw}
+                onChange={(e) => setSettings((prev) => ({ ...prev, klondikeDraw: parseInt(e.target.value) as 1 | 3 }))}
+              >
+                <option value={1}>Draw 1</option>
+                <option value={3}>Draw 3</option>
+              </select>
+            </div>
+          </div>
+        </>
+      )}
+
       <div className="cards-launcher__divider" />
 
       <button className="cards-launcher__launch-btn" onClick={() => onLaunch(game, settings)}>
@@ -178,8 +239,8 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
 
       {showDeckModal && (
         <DeckModal
-          cardBack={settings.cardBack}
-          onSelect={(color) => setSettings((prev) => ({ ...prev, cardBack: color }))}
+          appearance={settings.appearance}
+          onUpdate={(a) => setSettings((prev) => ({ ...prev, appearance: a }))}
           onClose={() => setShowDeckModal(false)}
         />
       )}

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -227,6 +227,25 @@ export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) 
                 <option value={3}>Draw 3</option>
               </select>
             </div>
+            <div className="cards-launcher__row">
+              <span className="cards-launcher__option-label">Relaxed Rules:</span>
+              <label className="cards-launcher__checkbox-wrap">
+                <input
+                  type="checkbox"
+                  className="cards-launcher__checkbox"
+                  checked={settings.klondikeRelaxed}
+                  onChange={(e) => setSettings((prev) => ({ ...prev, klondikeRelaxed: e.target.checked }))}
+                />
+                <span className="cards-launcher__checkbox-text">{settings.klondikeRelaxed ? "On" : "Off"}</span>
+              </label>
+            </div>
+            {settings.klondikeRelaxed && (
+              <div className="cards-launcher__row">
+                <span style={{ fontSize: "6px", color: "#666", lineHeight: 1.4 }}>
+                  Any card may be placed on empty columns
+                </span>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/src/experiences/Cards/CardsLauncher.tsx
+++ b/src/experiences/Cards/CardsLauncher.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import "./Cards.css";
 import {
+  DEFAULT_APPEARANCE,
   DEFAULT_DECK_SETTINGS,
   type CardsGame,
   type DeckSettings,
@@ -12,6 +13,41 @@ import { totalCards } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
+
+const STORAGE_KEY = "toybox-cards-settings-v1";
+
+function loadPersistedState(): { game: CardsGame; settings: DeckSettings } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { game: "war", settings: DEFAULT_DECK_SETTINGS };
+    const parsed = JSON.parse(raw) as { game?: CardsGame; settings?: Partial<DeckSettings> };
+    return {
+      game: (parsed.game ?? "war") as CardsGame,
+      settings: {
+        ...DEFAULT_DECK_SETTINGS,
+        ...(parsed.settings ?? {}),
+        appearance: {
+          ...DEFAULT_APPEARANCE,
+          ...(parsed.settings?.appearance ?? {}),
+          backImageUrl: null, // don't restore large data URLs
+        },
+      },
+    };
+  } catch {
+    return { game: "war", settings: DEFAULT_DECK_SETTINGS };
+  }
+}
+
+function persistState(game: CardsGame, settings: DeckSettings) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      game,
+      settings: { ...settings, appearance: { ...settings.appearance, backImageUrl: null } },
+    }));
+  } catch {
+    // localStorage unavailable or full — ignore
+  }
+}
 
 const SUITS: { id: Suit; symbol: string; isRed: boolean }[] = [
   { id: "spades",   symbol: "♠", isRed: false },
@@ -38,9 +74,15 @@ interface CardsLauncherProps {
 }
 
 export default function CardsLauncher({ onLaunch, onQuit }: CardsLauncherProps) {
-  const [game, setGame] = useState<CardsGame>("war");
-  const [settings, setSettings] = useState<DeckSettings>(DEFAULT_DECK_SETTINGS);
+  const initial = useMemo(loadPersistedState, []);
+  const [game, setGame] = useState<CardsGame>(initial.game);
+  const [settings, setSettings] = useState<DeckSettings>(initial.settings);
   const [showDeckModal, setShowDeckModal] = useState(false);
+
+  // Persist whenever game or settings change
+  useEffect(() => {
+    persistState(game, settings);
+  }, [game, settings]);
 
   const toggleSuit = (suit: Suit) => {
     const active = settings.suits.includes(suit);

--- a/src/experiences/Cards/DeckModal.css
+++ b/src/experiences/Cards/DeckModal.css
@@ -1,11 +1,11 @@
 .deck-modal-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 200;
+  z-index: 10000;
   overflow-y: auto;
 }
 

--- a/src/experiences/Cards/DeckModal.css
+++ b/src/experiences/Cards/DeckModal.css
@@ -282,7 +282,28 @@
   pointer-events: none;
 }
 
-/* Four-color */
+/* Suit color mode radio buttons */
+.deck-modal__suit-modes {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.deck-modal__suit-mode-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.deck-modal__radio {
+  accent-color: #cc4400;
+  cursor: pointer;
+  width: 12px;
+  height: 12px;
+}
+
+/* Legacy check-row (kept for other uses) */
 .deck-modal__check-row {
   display: flex;
   align-items: center;

--- a/src/experiences/Cards/DeckModal.css
+++ b/src/experiences/Cards/DeckModal.css
@@ -282,6 +282,41 @@
   pointer-events: none;
 }
 
+/* Card text size buttons */
+.deck-modal__text-sizes {
+  display: flex;
+  gap: 6px;
+}
+
+.deck-modal__size-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 5px 10px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #d4d0c8;
+  cursor: pointer;
+  font-family: "Press Start 2P", monospace;
+  min-width: 52px;
+}
+
+.deck-modal__size-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #c0c0c0;
+  outline: 1px solid #000;
+}
+
+.deck-modal__size-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.deck-modal__size-label {
+  font-size: 5px;
+  color: #444;
+}
+
 /* Suit color mode radio buttons */
 .deck-modal__suit-modes {
   display: flex;

--- a/src/experiences/Cards/DeckModal.css
+++ b/src/experiences/Cards/DeckModal.css
@@ -6,13 +6,16 @@
   align-items: center;
   justify-content: center;
   z-index: 200;
+  overflow-y: auto;
 }
 
 .deck-modal {
   background: #c0c0c0;
   border: 2px solid;
   border-color: #ffffff #808080 #808080 #ffffff;
-  min-width: 180px;
+  min-width: 300px;
+  max-width: 340px;
+  width: 100%;
 }
 
 .deck-modal__titlebar {
@@ -45,35 +48,269 @@
   border-color: #808080 #ffffff #ffffff #808080;
 }
 
-.deck-modal__body {
-  padding: 12px;
+/* ── Tabs ── */
+.deck-modal__tabs {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
+  gap: 0;
+  padding: 6px 8px 0;
+  border-bottom: 2px solid #808080;
 }
 
-.deck-modal__swatches {
+.deck-modal__tab {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 4px 10px;
+  border: 2px solid;
+  border-color: #ffffff #808080 transparent #ffffff;
+  background: #d4d0c8;
+  color: #444;
+  cursor: pointer;
+  margin-bottom: -2px;
+  position: relative;
+}
+
+.deck-modal__tab--active {
+  background: #c0c0c0;
+  color: #000;
+  border-bottom-color: #c0c0c0;
+  z-index: 1;
+}
+
+/* ── Body ── */
+.deck-modal__body {
+  padding: 10px 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: "Press Start 2P", monospace;
+}
+
+.deck-modal__section-label {
+  font-size: 7px;
+  color: #000;
+  margin-top: 4px;
+}
+
+/* Patterns */
+.deck-modal__patterns {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
-  justify-content: center;
 }
 
-.deck-modal__swatch {
-  width: 24px;
-  height: 24px;
+.deck-modal__pattern-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 4px;
   border: 2px solid;
   border-color: #ffffff #808080 #808080 #ffffff;
+  background: #d4d0c8;
   cursor: pointer;
 }
 
-.deck-modal__swatch:active,
-.deck-modal__swatch--selected {
+.deck-modal__pattern-btn--active {
   border-color: #808080 #ffffff #ffffff #808080;
-  box-shadow: inset 0 0 0 2px #000000;
+  background: #c0c0c0;
+  outline: 1px solid #000;
 }
 
+.deck-modal__pattern-thumb {
+  width: 32px;
+  height: 44px;
+  background-color: var(--cbp, #cc4400);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(0,0,0,0.2);
+}
+
+.deck-modal__pattern-thumb-inner {
+  position: absolute;
+  inset: 3px;
+}
+
+/* Crosshatch thumb */
+.deck-modal__pattern-thumb[data-pattern="crosshatch"] .deck-modal__pattern-thumb-inner {
+  background:
+    repeating-linear-gradient(45deg, transparent, transparent 4px, var(--cbs, #ffffff55) 4px, var(--cbs, #ffffff55) 5px),
+    repeating-linear-gradient(-45deg, transparent, transparent 4px, var(--cbs, #ffffff55) 4px, var(--cbs, #ffffff55) 5px);
+}
+
+/* Diagonal thumb */
+.deck-modal__pattern-thumb[data-pattern="diagonal"] .deck-modal__pattern-thumb-inner {
+  background: repeating-linear-gradient(45deg, transparent, transparent 6px, var(--cbs, #ffffff55) 6px, var(--cbs, #ffffff55) 8px);
+}
+
+/* Diamonds thumb */
+.deck-modal__pattern-thumb[data-pattern="diamonds"] .deck-modal__pattern-thumb-inner {
+  background:
+    repeating-linear-gradient(45deg, transparent, transparent 2px, var(--cbs, #ffffff55) 2px, var(--cbs, #ffffff55) 3px),
+    repeating-linear-gradient(-45deg, transparent, transparent 2px, var(--cbs, #ffffff55) 2px, var(--cbs, #ffffff55) 3px);
+}
+
+/* Noahsoft thumb */
+.deck-modal__pattern-thumb[data-pattern="noahsoft"] .deck-modal__pattern-thumb-inner {
+  background: repeating-linear-gradient(135deg, transparent, transparent 8px, var(--cbs, #ffffff55) 8px, var(--cbs, #ffffff55) 10px);
+}
+
+.deck-modal__pattern-ns {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  color: var(--cbs, rgba(255,255,255,0.5));
+  pointer-events: none;
+}
+
+.deck-modal__pattern-label {
+  font-size: 5px;
+  color: #444;
+}
+
+/* Color rows */
+.deck-modal__color-row {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.deck-modal__swatch {
+  width: 20px;
+  height: 20px;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.deck-modal__swatch--selected {
+  border-color: #ffffff #808080 #808080 #ffffff;
+  outline: 2px solid #000;
+  outline-offset: 1px;
+}
+
+.deck-modal__custom-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 9px;
+  width: 22px;
+  height: 20px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  padding: 0;
+  color: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.deck-modal__custom-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.deck-modal__hidden-color {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Image upload */
+.deck-modal__image-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.deck-modal__img-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  padding: 3px 7px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  color: #000;
+}
+
+.deck-modal__img-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.deck-modal__img-btn--clear {
+  color: #cc4400;
+}
+
+.deck-modal__img-name {
+  font-size: 6px;
+  color: #228833;
+}
+
+/* Face styles */
+.deck-modal__face-styles {
+  display: flex;
+  gap: 8px;
+}
+
+.deck-modal__face-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 4px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #d4d0c8;
+  cursor: pointer;
+}
+
+.deck-modal__face-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #c0c0c0;
+  outline: 1px solid #000;
+}
+
+.deck-modal__face-preview {
+  pointer-events: none;
+}
+
+/* Four-color */
+.deck-modal__check-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.deck-modal__check-label {
+  font-size: 7px;
+  color: #000;
+}
+
+.deck-modal__four-color-preview {
+  display: flex;
+  gap: 4px;
+}
+
+/* Preview */
+.deck-modal__preview-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 6px 0 4px;
+  border-top: 1px solid #808080;
+  margin-top: 4px;
+}
+
+/* Footer */
 .deck-modal__footer {
   padding: 8px;
   display: flex;
@@ -87,7 +324,7 @@
   border-color: #ffffff #808080 #808080 #ffffff;
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
-  padding: 4px 16px;
+  padding: 4px 20px;
   cursor: pointer;
   min-width: 60px;
 }

--- a/src/experiences/Cards/DeckModal.tsx
+++ b/src/experiences/Cards/DeckModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import type { CardAppearance, BackPattern, CardFaceStyle } from "./types";
+import type { CardAppearance, BackPattern, CardFaceStyle, SuitColorMode } from "./types";
 import { PlayingCard } from "./PlayingCard";
 import "./DeckModal.css";
 
@@ -214,18 +214,26 @@ export function DeckModal({ appearance, onUpdate, onClose }: DeckModalProps) {
                 ))}
               </div>
 
-              {/* Four-color suits */}
+              {/* Suit color mode */}
               <div className="deck-modal__section-label">Suit Colors:</div>
-              <label className="deck-modal__check-row">
-                <input
-                  type="checkbox"
-                  className="cards-launcher__checkbox"
-                  checked={appearance.fourColorSuits}
-                  onChange={(e) => set({ fourColorSuits: e.target.checked })}
-                />
-                <span className="deck-modal__check-label">Four-color suits</span>
-              </label>
-              {appearance.fourColorSuits && (
+              <div className="deck-modal__suit-modes">
+                {(["standard", "four-color", "high-contrast"] as SuitColorMode[]).map((mode) => (
+                  <label key={mode} className="deck-modal__suit-mode-option">
+                    <input
+                      type="radio"
+                      name="suitColorMode"
+                      value={mode}
+                      checked={(appearance.suitColorMode ?? "standard") === mode}
+                      onChange={() => set({ suitColorMode: mode })}
+                      className="deck-modal__radio"
+                    />
+                    <span className="deck-modal__check-label">
+                      {mode === "standard" ? "Standard" : mode === "four-color" ? "Four-Color" : "High Contrast"}
+                    </span>
+                  </label>
+                ))}
+              </div>
+              {(appearance.suitColorMode ?? "standard") !== "standard" && (
                 <div className="deck-modal__four-color-preview">
                   <PlayingCard card={PREVIEW_CARD_SPADE}   size="sm" appearance={appearance} />
                   <PlayingCard card={PREVIEW_CARD_HEART}   size="sm" appearance={appearance} />

--- a/src/experiences/Cards/DeckModal.tsx
+++ b/src/experiences/Cards/DeckModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import type { CardAppearance, BackPattern, CardFaceStyle, SuitColorMode } from "./types";
+import type { CardAppearance, BackPattern, CardFaceStyle, CardTextSize, SuitColorMode } from "./types";
 import { PlayingCard } from "./PlayingCard";
 import "./DeckModal.css";
 
@@ -210,6 +210,25 @@ export function DeckModal({ appearance, onUpdate, onClose }: DeckModalProps) {
                       />
                     </div>
                     <span className="deck-modal__pattern-label">{fs.label}</span>
+                  </button>
+                ))}
+              </div>
+
+              {/* Card text size */}
+              <div className="deck-modal__section-label">Text Size:</div>
+              <div className="deck-modal__text-sizes">
+                {(["normal", "large", "xl"] as CardTextSize[]).map((sz) => (
+                  <button
+                    key={sz}
+                    className={`deck-modal__size-btn${(appearance.cardTextSize ?? "normal") === sz ? " deck-modal__size-btn--active" : ""}`}
+                    onClick={() => set({ cardTextSize: sz })}
+                  >
+                    <span style={{ fontSize: sz === "normal" ? 7 : sz === "large" ? 9 : 11 }}>
+                      {sz === "normal" ? "Aa" : sz === "large" ? "Aa" : "Aa"}
+                    </span>
+                    <span className="deck-modal__size-label">
+                      {sz === "normal" ? "Normal" : sz === "large" ? "Large" : "XL"}
+                    </span>
                   </button>
                 ))}
               </div>

--- a/src/experiences/Cards/DeckModal.tsx
+++ b/src/experiences/Cards/DeckModal.tsx
@@ -1,37 +1,248 @@
-import { CARD_BACK_COLORS } from "./types";
+import { useState, useRef } from "react";
+import type { CardAppearance, BackPattern, CardFaceStyle } from "./types";
 import { PlayingCard } from "./PlayingCard";
 import "./DeckModal.css";
 
-const PREVIEW_CARD = { suit: "spades" as const, rank: "A" as const, id: "deck-preview" };
+const PREVIEW_CARD_SPADE = { suit: "spades" as const, rank: "A" as const, id: "deck-preview-s" };
+const PREVIEW_CARD_HEART = { suit: "hearts" as const, rank: "K" as const, id: "deck-preview-h" };
+const PREVIEW_CARD_DIAMOND = { suit: "diamonds" as const, rank: "Q" as const, id: "deck-preview-d" };
+const PREVIEW_CARD_CLUB = { suit: "clubs" as const, rank: "J" as const, id: "deck-preview-c" };
+
+const PRIMARY_PRESETS = [
+  { label: "Orange", color: "#cc4400" },
+  { label: "Red",    color: "#8a1a1a" },
+  { label: "Navy",   color: "#1a4a8a" },
+  { label: "Forest", color: "#1a5c2a" },
+  { label: "Purple", color: "#5b2d8e" },
+  { label: "Black",  color: "#1a1a1a" },
+];
+
+const SECONDARY_PRESETS = [
+  { label: "White",      color: "#ffffff" },
+  { label: "Cream",      color: "#f0e8d0" },
+  { label: "Yellow",     color: "#ffcc00" },
+  { label: "Gold",       color: "#ff8833" },
+  { label: "Light gray", color: "#d4d0c8" },
+  { label: "Black",      color: "#000000" },
+];
+
+const PATTERNS: { value: BackPattern; label: string }[] = [
+  { value: "crosshatch", label: "Crosshatch" },
+  { value: "diagonal",   label: "Diagonal" },
+  { value: "diamonds",   label: "Diamonds" },
+  { value: "noahsoft",   label: "Noahsoft" },
+];
+
+const FACE_STYLES: { value: CardFaceStyle; label: string }[] = [
+  { value: "classic",     label: "Classic" },
+  { value: "minimal",     label: "Minimal" },
+  { value: "large-index", label: "Large Idx" },
+];
 
 interface DeckModalProps {
-  cardBack: string;
-  onSelect: (color: string) => void;
+  appearance: CardAppearance;
+  onUpdate: (appearance: CardAppearance) => void;
   onClose: () => void;
 }
 
-export function DeckModal({ cardBack, onSelect, onClose }: DeckModalProps) {
+export function DeckModal({ appearance, onUpdate, onClose }: DeckModalProps) {
+  const [tab, setTab] = useState<"back" | "face">("back");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const primaryColorRef = useRef<HTMLInputElement>(null);
+  const secondaryColorRef = useRef<HTMLInputElement>(null);
+
+  const set = (patch: Partial<CardAppearance>) => onUpdate({ ...appearance, ...patch });
+
+  const handleImageFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      set({ backImageUrl: (ev.target?.result as string) ?? null });
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  };
+
   return (
     <div className="deck-modal-overlay" onClick={onClose}>
       <div className="deck-modal" onClick={(e) => e.stopPropagation()}>
+        {/* Title bar */}
         <div className="deck-modal__titlebar">
           <span>Card Appearance</span>
           <button className="deck-modal__close" onClick={onClose} aria-label="Close">✕</button>
         </div>
-        <div className="deck-modal__body">
-          <div className="deck-modal__swatches">
-            {CARD_BACK_COLORS.map((cb) => (
-              <button
-                key={cb.color}
-                className={`deck-modal__swatch${cardBack === cb.color ? " deck-modal__swatch--selected" : ""}`}
-                style={{ background: cb.color }}
-                title={cb.label}
-                onClick={() => onSelect(cb.color)}
-              />
-            ))}
-          </div>
-          <PlayingCard card={PREVIEW_CARD} faceDown backColor={cardBack} />
+
+        {/* Tabs */}
+        <div className="deck-modal__tabs">
+          <button
+            className={`deck-modal__tab${tab === "back" ? " deck-modal__tab--active" : ""}`}
+            onClick={() => setTab("back")}
+          >Back</button>
+          <button
+            className={`deck-modal__tab${tab === "face" ? " deck-modal__tab--active" : ""}`}
+            onClick={() => setTab("face")}
+          >Face</button>
         </div>
+
+        <div className="deck-modal__body">
+          {tab === "back" && (
+            <>
+              {/* Pattern picker */}
+              <div className="deck-modal__section-label">Pattern:</div>
+              <div className="deck-modal__patterns">
+                {PATTERNS.map((p) => (
+                  <button
+                    key={p.value}
+                    className={`deck-modal__pattern-btn${appearance.backPattern === p.value ? " deck-modal__pattern-btn--active" : ""}`}
+                    onClick={() => set({ backPattern: p.value })}
+                    title={p.label}
+                  >
+                    <div
+                      className="deck-modal__pattern-thumb"
+                      data-pattern={p.value}
+                      style={{
+                        "--cbp": appearance.backPrimaryColor,
+                        "--cbs": appearance.backSecondaryColor + "55",
+                      } as React.CSSProperties}
+                    >
+                      <div className="deck-modal__pattern-thumb-inner" />
+                      {p.value === "noahsoft" && <span className="deck-modal__pattern-ns">NS</span>}
+                    </div>
+                    <span className="deck-modal__pattern-label">{p.label}</span>
+                  </button>
+                ))}
+              </div>
+
+              {/* Primary color */}
+              <div className="deck-modal__section-label">Back Color:</div>
+              <div className="deck-modal__color-row">
+                {PRIMARY_PRESETS.map((c) => (
+                  <button
+                    key={c.color}
+                    className={`deck-modal__swatch${appearance.backPrimaryColor === c.color ? " deck-modal__swatch--selected" : ""}`}
+                    style={{ background: c.color }}
+                    title={c.label}
+                    onClick={() => set({ backPrimaryColor: c.color })}
+                  />
+                ))}
+                <button
+                  className="deck-modal__custom-btn"
+                  onClick={() => primaryColorRef.current?.click()}
+                >⋯</button>
+                <input
+                  ref={primaryColorRef}
+                  type="color"
+                  value={appearance.backPrimaryColor}
+                  onChange={(e) => set({ backPrimaryColor: e.target.value })}
+                  className="deck-modal__hidden-color"
+                />
+              </div>
+
+              {/* Secondary color */}
+              <div className="deck-modal__section-label">Pattern Color:</div>
+              <div className="deck-modal__color-row">
+                {SECONDARY_PRESETS.map((c) => (
+                  <button
+                    key={c.color}
+                    className={`deck-modal__swatch${appearance.backSecondaryColor === c.color ? " deck-modal__swatch--selected" : ""}`}
+                    style={{ background: c.color, border: c.color === "#ffffff" ? "2px solid #808080" : undefined }}
+                    title={c.label}
+                    onClick={() => set({ backSecondaryColor: c.color })}
+                  />
+                ))}
+                <button
+                  className="deck-modal__custom-btn"
+                  onClick={() => secondaryColorRef.current?.click()}
+                >⋯</button>
+                <input
+                  ref={secondaryColorRef}
+                  type="color"
+                  value={appearance.backSecondaryColor}
+                  onChange={(e) => set({ backSecondaryColor: e.target.value })}
+                  className="deck-modal__hidden-color"
+                />
+              </div>
+
+              {/* Custom image */}
+              <div className="deck-modal__section-label">Custom Back:</div>
+              <div className="deck-modal__image-row">
+                <button
+                  className="deck-modal__img-btn"
+                  onClick={() => fileInputRef.current?.click()}
+                >Browse…</button>
+                {appearance.backImageUrl && (
+                  <button
+                    className="deck-modal__img-btn deck-modal__img-btn--clear"
+                    onClick={() => set({ backImageUrl: null })}
+                  >Clear</button>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageFile}
+                  className="deck-modal__hidden-color"
+                />
+                {appearance.backImageUrl && (
+                  <span className="deck-modal__img-name">image set ✓</span>
+                )}
+              </div>
+            </>
+          )}
+
+          {tab === "face" && (
+            <>
+              {/* Face style */}
+              <div className="deck-modal__section-label">Card Face:</div>
+              <div className="deck-modal__face-styles">
+                {FACE_STYLES.map((fs) => (
+                  <button
+                    key={fs.value}
+                    className={`deck-modal__face-btn${appearance.cardFaceStyle === fs.value ? " deck-modal__face-btn--active" : ""}`}
+                    onClick={() => set({ cardFaceStyle: fs.value })}
+                  >
+                    <div className="deck-modal__face-preview">
+                      <PlayingCard
+                        card={PREVIEW_CARD_SPADE}
+                        size="sm"
+                        appearance={{ ...appearance, cardFaceStyle: fs.value }}
+                      />
+                    </div>
+                    <span className="deck-modal__pattern-label">{fs.label}</span>
+                  </button>
+                ))}
+              </div>
+
+              {/* Four-color suits */}
+              <div className="deck-modal__section-label">Suit Colors:</div>
+              <label className="deck-modal__check-row">
+                <input
+                  type="checkbox"
+                  className="cards-launcher__checkbox"
+                  checked={appearance.fourColorSuits}
+                  onChange={(e) => set({ fourColorSuits: e.target.checked })}
+                />
+                <span className="deck-modal__check-label">Four-color suits</span>
+              </label>
+              {appearance.fourColorSuits && (
+                <div className="deck-modal__four-color-preview">
+                  <PlayingCard card={PREVIEW_CARD_SPADE}   size="sm" appearance={appearance} />
+                  <PlayingCard card={PREVIEW_CARD_HEART}   size="sm" appearance={appearance} />
+                  <PlayingCard card={PREVIEW_CARD_DIAMOND} size="sm" appearance={appearance} />
+                  <PlayingCard card={PREVIEW_CARD_CLUB}    size="sm" appearance={appearance} />
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Back preview */}
+          <div className="deck-modal__preview-row">
+            <PlayingCard card={PREVIEW_CARD_SPADE} faceDown appearance={appearance} />
+            <PlayingCard card={PREVIEW_CARD_SPADE} appearance={appearance} />
+          </div>
+        </div>
+
         <div className="deck-modal__footer">
           <button className="deck-modal__ok" onClick={onClose}>OK</button>
         </div>

--- a/src/experiences/Cards/FlippableCard.tsx
+++ b/src/experiences/Cards/FlippableCard.tsx
@@ -1,0 +1,36 @@
+import "./Cards.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, CardAppearance } from "./types";
+import { DEFAULT_APPEARANCE } from "./types";
+
+export interface FlippableCardProps {
+  card: Card;
+  faceDown: boolean;
+  appearance?: CardAppearance;
+  size?: "sm";
+  dealIndex?: number;
+}
+
+/** A card with a CSS 3D flip transition. faceDown=true shows the back; flipping to false animates to the front. */
+export function FlippableCard({
+  card,
+  faceDown,
+  appearance = DEFAULT_APPEARANCE,
+  size,
+  dealIndex,
+}: FlippableCardProps) {
+  const cw = size === "sm" ? 52 : 72;
+  const ch = size === "sm" ? 72 : 100;
+  return (
+    <div className="flippable" style={{ width: cw, height: ch }}>
+      <div className={`flippable__inner${faceDown ? "" : " flippable__inner--face-up"}`}>
+        <div className="flippable__face flippable__face--back">
+          <PlayingCard card={card} faceDown appearance={appearance} size={size} dealIndex={dealIndex} />
+        </div>
+        <div className="flippable__face flippable__face--front">
+          <PlayingCard card={card} appearance={appearance} size={size} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/FreeCell.css
+++ b/src/experiences/Cards/FreeCell.css
@@ -1,0 +1,263 @@
+/* ── FreeCell Layout ────────────────────────────────────────────────────── */
+
+.freecell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  background: #1a4a1a;
+  font-family: "Press Start 2P", monospace;
+  min-height: 400px;
+  user-select: none;
+}
+
+/* ── Top Row (free cells + status + foundations) ────────────────────────── */
+
+.freecell__top-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.freecell__free-cells {
+  display: flex;
+  gap: 4px;
+}
+
+.freecell__foundations {
+  display: flex;
+  gap: 4px;
+}
+
+.freecell__center-status {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.freecell__moves {
+  font-size: 7px;
+  color: #c0c0c0;
+  white-space: nowrap;
+}
+
+.freecell__auto-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  color: #000;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.freecell__auto-btn:hover:not(:disabled) {
+  background: #d4d0c8;
+}
+
+.freecell__auto-btn:active:not(:disabled) {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.freecell__auto-btn:disabled {
+  color: #808080;
+  cursor: default;
+}
+
+/* ── Cell Slots (free cells + foundations) ──────────────────────────────── */
+
+.freecell__cell-slot {
+  width: 52px;
+  height: 72px;
+  position: relative;
+  cursor: pointer;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.freecell__cell-slot--selected {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
+.freecell__cell-slot--valid {
+  outline: 2px solid #44cc44;
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
+.freecell__cell-slot--foundation {
+  cursor: pointer;
+}
+
+/* ── Empty slot placeholders ────────────────────────────────────────────── */
+
+.freecell__empty-slot {
+  width: 52px;
+  height: 72px;
+  border-radius: 3px;
+  border: 2px dashed #3a6a3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.freecell__empty-slot--freecell {
+  background: #1a3a1a;
+  border-color: #2a5a2a;
+}
+
+.freecell__empty-slot--foundation {
+  background: #163816;
+  border-color: #2a5a2a;
+}
+
+.freecell__empty-slot--cascade {
+  background: #163816;
+  border-color: #2a5a2a;
+  width: 100%;
+  height: 72px;
+}
+
+.freecell__suit-hint {
+  font-size: 18px;
+  color: #2a5a2a;
+  line-height: 1;
+}
+
+/* ── Cascades ───────────────────────────────────────────────────────────── */
+
+.freecell__cascades {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  align-items: flex-start;
+}
+
+.freecell__cascade {
+  flex: 1;
+  position: relative;
+  min-width: 56px;
+  /* height grows with content */
+  min-height: 80px;
+}
+
+.freecell__cascade--valid > .freecell__empty-slot--cascade {
+  border-color: #44cc44;
+  background: #1e4a1e;
+}
+
+/* Highlight the empty-cascade slot itself when valid drop target */
+.freecell__cascade--valid .freecell__empty-slot--cascade {
+  border-color: #44cc44;
+}
+
+/* ── Cascade Cards ──────────────────────────────────────────────────────── */
+
+.freecell__cascade-card {
+  position: absolute;
+  left: 0;
+  cursor: pointer;
+}
+
+.freecell__cascade-card--selected {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
+/* The topmost card in a selected sequence keeps the orange outline */
+.freecell__cascade-card--seq-start {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
+/* ── Win Overlay ────────────────────────────────────────────────────────── */
+
+.freecell__win-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  border-radius: 2px;
+}
+
+.freecell__win-banner {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 24px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.freecell__win-title {
+  font-family: "Press Start 2P", monospace;
+  font-size: 16px;
+  color: #228833;
+  text-shadow: 1px 1px 0 #000;
+}
+
+.freecell__win-moves {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  color: #333;
+}
+
+.freecell__win-btns {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────────── */
+
+.freecell__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 8px 16px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.freecell__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+
+.freecell__btn--primary:hover {
+  background: #ee5500;
+}
+
+.freecell__btn--primary:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+}
+
+.freecell__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.freecell__btn--secondary:hover {
+  background: #d4d0c8;
+}
+
+.freecell__btn--secondary:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}

--- a/src/experiences/Cards/FreeCell.css
+++ b/src/experiences/Cards/FreeCell.css
@@ -1,3 +1,50 @@
+/* ── FreeCell Wrapper ───────────────────────────────────────────────────── */
+
+.freecell-wrapper {
+  width: 100%;
+}
+
+/* ── Portrait mode toggle bar ───────────────────────────────────────────── */
+
+.freecell__portrait-toggle {
+  display: flex;
+  gap: 4px;
+  padding: 4px 6px;
+  background: #1a3a1a;
+  border-bottom: 1px solid #2a5a2a;
+}
+
+.freecell__portrait-toggle--overlay {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 20;
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+.freecell__portrait-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 6px;
+  background: #c0c0c0;
+  color: #000;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 3px 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.freecell__portrait-btn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.freecell__portrait-btn--active {
+  border-color: #808080 #ffffff #ffffff #808080;
+  background: #d4d0c8;
+}
+
 /* ── FreeCell Layout ────────────────────────────────────────────────────── */
 
 .freecell {

--- a/src/experiences/Cards/FreeCell.css
+++ b/src/experiences/Cards/FreeCell.css
@@ -1,97 +1,117 @@
-/* ── FreeCell Wrapper ───────────────────────────────────────────────────── */
+/* ── FreeCell ───────────────────────────────────────────────────────────────── */
 
-.freecell-wrapper {
-  width: 100%;
-}
-
-/* ── Portrait mode toggle bar ───────────────────────────────────────────── */
-
-.freecell__portrait-toggle {
+.freecell {
   display: flex;
-  gap: 4px;
-  padding: 4px 6px;
-  background: #1a3a1a;
-  border-bottom: 1px solid #2a5a2a;
-}
-
-.freecell__portrait-toggle--overlay {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  z-index: 20;
-  padding: 0;
-  background: none;
-  border: none;
-}
-
-.freecell__portrait-btn {
+  flex-direction: column;
   font-family: "Press Start 2P", monospace;
-  font-size: 6px;
+  font-size: 8px;
+  user-select: none;
+  flex: 1;
+  min-height: 0;
+  background: #1a4a1a;
+}
+
+/* ── Stage container ─────────────────────────────────────────────────────────── */
+
+.freecell__stage-container {
+  flex: 1;
+  min-height: 200px;
+  position: relative;
+  background: #1a4a1a;
+  overflow: hidden;
+}
+
+.freecell__stage {
+  background: #1a4a1a;
+  isolation: isolate;
+  position: relative;
+}
+
+/* ── Empty card slot placeholders ─────────────────────────────────────────────── */
+
+.freecell__slot {
+  position: absolute;
+  width: 52px;
+  height: 72px;
+  border-radius: 3px;
+  border: 2px dashed #3a6a3a;
+  background: #163816;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.freecell__slot--freecell {
+  background: #1a3a1a;
+  border-color: #2a5a2a;
+}
+
+.freecell__slot--foundation {
+  background: #163816;
+  border-color: #2a5a2a;
+}
+
+.freecell__suit-hint {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.2);
+  font-family: sans-serif;
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* ── Status bar ───────────────────────────────────────────────────────────────── */
+
+.freecell__statusbar {
   background: #c0c0c0;
-  color: #000;
+  border-top: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 7px;
+  flex-shrink: 0;
+}
+
+/* ── Controls bar ─────────────────────────────────────────────────────────────── */
+
+.freecell__controls {
+  background: #c0c0c0;
+  border-top: 1px solid #808080;
+  padding: 6px 10px 8px;
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────────────── */
+
+.freecell__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  padding: 5px 10px;
   border: 2px solid;
-  border-color: #ffffff #808080 #808080 #ffffff;
-  padding: 3px 6px;
   cursor: pointer;
   white-space: nowrap;
 }
 
-.freecell__portrait-btn:active {
-  border-color: #808080 #ffffff #ffffff #808080;
+.freecell__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
 }
+.freecell__btn--primary:hover  { background: #ee5500; }
+.freecell__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
 
-.freecell__portrait-btn--active {
-  border-color: #808080 #ffffff #ffffff #808080;
-  background: #d4d0c8;
+.freecell__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
 }
-
-/* ── FreeCell Layout ────────────────────────────────────────────────────── */
-
-.freecell {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px;
-  background: #1a4a1a;
-  font-family: "Press Start 2P", monospace;
-  min-height: 400px;
-  user-select: none;
-}
-
-/* ── Top Row (free cells + status + foundations) ────────────────────────── */
-
-.freecell__top-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-}
-
-.freecell__free-cells {
-  display: flex;
-  gap: 4px;
-}
-
-.freecell__foundations {
-  display: flex;
-  gap: 4px;
-}
-
-.freecell__center-status {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 4px 0;
-}
-
-.freecell__moves {
-  font-size: 7px;
-  color: #c0c0c0;
-  white-space: nowrap;
-}
+.freecell__btn--secondary:hover  { background: #d4d0c8; }
+.freecell__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }
 
 .freecell__auto-btn {
   font-family: "Press Start 2P", monospace;
@@ -100,134 +120,14 @@
   color: #000;
   border: 2px solid;
   border-color: #ffffff #808080 #808080 #ffffff;
-  padding: 4px 8px;
+  padding: 3px 8px;
   cursor: pointer;
 }
+.freecell__auto-btn:hover:not(:disabled)  { background: #d4d0c8; }
+.freecell__auto-btn:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
+.freecell__auto-btn:disabled { color: #808080; cursor: default; }
 
-.freecell__auto-btn:hover:not(:disabled) {
-  background: #d4d0c8;
-}
-
-.freecell__auto-btn:active:not(:disabled) {
-  border-color: #808080 #ffffff #ffffff #808080;
-}
-
-.freecell__auto-btn:disabled {
-  color: #808080;
-  cursor: default;
-}
-
-/* ── Cell Slots (free cells + foundations) ──────────────────────────────── */
-
-.freecell__cell-slot {
-  width: 52px;
-  height: 72px;
-  position: relative;
-  cursor: pointer;
-  border-radius: 3px;
-  flex-shrink: 0;
-}
-
-.freecell__cell-slot--selected {
-  outline: 2px solid #cc4400;
-  outline-offset: 1px;
-  border-radius: 3px;
-}
-
-.freecell__cell-slot--valid {
-  outline: 2px solid #44cc44;
-  outline-offset: 1px;
-  border-radius: 3px;
-}
-
-.freecell__cell-slot--foundation {
-  cursor: pointer;
-}
-
-/* ── Empty slot placeholders ────────────────────────────────────────────── */
-
-.freecell__empty-slot {
-  width: 52px;
-  height: 72px;
-  border-radius: 3px;
-  border: 2px dashed #3a6a3a;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.freecell__empty-slot--freecell {
-  background: #1a3a1a;
-  border-color: #2a5a2a;
-}
-
-.freecell__empty-slot--foundation {
-  background: #163816;
-  border-color: #2a5a2a;
-}
-
-.freecell__empty-slot--cascade {
-  background: #163816;
-  border-color: #2a5a2a;
-  width: 100%;
-  height: 72px;
-}
-
-.freecell__suit-hint {
-  font-size: 18px;
-  color: #2a5a2a;
-  line-height: 1;
-}
-
-/* ── Cascades ───────────────────────────────────────────────────────────── */
-
-.freecell__cascades {
-  display: flex;
-  gap: 4px;
-  flex: 1;
-  align-items: flex-start;
-}
-
-.freecell__cascade {
-  flex: 1;
-  position: relative;
-  min-width: 56px;
-  /* height grows with content */
-  min-height: 80px;
-}
-
-.freecell__cascade--valid > .freecell__empty-slot--cascade {
-  border-color: #44cc44;
-  background: #1e4a1e;
-}
-
-/* Highlight the empty-cascade slot itself when valid drop target */
-.freecell__cascade--valid .freecell__empty-slot--cascade {
-  border-color: #44cc44;
-}
-
-/* ── Cascade Cards ──────────────────────────────────────────────────────── */
-
-.freecell__cascade-card {
-  position: absolute;
-  left: 0;
-  cursor: pointer;
-}
-
-.freecell__cascade-card--selected {
-  outline: 2px solid #cc4400;
-  outline-offset: 1px;
-  border-radius: 3px;
-}
-
-/* The topmost card in a selected sequence keeps the orange outline */
-.freecell__cascade-card--seq-start {
-  outline: 2px solid #cc4400;
-  outline-offset: 1px;
-  border-radius: 3px;
-}
-
-/* ── Win Overlay ────────────────────────────────────────────────────────── */
+/* ── Win overlay ──────────────────────────────────────────────────────────────── */
 
 .freecell__win-overlay {
   position: absolute;
@@ -236,8 +136,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
-  border-radius: 2px;
+  z-index: 10000;
 }
 
 .freecell__win-banner {
@@ -248,63 +147,23 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
   text-align: center;
 }
 
 .freecell__win-title {
-  font-family: "Press Start 2P", monospace;
   font-size: 16px;
   color: #228833;
   text-shadow: 1px 1px 0 #000;
 }
 
 .freecell__win-moves {
-  font-family: "Press Start 2P", monospace;
   font-size: 8px;
   color: #333;
 }
 
 .freecell__win-btns {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   margin-top: 4px;
-}
-
-/* ── Buttons ────────────────────────────────────────────────────────────── */
-
-.freecell__btn {
-  font-family: "Press Start 2P", monospace;
-  font-size: 8px;
-  padding: 8px 16px;
-  border: 2px solid;
-  cursor: pointer;
-}
-
-.freecell__btn--primary {
-  background: #cc4400;
-  color: #fff;
-  border-color: #ffcc88 #664400 #664400 #ffcc88;
-}
-
-.freecell__btn--primary:hover {
-  background: #ee5500;
-}
-
-.freecell__btn--primary:active {
-  border-color: #664400 #ffcc88 #ffcc88 #664400;
-}
-
-.freecell__btn--secondary {
-  background: #c0c0c0;
-  color: #000;
-  border-color: #ffffff #808080 #808080 #ffffff;
-}
-
-.freecell__btn--secondary:hover {
-  background: #d4d0c8;
-}
-
-.freecell__btn--secondary:active {
-  border-color: #808080 #ffffff #ffffff #808080;
 }

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -178,46 +178,61 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
     }
   }
 
-  function applyAutoMoves(g: FCGame): FCGame {
-    let changed = true, s = g;
-    while (changed) {
-      changed = false;
-      for (let i = 0; i < 4; i++) {
-        const c = s.freeCells[i]; if (!c) continue;
-        const fi = SUITS.indexOf(c.suit as Suit);
-        if (fi >= 0 && canFound(c, s.foundations[fi]) && isSafeAuto(c, s.foundations)) {
-          s = { ...s,
-            foundations: s.foundations.map((f,j) => j===fi ? [...f,c] : f),
-            freeCells: s.freeCells.map((fc,j): Card|null => j===i ? null : fc),
-          };
-          changed = true;
-        }
-      }
-      for (let col = 0; col < 8; col++) {
-        if (s.cascades[col].length === 0) continue;
-        const c = s.cascades[col][s.cascades[col].length - 1];
-        const fi = SUITS.indexOf(c.suit as Suit);
-        if (fi >= 0 && canFound(c, s.foundations[fi]) && isSafeAuto(c, s.foundations)) {
-          s = { ...s,
-            foundations: s.foundations.map((f,j) => j===fi ? [...f,c] : f),
-            cascades: s.cascades.map((col2,j) => j===col ? col2.slice(0,-1) : col2),
-          };
-          changed = true;
-        }
+  function findAutoMove(g: FCGame): {
+    card: Card; fi: number; fromKind: "freecell"|"cascade"; fromIdx: number; newG: FCGame;
+  } | null {
+    for (let i = 0; i < 4; i++) {
+      const c = g.freeCells[i]; if (!c) continue;
+      const fi = SUITS.indexOf(c.suit as Suit);
+      if (fi >= 0 && canFound(c, g.foundations[fi]) && isSafeAuto(c, g.foundations)) {
+        return { card:c, fi, fromKind:"freecell", fromIdx:i,
+          newG: { ...g, freeCells:g.freeCells.map((fc,j):Card|null => j===i ? null : fc),
+                        foundations:g.foundations.map((f,j) => j===fi ? [...f,c] : f) } };
       }
     }
-    return s;
+    for (let col = 0; col < 8; col++) {
+      if (g.cascades[col].length === 0) continue;
+      const c = g.cascades[col][g.cascades[col].length - 1];
+      const fi = SUITS.indexOf(c.suit as Suit);
+      if (fi >= 0 && canFound(c, g.foundations[fi]) && isSafeAuto(c, g.foundations)) {
+        return { card:c, fi, fromKind:"cascade", fromIdx:col,
+          newG: { ...g, cascades:g.cascades.map((col2,j) => j===col ? col2.slice(0,-1) : col2),
+                        foundations:g.foundations.map((f,j) => j===fi ? [...f,c] : f) } };
+      }
+    }
+    return null;
+  }
+
+  function animateAutoMoves(g: FCGame, onDone: (finalG: FCGame) => void): void {
+    const move = findAutoMove(g);
+    if (!move) { onDone(g); return; }
+    const { card, fi, fromKind, fromIdx, newG } = move;
+    setCardStates(prev => ({
+      ...prev,
+      [card.id]: { ...prev[card.id], x:COL_X[4+fi], y:TOP_Y, z:ANIM_Z+1, transitionMs:200, transitionDelay:0 },
+    }));
+    after(300, () => {
+      if (fromKind === "freecell") fcSt.current[fromIdx].clear();
+      else cascSt.current[fromIdx].removeTop();
+      foundSt.current[fi].addCard(card, { toTop:true, faceDown:false });
+      setCardStates(allLayouts(0));
+      animateAutoMoves(newG, onDone);
+    });
   }
 
   function completeMove(newG: FCGame): void {
-    const withAuto = applyAutoMoves(newG);
-    syncStacks(withAuto);
-    gameRef.current = withAuto;
-    setGame(withAuto);
+    syncStacks(newG);
+    gameRef.current = newG;
+    setGame(newG);
     setCardStates(allLayouts(0));
     setMoves(m => m + 1);
-    isAnim.current = false;
-    setPhase(withAuto.foundations.every(f => f.length === 13) ? "won" : "playing");
+    animateAutoMoves(newG, (finalG) => {
+      gameRef.current = finalG;
+      setGame(finalG);
+      setCardStates(allLayouts(0));
+      isAnim.current = false;
+      setPhase(finalG.foundations.every(f => f.length === 13) ? "won" : "playing");
+    });
   }
 
   // Scale to fit container
@@ -465,12 +480,15 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
 
   const handleAutoMove = useCallback(() => {
     if (isAnim.current || phase !== "playing") return;
-    const g = applyAutoMoves(gameRef.current);
-    syncStacks(g);
-    gameRef.current = g;
-    setGame(g);
-    setCardStates(allLayouts(0));
-    setPhase(g.foundations.every(f => f.length === 13) ? "won" : "playing");
+    isAnim.current = true;
+    setPhase("animating");
+    animateAutoMoves(gameRef.current, (finalG) => {
+      gameRef.current = finalG;
+      setGame(finalG);
+      setCardStates(allLayouts(0));
+      isAnim.current = false;
+      setPhase(finalG.foundations.every(f => f.length === 13) ? "won" : "playing");
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase]);
 

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -1,0 +1,693 @@
+import { useState, useCallback, useMemo } from "react";
+import "./Cards.css";
+import "./FreeCell.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
+import { shuffle } from "./deckUtils";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { DeckModal } from "./DeckModal";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"] as const;
+const ALL_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+const FOUNDATION_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+
+const RANK_VAL: Record<string, number> = {
+  A: 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7,
+  "8": 8, "9": 9, "10": 10, J: 11, Q: 12, K: 13,
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface FreeCellSelection {
+  from: "cascade" | "freecell";
+  colIndex: number;
+  cardIndex: number; // index in cascade where sequence starts (0 = bottommost = topmost visible)
+  cards: Card[];
+}
+
+interface FreeCellState {
+  cascades: Card[][];
+  freeCells: (Card | null)[];
+  foundations: Card[][];
+  selected: FreeCellSelection | null;
+  moves: number;
+  phase: "playing" | "won";
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildFreeCellDeck(): Card[] {
+  const cards: Card[] = [];
+  for (const suit of ALL_SUITS) {
+    for (const rank of RANKS) {
+      cards.push({ suit, rank, id: `${suit}-${rank}` });
+    }
+  }
+  return shuffle(cards);
+}
+
+function isRed(suit: string): boolean {
+  return suit === "hearts" || suit === "diamonds";
+}
+
+function isBlack(suit: string): boolean {
+  return suit === "spades" || suit === "clubs";
+}
+
+function oppositeColor(a: string, b: string): boolean {
+  return (isRed(a) && isBlack(b)) || (isBlack(a) && isRed(b));
+}
+
+/** Can card `top` be placed on `base` in the tableau? */
+function canStackOnCascade(top: Card, base: Card): boolean {
+  if (top.suit === "joker" || base.suit === "joker") return false;
+  return (
+    oppositeColor(top.suit, base.suit) &&
+    RANK_VAL[top.rank] === RANK_VAL[base.rank] - 1
+  );
+}
+
+/** Can card be placed on foundation? */
+function canPlaceOnFoundation(card: Card, foundation: Card[]): boolean {
+  if (card.suit === "joker") return false;
+  if (foundation.length === 0) return RANK_VAL[card.rank] === 1;
+  const top = foundation[foundation.length - 1];
+  return top.suit === card.suit && RANK_VAL[card.rank] === RANK_VAL[top.rank] + 1;
+}
+
+/** Check if a sequence of cards forms a valid alternating-color descending run */
+function isValidSequence(cards: Card[]): boolean {
+  for (let i = 0; i < cards.length - 1; i++) {
+    if (!canStackOnCascade(cards[i + 1], cards[i])) return false;
+  }
+  return true;
+}
+
+/** Supermove: max cards that can be moved */
+function maxMovableCards(freeCells: (Card | null)[], cascades: Card[][], excludeColIndex: number): number {
+  const emptyFreeCells = freeCells.filter((c) => c === null).length;
+  const emptyCascades = cascades.filter((col, i) => i !== excludeColIndex && col.length === 0).length;
+  return (emptyFreeCells + 1) * Math.pow(2, emptyCascades);
+}
+
+function makeInitialState(): FreeCellState {
+  const deck = buildFreeCellDeck();
+  const cascades: Card[][] = Array.from({ length: 8 }, () => []);
+  // Deal: columns 0–3 get 7 cards, columns 4–7 get 6 cards
+  let idx = 0;
+  for (let col = 0; col < 8; col++) {
+    const count = col < 4 ? 7 : 6;
+    for (let i = 0; i < count; i++) {
+      cascades[col].push(deck[idx++]);
+    }
+  }
+  return {
+    cascades,
+    freeCells: [null, null, null, null],
+    foundations: [[], [], [], []],
+    selected: null,
+    moves: 0,
+    phase: "playing",
+  };
+}
+
+function checkWin(state: FreeCellState): boolean {
+  return state.foundations.every((f) => f.length === 13);
+}
+
+// ── Auto-move logic ───────────────────────────────────────────────────────────
+
+/**
+ * Return true if moving `card` to foundation is "safe" —
+ * i.e. no card that could be built on it is still in play at a lower foundation level.
+ */
+function isSafeToAutoMove(card: Card, foundations: Card[][]): boolean {
+  if (card.suit === "joker") return false;
+  const cardVal = RANK_VAL[card.rank];
+  if (cardVal <= 2) return true;
+  // Safe if both colors of the rank below are already on foundations
+  const needVal = cardVal - 1;
+  for (const suit of FOUNDATION_SUITS) {
+    const foundIdx = FOUNDATION_SUITS.indexOf(suit);
+    const f = foundations[foundIdx];
+    const topVal = f.length > 0 ? RANK_VAL[f[f.length - 1].rank] : 0;
+    if (isRed(card.suit) !== isRed(suit) && topVal < needVal) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function autoMoveToFoundation(state: FreeCellState): FreeCellState {
+  let changed = true;
+  let s = { ...state };
+  while (changed) {
+    changed = false;
+    // Check free cells
+    for (let i = 0; i < 4; i++) {
+      const card = s.freeCells[i];
+      if (!card) continue;
+      const foundIdx = FOUNDATION_SUITS.indexOf(card.suit as Suit);
+      if (foundIdx >= 0 && canPlaceOnFoundation(card, s.foundations[foundIdx]) && isSafeToAutoMove(card, s.foundations)) {
+        const newFounds = s.foundations.map((f, fi) => fi === foundIdx ? [...f, card] : f);
+        const newFreeCells = s.freeCells.map((c, ci) => ci === i ? null : c);
+        s = { ...s, foundations: newFounds, freeCells: newFreeCells, moves: s.moves + 1 };
+        changed = true;
+      }
+    }
+    // Check cascade tops
+    for (let col = 0; col < 8; col++) {
+      if (s.cascades[col].length === 0) continue;
+      const card = s.cascades[col][s.cascades[col].length - 1];
+      const foundIdx = FOUNDATION_SUITS.indexOf(card.suit as Suit);
+      if (foundIdx >= 0 && canPlaceOnFoundation(card, s.foundations[foundIdx]) && isSafeToAutoMove(card, s.foundations)) {
+        const newFounds = s.foundations.map((f, fi) => fi === foundIdx ? [...f, card] : f);
+        const newCascades = s.cascades.map((col2, ci) => ci === col ? col2.slice(0, col2.length - 1) : col2);
+        s = { ...s, foundations: newFounds, cascades: newCascades, moves: s.moves + 1 };
+        changed = true;
+      }
+    }
+  }
+  return s;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface FreeCellProps {
+  settings: DeckSettings;
+  onNewGame?: () => void;
+  onQuit?: () => void;
+}
+
+export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps) {
+  const [state, setState] = useState<FreeCellState>(() => makeInitialState());
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [showDeckModal, setShowDeckModal] = useState(false);
+
+  // ── Game actions ──────────────────────────────────────────────────────────
+
+  const restart = useCallback(() => {
+    setState(makeInitialState());
+  }, []);
+
+  const handleAutoMove = useCallback(() => {
+    setState((s) => {
+      if (s.phase === "won") return s;
+      const next = autoMoveToFoundation(s);
+      const won = checkWin(next);
+      return { ...next, phase: won ? "won" : "playing" };
+    });
+  }, []);
+
+  // ── Selection & move logic ────────────────────────────────────────────────
+
+  const handleFreeCellClick = useCallback((cellIdx: number) => {
+    setState((s) => {
+      if (s.phase === "won") return s;
+      const cellCard = s.freeCells[cellIdx];
+
+      // If something is selected, try to move it here
+      if (s.selected) {
+        // Can only move single card to free cell from cascade
+        if (s.selected.cards.length === 1) {
+          const movingCard = s.selected.cards[0];
+
+          // Move to empty free cell
+          if (cellCard === null && s.selected.from === "cascade") {
+            const newFreeCells = s.freeCells.map((c, i) => i === cellIdx ? movingCard : c);
+            const newCascades = s.cascades.map((col, i) =>
+              i === s.selected!.colIndex ? col.slice(0, s.selected!.cardIndex) : col
+            );
+            const next: FreeCellState = {
+              ...s,
+              freeCells: newFreeCells,
+              cascades: newCascades,
+              selected: null,
+              moves: s.moves + 1,
+            };
+            return autoMoveToFoundation(next);
+          }
+
+          // Move from free cell to free cell (if destination empty)
+          if (cellCard === null && s.selected.from === "freecell") {
+            if (cellIdx === s.selected.colIndex) {
+              return { ...s, selected: null };
+            }
+            const newFreeCells = s.freeCells.map((c, i) => {
+              if (i === cellIdx) return movingCard;
+              if (i === s.selected!.colIndex) return null;
+              return c;
+            });
+            const next: FreeCellState = {
+              ...s,
+              freeCells: newFreeCells,
+              selected: null,
+              moves: s.moves + 1,
+            };
+            return autoMoveToFoundation(next);
+          }
+        }
+
+        // Click same free cell card — deselect
+        if (s.selected.from === "freecell" && s.selected.colIndex === cellIdx) {
+          return { ...s, selected: null };
+        }
+
+        // Try selecting the free cell card instead
+        if (cellCard) {
+          return {
+            ...s,
+            selected: {
+              from: "freecell",
+              colIndex: cellIdx,
+              cardIndex: 0,
+              cards: [cellCard],
+            },
+          };
+        }
+
+        return { ...s, selected: null };
+      }
+
+      // No selection — select the free cell card
+      if (cellCard) {
+        return {
+          ...s,
+          selected: {
+            from: "freecell",
+            colIndex: cellIdx,
+            cardIndex: 0,
+            cards: [cellCard],
+          },
+        };
+      }
+
+      return s;
+    });
+  }, []);
+
+  const handleFoundationClick = useCallback((foundIdx: number) => {
+    setState((s) => {
+      if (s.phase === "won") return s;
+      if (!s.selected || s.selected.cards.length !== 1) return s;
+
+      const movingCard = s.selected.cards[0];
+      if (!canPlaceOnFoundation(movingCard, s.foundations[foundIdx])) {
+        return { ...s, selected: null };
+      }
+
+      const newFounds = s.foundations.map((f, fi) =>
+        fi === foundIdx ? [...f, movingCard] : f
+      );
+
+      let newCascades = s.cascades;
+      let newFreeCells = s.freeCells;
+
+      if (s.selected.from === "cascade") {
+        newCascades = s.cascades.map((col, i) =>
+          i === s.selected!.colIndex ? col.slice(0, s.selected!.cardIndex) : col
+        );
+      } else {
+        newFreeCells = s.freeCells.map((c, i) =>
+          i === s.selected!.colIndex ? null : c
+        );
+      }
+
+      const next: FreeCellState = {
+        ...s,
+        foundations: newFounds,
+        cascades: newCascades,
+        freeCells: newFreeCells,
+        selected: null,
+        moves: s.moves + 1,
+      };
+      const afterAuto = autoMoveToFoundation(next);
+      const won = checkWin(afterAuto);
+      return { ...afterAuto, phase: won ? "won" : "playing" };
+    });
+  }, []);
+
+  const handleCascadeClick = useCallback((colIndex: number, cardIdx: number) => {
+    setState((s) => {
+      if (s.phase === "won") return s;
+      const col = s.cascades[colIndex];
+
+      // If nothing selected, try to select from this cascade
+      if (!s.selected) {
+        if (col.length === 0) return s;
+        // cardIdx is the index in the array (last = top of pile)
+        const seq = col.slice(cardIdx);
+        if (!isValidSequence(seq)) return s;
+        return {
+          ...s,
+          selected: {
+            from: "cascade",
+            colIndex,
+            cardIndex: cardIdx,
+            cards: seq,
+          },
+        };
+      }
+
+      // Something is selected — try to move it here
+      const { selected } = s;
+
+      // Click same card to deselect
+      if (
+        selected.from === "cascade" &&
+        selected.colIndex === colIndex &&
+        selected.cardIndex === cardIdx
+      ) {
+        return { ...s, selected: null };
+      }
+
+      const movingCards = selected.cards;
+      const movingTop = movingCards[0]; // first card = top of sequence (placed last)
+
+      // Can we place here?
+      let canPlace = false;
+      if (col.length === 0) {
+        canPlace = true;
+      } else {
+        const destTop = col[col.length - 1];
+        canPlace = canStackOnCascade(movingTop, destTop);
+      }
+
+      if (!canPlace) {
+        // Try to change selection to the clicked column
+        if (col.length > 0 && cardIdx < col.length) {
+          const seq = col.slice(cardIdx);
+          if (isValidSequence(seq)) {
+            return {
+              ...s,
+              selected: {
+                from: "cascade",
+                colIndex,
+                cardIndex: cardIdx,
+                cards: seq,
+              },
+            };
+          }
+        }
+        return { ...s, selected: null };
+      }
+
+      // Check supermove limit
+      const maxMove = maxMovableCards(s.freeCells, s.cascades, colIndex);
+      if (movingCards.length > maxMove) {
+        return { ...s, selected: null };
+      }
+
+      // Perform the move
+      const newCascades = s.cascades.map((c, i) => {
+        if (i === colIndex) return [...c, ...movingCards];
+        if (selected.from === "cascade" && i === selected.colIndex) {
+          return c.slice(0, selected.cardIndex);
+        }
+        return c;
+      });
+
+      let newFreeCells = s.freeCells;
+      if (selected.from === "freecell") {
+        newFreeCells = s.freeCells.map((c, i) =>
+          i === selected.colIndex ? null : c
+        );
+      }
+
+      const next: FreeCellState = {
+        ...s,
+        cascades: newCascades,
+        freeCells: newFreeCells,
+        selected: null,
+        moves: s.moves + 1,
+      };
+      const afterAuto = autoMoveToFoundation(next);
+      const won = checkWin(afterAuto);
+      return { ...afterAuto, phase: won ? "won" : "playing" };
+    });
+  }, []);
+
+  const handleEmptyCascadeClick = useCallback((colIndex: number) => {
+    setState((s) => {
+      if (s.phase === "won") return s;
+      if (!s.selected) return s;
+
+      const { selected } = s;
+      const movingCards = selected.cards;
+
+      const maxMove = maxMovableCards(s.freeCells, s.cascades, colIndex);
+      if (movingCards.length > maxMove) {
+        return { ...s, selected: null };
+      }
+
+      const newCascades = s.cascades.map((col, i) => {
+        if (i === colIndex) return [...col, ...movingCards];
+        if (selected.from === "cascade" && i === selected.colIndex) {
+          return col.slice(0, selected.cardIndex);
+        }
+        return col;
+      });
+
+      let newFreeCells = s.freeCells;
+      if (selected.from === "freecell") {
+        newFreeCells = s.freeCells.map((c, i) =>
+          i === selected.colIndex ? null : c
+        );
+      }
+
+      const next: FreeCellState = {
+        ...s,
+        cascades: newCascades,
+        freeCells: newFreeCells,
+        selected: null,
+        moves: s.moves + 1,
+      };
+      const afterAuto = autoMoveToFoundation(next);
+      const won = checkWin(afterAuto);
+      return { ...afterAuto, phase: won ? "won" : "playing" };
+    });
+  }, []);
+
+  // ── Computed highlight state ──────────────────────────────────────────────
+
+  const validDestinations = useMemo(() => {
+    if (!state.selected) return null;
+    const sel = state.selected;
+    const movingCards = sel.cards;
+    const movingTop = movingCards[0];
+
+    const maxMove = maxMovableCards(state.freeCells, state.cascades, sel.from === "cascade" ? sel.colIndex : -1);
+
+    const cascadeValid: boolean[] = state.cascades.map((col, i) => {
+      if (sel.from === "cascade" && i === sel.colIndex) return false;
+      if (movingCards.length > maxMove) return false;
+      if (col.length === 0) return true;
+      const destTop = col[col.length - 1];
+      return canStackOnCascade(movingTop, destTop);
+    });
+
+    const freeCellValid: boolean[] = state.freeCells.map((c, i) => {
+      if (sel.from === "freecell" && i === sel.colIndex) return false;
+      return c === null && movingCards.length === 1;
+    });
+
+    const foundationValid: boolean[] = state.foundations.map((f, fi) => {
+      return movingCards.length === 1 && canPlaceOnFoundation(movingTop, f) &&
+        FOUNDATION_SUITS[fi] === movingTop.suit;
+    });
+
+    return { cascadeValid, freeCellValid, foundationValid };
+  }, [state]);
+
+  // ── Menus ─────────────────────────────────────────────────────────────────
+
+  const menus = useMemo<MenuBarMenu[]>(() => {
+    const gameItems: MenuBarMenu["items"] = [
+      { label: "Restart", onClick: restart },
+      ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
+      ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+    ];
+    return [
+      { label: "Game", items: gameItems },
+      {
+        label: "Options",
+        items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }],
+      },
+    ];
+  }, [restart, onNewGame, onQuit]);
+
+  useWindowMenus(menus);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const { cascades, freeCells, foundations, selected, moves, phase } = state;
+
+  const SUIT_SYMBOL: Record<string, string> = {
+    spades: "♠",
+    hearts: "♥",
+    diamonds: "♦",
+    clubs: "♣",
+  };
+
+  return (
+    <div className="freecell">
+      {showDeckModal && (
+        <DeckModal
+          appearance={appearance}
+          onUpdate={setAppearance}
+          onClose={() => setShowDeckModal(false)}
+        />
+      )}
+
+      {/* Top area: free cells + foundations */}
+      <div className="freecell__top-row">
+        {/* Free cells */}
+        <div className="freecell__free-cells">
+          {freeCells.map((card, i) => {
+            const isSelected = selected?.from === "freecell" && selected.colIndex === i;
+            const isValid = validDestinations?.freeCellValid[i] ?? false;
+            return (
+              <div
+                key={i}
+                className={
+                  "freecell__cell-slot" +
+                  (isSelected ? " freecell__cell-slot--selected" : "") +
+                  (isValid ? " freecell__cell-slot--valid" : "")
+                }
+                onClick={() => handleFreeCellClick(i)}
+                title="Free Cell"
+              >
+                {card ? (
+                  <PlayingCard card={card} appearance={appearance} size="sm" />
+                ) : (
+                  <div className="freecell__empty-slot freecell__empty-slot--freecell" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Spacer / status */}
+        <div className="freecell__center-status">
+          <div className="freecell__moves">Moves: {moves}</div>
+          <button
+            className="freecell__auto-btn"
+            onClick={handleAutoMove}
+            disabled={phase === "won"}
+            title="Auto-move safe cards to foundations"
+          >
+            Auto
+          </button>
+        </div>
+
+        {/* Foundations */}
+        <div className="freecell__foundations">
+          {FOUNDATION_SUITS.map((suit, i) => {
+            const pile = foundations[i];
+            const topCard = pile.length > 0 ? pile[pile.length - 1] : null;
+            const isValid = validDestinations?.foundationValid[i] ?? false;
+            return (
+              <div
+                key={suit}
+                className={
+                  "freecell__cell-slot freecell__cell-slot--foundation" +
+                  (isValid ? " freecell__cell-slot--valid" : "")
+                }
+                onClick={() => handleFoundationClick(i)}
+                title={`${suit} foundation`}
+              >
+                {topCard ? (
+                  <PlayingCard card={topCard} appearance={appearance} size="sm" />
+                ) : (
+                  <div className="freecell__empty-slot freecell__empty-slot--foundation">
+                    <span className="freecell__suit-hint">{SUIT_SYMBOL[suit]}</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Cascade area */}
+      <div className="freecell__cascades">
+        {cascades.map((col, colIdx) => {
+          const isCascadeValid = validDestinations?.cascadeValid[colIdx] ?? false;
+          // Height: (n-1) slivers * 22px + full card height 72px; or 72 if empty
+          const colHeight = col.length === 0 ? 72 : (col.length - 1) * 22 + 72;
+          return (
+            <div
+              key={colIdx}
+              className={
+                "freecell__cascade" +
+                (isCascadeValid ? " freecell__cascade--valid" : "")
+              }
+              style={{ height: colHeight }}
+              onClick={col.length === 0 ? () => handleEmptyCascadeClick(colIdx) : undefined}
+            >
+              {col.length === 0 ? (
+                <div className="freecell__empty-slot freecell__empty-slot--cascade" />
+              ) : (
+                col.map((card, cardIdx) => {
+                  const isSeqStart = selected?.from === "cascade" &&
+                    selected.colIndex === colIdx &&
+                    selected.cardIndex === cardIdx;
+                  const isInSelected = selected?.from === "cascade" &&
+                    selected.colIndex === colIdx &&
+                    cardIdx >= selected.cardIndex;
+                  const isTop = cardIdx === col.length - 1;
+                  const offsetY = cardIdx * 22;
+
+                  return (
+                    <div
+                      key={card.id}
+                      className={
+                        "freecell__cascade-card" +
+                        (isInSelected ? " freecell__cascade-card--selected" : "") +
+                        (isSeqStart ? " freecell__cascade-card--seq-start" : "")
+                      }
+                      style={{
+                        top: `${offsetY}px`,
+                        zIndex: cardIdx + 1,
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCascadeClick(colIdx, cardIdx);
+                      }}
+                      title={isTop ? `${card.rank} of ${card.suit}` : undefined}
+                    >
+                      <PlayingCard card={card} appearance={appearance} size="sm" />
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Win banner */}
+      {phase === "won" && (
+        <div className="freecell__win-overlay">
+          <div className="freecell__win-banner">
+            <div className="freecell__win-title">You Win!</div>
+            <div className="freecell__win-moves">Completed in {moves} moves</div>
+            <div className="freecell__win-btns">
+              <button className="freecell__btn freecell__btn--primary" onClick={restart}>
+                Play Again
+              </button>
+              {onNewGame && (
+                <button className="freecell__btn freecell__btn--secondary" onClick={onNewGame}>
+                  New Game
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -31,6 +31,7 @@ const COL_X = (() => {
 const CARD_W = 52;
 const CARD_H = 72;
 
+const FC_SAVE_KEY = "cards-fc-save";
 const SUIT_SYMBOL: Record<string, string> = { spades:"♠", hearts:"♥", diamonds:"♦", clubs:"♣" };
 const FOUNDATION_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
 
@@ -246,6 +247,32 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
     return () => obs.disconnect();
   }, []);
 
+  // Save game state after every move (not during the deal animation)
+  useEffect(() => {
+    if (allCards.length === 0 || phase === "dealing") return;
+    try { localStorage.setItem(FC_SAVE_KEY, JSON.stringify({ version: 1, game, moves })); } catch {}
+  }, [game, moves, phase, allCards.length]);
+
+  // ── restoreGame ───────────────────────────────────────────────────────────────
+
+  function restoreGame(savedGame: FCGame, savedMoves: number): void {
+    clearTimers();
+    isAnim.current = false;
+    setSelected(null);
+    setMoves(savedMoves);
+    const allC: Card[] = [
+      ...savedGame.cascades.flat(),
+      ...savedGame.freeCells.filter((c): c is Card => c !== null),
+      ...savedGame.foundations.flat(),
+    ];
+    syncStacks(savedGame);
+    gameRef.current = savedGame;
+    setAllCards(allC);
+    setGame(savedGame);
+    setCardStates(allLayouts(0));
+    setPhase(savedGame.foundations.every(f => f.length === 13) ? "won" : "playing");
+  }
+
   // ── startGame ────────────────────────────────────────────────────────────────
 
   const startGame = useCallback(() => {
@@ -254,6 +281,7 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
     setSelected(null);
     setMoves(0);
     setPhase("dealing");
+    try { localStorage.removeItem(FC_SAVE_KEY); } catch {}
 
     const deck: Card[] = [];
     for (const suit of SUITS) for (const rank of RANKS) deck.push({ suit, rank, id:`${suit}-${rank}` });
@@ -302,7 +330,21 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings, clearTimers]);
 
-  useEffect(() => { startGame(); return clearTimers; }, []); // eslint-disable-line
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(FC_SAVE_KEY);
+      if (raw) {
+        const saved = JSON.parse(raw) as { version: number; game: FCGame; moves: number };
+        if (saved.version === 1 && saved.game && Array.isArray(saved.game.cascades)) {
+          restoreGame(saved.game, saved.moves ?? 0);
+          return clearTimers;
+        }
+      }
+    } catch {}
+    startGame();
+    return clearTimers;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ── Move executors ────────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -269,8 +269,38 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
     gameRef.current = savedGame;
     setAllCards(allC);
     setGame(savedGame);
-    setCardStates(allLayouts(0));
-    setPhase(savedGame.foundations.every(f => f.length === 13) ? "won" : "playing");
+
+    // Deal animation: cards start off-screen top, stagger into position
+    const initStates: Record<string, CardVisualState> = {};
+    for (const c of allC) {
+      initStates[c.id] = { x: STAGE_W / 2, y: -80, z: 100, rotation: 0, faceDown: false, transitionMs: 0 };
+    }
+    setCardStates(initStates);
+    setPhase("dealing");
+
+    const DEAL_MS = 240;
+    const finalLayout = allLayouts(DEAL_MS);
+    for (let col = 0; col < 8; col++) {
+      cascSt.current[col].cards.forEach((c, i) => {
+        if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: (col + i) * 28 };
+      });
+    }
+    for (let i = 0; i < 4; i++) {
+      fcSt.current[i].cards.forEach((c, j) => {
+        if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: (8 + i + j) * 28 };
+      });
+      foundSt.current[i].cards.forEach((c, j) => {
+        if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: (12 + i + j) * 28 };
+      });
+    }
+
+    after(80, () => {
+      setCardStates(finalLayout);
+      after(DEAL_MS + 14 * 28 + 150, () => {
+        setCardStates(allLayouts(0));
+        setPhase(savedGame.foundations.every(f => f.length === 13) ? "won" : "playing");
+      });
+    });
   }
 
   // ── startGame ────────────────────────────────────────────────────────────────

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./FreeCell.css";
 import { PermCard } from "./PermCard";

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -1,791 +1,611 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./FreeCell.css";
-import { PlayingCard } from "./PlayingCard";
+import { PermCard } from "./PermCard";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
 import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
 import { shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
-// ── Constants ─────────────────────────────────────────────────────────────────
+// ── Layout ────────────────────────────────────────────────────────────────────
 
-const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"] as const;
-const ALL_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+const STAGE_W  = 520;
+const STAGE_H  = 540;
+const TOP_Y    = 50;
+const CASC_Y   = 152;
+const FAN_STEP = 22;
+const ANIM_Z   = 9000;
+const ANIM_MS  = 180;
+const STEP_MS  = 220;
+
+// 8 evenly-spaced column centers for sm cards (52px wide) with 8px gaps
+const COL_X = (() => {
+  const gw = 8 * 52 + 7 * 8;
+  const sx = (STAGE_W - gw) / 2 + 26;
+  return Array.from({ length: 8 }, (_, i) => sx + i * 60);
+})();
+
+const CARD_W = 52;
+const CARD_H = 72;
+
+const SUIT_SYMBOL: Record<string, string> = { spades:"♠", hearts:"♥", diamonds:"♦", clubs:"♣" };
 const FOUNDATION_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
 
-const RANK_VAL: Record<string, number> = {
-  A: 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7,
-  "8": 8, "9": 9, "10": 10, J: 11, Q: 12, K: 13,
+// ── Game helpers ──────────────────────────────────────────────────────────────
+
+const RANKS = ["A","2","3","4","5","6","7","8","9","10","J","Q","K"] as const;
+const SUITS: Suit[] = ["spades","hearts","diamonds","clubs"];
+const RV: Record<string, number> = {
+  A:1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,J:11,Q:12,K:13,
 };
+
+function isRed(s: string) { return s === "hearts" || s === "diamonds"; }
+function canStack(top: Card, base: Card): boolean {
+  return isRed(top.suit) !== isRed(base.suit) && RV[top.rank] === RV[base.rank] - 1;
+}
+function canFound(c: Card, pile: Card[]): boolean {
+  if (pile.length === 0) return RV[c.rank] === 1;
+  const t = pile[pile.length - 1];
+  return t.suit === c.suit && RV[c.rank] === RV[t.rank] + 1;
+}
+function isValidSeq(cards: Card[]): boolean {
+  for (let i = 0; i < cards.length - 1; i++) if (!canStack(cards[i + 1], cards[i])) return false;
+  return true;
+}
+function maxMovable(fcs: (Card|null)[], cols: Card[][], excl: number): number {
+  const ef = fcs.filter(c => c === null).length;
+  const ec = cols.filter((c, i) => i !== excl && c.length === 0).length;
+  return (ef + 1) * Math.pow(2, ec);
+}
+function isSafeAuto(card: Card, foundations: Card[][]): boolean {
+  const v = RV[card.rank];
+  if (v <= 2) return true;
+  const need = v - 1;
+  const opp = isRed(card.suit) ? SUITS.filter(s => !isRed(s)) : SUITS.filter(s => isRed(s));
+  return opp.every(s => {
+    const fi = SUITS.indexOf(s);
+    const top = foundations[fi].length > 0 ? RV[foundations[fi][foundations[fi].length - 1].rank] : 0;
+    return top >= need;
+  });
+}
+
+// ── Animation step planner ────────────────────────────────────────────────────
+// seq: bottom-to-top (seq[0] placed on destination first, last card placed last).
+// Routes multi-card moves visibly through free cells and empty columns.
+
+interface AnimStep { cardId: string; x: number; y: number; z: number; }
+
+function planSteps(
+  seq: Card[],
+  dx: number, dy: number, dc: number,
+  afc: Array<{x:number;y:number}>,
+  acc: Array<{x:number;y:number}>,
+  out: AnimStep[]
+): void {
+  const n = seq.length;
+  if (n === 0) return;
+  if (n === 1) { out.push({ cardId:seq[0].id, x:dx, y:dy+dc*FAN_STEP, z:ANIM_Z }); return; }
+  if (afc.length >= n - 1) {
+    for (let i = n - 1; i >= 1; i--)
+      out.push({ cardId:seq[i].id, x:afc[n-1-i].x, y:afc[n-1-i].y, z:ANIM_Z+i });
+    out.push({ cardId:seq[0].id, x:dx, y:dy+dc*FAN_STEP, z:ANIM_Z });
+    for (let i = 1; i < n; i++)
+      out.push({ cardId:seq[i].id, x:dx, y:dy+(dc+i)*FAN_STEP, z:ANIM_Z+(n-i) });
+    return;
+  }
+  if (acc.length === 0) return;
+  const tmp = acc[0], rem = acc.slice(1);
+  const split = Math.ceil(n / 2);
+  planSteps(seq.slice(n - split), tmp.x, tmp.y, 0, afc, rem, out);
+  planSteps(seq.slice(0, n - split), dx, dy, dc, afc, rem, out);
+  planSteps(seq.slice(n - split), dx, dy, dc + (n - split), afc, rem, out);
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-interface FreeCellSelection {
-  from: "cascade" | "freecell";
-  colIndex: number;
-  cardIndex: number; // index in cascade where sequence starts (0 = bottommost = topmost visible)
-  cards: Card[];
-}
-
-interface FreeCellState {
-  cascades: Card[][];
-  freeCells: (Card | null)[];
+interface FCGame {
+  cascades:    Card[][];
+  freeCells:   (Card|null)[];
   foundations: Card[][];
-  selected: FreeCellSelection | null;
-  moves: number;
-  phase: "playing" | "won";
 }
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function buildFreeCellDeck(): Card[] {
-  const cards: Card[] = [];
-  for (const suit of ALL_SUITS) {
-    for (const rank of RANKS) {
-      cards.push({ suit, rank, id: `${suit}-${rank}` });
-    }
-  }
-  return shuffle(cards);
-}
-
-function isRed(suit: string): boolean {
-  return suit === "hearts" || suit === "diamonds";
-}
-
-function isBlack(suit: string): boolean {
-  return suit === "spades" || suit === "clubs";
-}
-
-function oppositeColor(a: string, b: string): boolean {
-  return (isRed(a) && isBlack(b)) || (isBlack(a) && isRed(b));
-}
-
-/** Can card `top` be placed on `base` in the tableau? */
-function canStackOnCascade(top: Card, base: Card): boolean {
-  if (top.suit === "joker" || base.suit === "joker") return false;
-  return (
-    oppositeColor(top.suit, base.suit) &&
-    RANK_VAL[top.rank] === RANK_VAL[base.rank] - 1
-  );
-}
-
-/** Can card be placed on foundation? */
-function canPlaceOnFoundation(card: Card, foundation: Card[]): boolean {
-  if (card.suit === "joker") return false;
-  if (foundation.length === 0) return RANK_VAL[card.rank] === 1;
-  const top = foundation[foundation.length - 1];
-  return top.suit === card.suit && RANK_VAL[card.rank] === RANK_VAL[top.rank] + 1;
-}
-
-/** Check if a sequence of cards forms a valid alternating-color descending run */
-function isValidSequence(cards: Card[]): boolean {
-  for (let i = 0; i < cards.length - 1; i++) {
-    if (!canStackOnCascade(cards[i + 1], cards[i])) return false;
-  }
-  return true;
-}
-
-/** Supermove: max cards that can be moved */
-function maxMovableCards(freeCells: (Card | null)[], cascades: Card[][], excludeColIndex: number): number {
-  const emptyFreeCells = freeCells.filter((c) => c === null).length;
-  const emptyCascades = cascades.filter((col, i) => i !== excludeColIndex && col.length === 0).length;
-  return (emptyFreeCells + 1) * Math.pow(2, emptyCascades);
-}
-
-function makeInitialState(): FreeCellState {
-  const deck = buildFreeCellDeck();
-  const cascades: Card[][] = Array.from({ length: 8 }, () => []);
-  // Deal: columns 0–3 get 7 cards, columns 4–7 get 6 cards
-  let idx = 0;
-  for (let col = 0; col < 8; col++) {
-    const count = col < 4 ? 7 : 6;
-    for (let i = 0; i < count; i++) {
-      cascades[col].push(deck[idx++]);
-    }
-  }
-  return {
-    cascades,
-    freeCells: [null, null, null, null],
-    foundations: [[], [], [], []],
-    selected: null,
-    moves: 0,
-    phase: "playing",
-  };
-}
-
-function checkWin(state: FreeCellState): boolean {
-  return state.foundations.every((f) => f.length === 13);
-}
-
-// ── Auto-move logic ───────────────────────────────────────────────────────────
-
-/**
- * Return true if moving `card` to foundation is "safe" —
- * i.e. no card that could be built on it is still in play at a lower foundation level.
- */
-function isSafeToAutoMove(card: Card, foundations: Card[][]): boolean {
-  if (card.suit === "joker") return false;
-  const cardVal = RANK_VAL[card.rank];
-  if (cardVal <= 2) return true;
-  // Safe if both colors of the rank below are already on foundations
-  const needVal = cardVal - 1;
-  for (const suit of FOUNDATION_SUITS) {
-    const foundIdx = FOUNDATION_SUITS.indexOf(suit);
-    const f = foundations[foundIdx];
-    const topVal = f.length > 0 ? RANK_VAL[f[f.length - 1].rank] : 0;
-    if (isRed(card.suit) !== isRed(suit) && topVal < needVal) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function autoMoveToFoundation(state: FreeCellState): FreeCellState {
-  let changed = true;
-  let s = { ...state };
-  while (changed) {
-    changed = false;
-    // Check free cells
-    for (let i = 0; i < 4; i++) {
-      const card = s.freeCells[i];
-      if (!card) continue;
-      const foundIdx = FOUNDATION_SUITS.indexOf(card.suit as Suit);
-      if (foundIdx >= 0 && canPlaceOnFoundation(card, s.foundations[foundIdx]) && isSafeToAutoMove(card, s.foundations)) {
-        const newFounds = s.foundations.map((f, fi) => fi === foundIdx ? [...f, card] : f);
-        const newFreeCells = s.freeCells.map((c, ci) => ci === i ? null : c);
-        s = { ...s, foundations: newFounds, freeCells: newFreeCells, moves: s.moves + 1 };
-        changed = true;
-      }
-    }
-    // Check cascade tops
-    for (let col = 0; col < 8; col++) {
-      if (s.cascades[col].length === 0) continue;
-      const card = s.cascades[col][s.cascades[col].length - 1];
-      const foundIdx = FOUNDATION_SUITS.indexOf(card.suit as Suit);
-      if (foundIdx >= 0 && canPlaceOnFoundation(card, s.foundations[foundIdx]) && isSafeToAutoMove(card, s.foundations)) {
-        const newFounds = s.foundations.map((f, fi) => fi === foundIdx ? [...f, card] : f);
-        const newCascades = s.cascades.map((col2, ci) => ci === col ? col2.slice(0, col2.length - 1) : col2);
-        s = { ...s, foundations: newFounds, cascades: newCascades, moves: s.moves + 1 };
-        changed = true;
-      }
-    }
-  }
-  return s;
-}
+type SelFrom = "cascade" | "freecell";
+interface Selection { from: SelFrom; idx: number; startDepth: number; cards: Card[]; }
+type Phase = "dealing" | "playing" | "animating" | "won";
+interface FCProps { settings: DeckSettings; onNewGame?: () => void; onQuit?: () => void; }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-interface FreeCellProps {
-  settings: DeckSettings;
-  onNewGame?: () => void;
-  onQuit?: () => void;
-}
-
-type PortraitLayout = "rotate" | "grid";
-
-export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps) {
-  const [state, setState] = useState<FreeCellState>(() => makeInitialState());
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+export default function FreeCell({ settings, onNewGame, onQuit }: FCProps) {
+  const [allCards,      setAllCards]      = useState<Card[]>([]);
+  const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
+  const [game,          setGame]          = useState<FCGame>(() => ({
+    cascades: Array.from({length:8}, () => []), freeCells:[null,null,null,null], foundations:[[],[],[],[]]
+  }));
+  const [phase,         setPhase]         = useState<Phase>("dealing");
+  const [selected,      setSelected]      = useState<Selection | null>(null);
+  const [moves,         setMoves]         = useState(0);
+  const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
+  const [scale,         setScale]         = useState(1);
 
-  // Portrait-mode detection
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const [containerSize, setContainerSize] = useState({ w: 800, h: 600 });
-  const [portraitLayout, setPortraitLayout] = useState<PortraitLayout>("rotate");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isAnim       = useRef(false);
+  const gameRef      = useRef<FCGame>({ cascades: Array.from({length:8},()=>[]), freeCells:[null,null,null,null], foundations:[[],[],[],[]] });
+  const timers       = useRef<ReturnType<typeof setTimeout>[]>([]);
 
+  const clearTimers = useCallback(() => { timers.current.forEach(clearTimeout); timers.current = []; }, []);
+  function after(ms: number, fn: () => void) { timers.current.push(setTimeout(fn, ms)); }
+
+  const cascSt = useRef(
+    Array.from({length:8}, (_, i) =>
+      new CardStack({ zTier:10+i, baseX:COL_X[i], baseY:CASC_Y, faceUpOffsetY:FAN_STEP })
+    )
+  );
+  const fcSt = useRef(
+    Array.from({length:4}, (_, i) =>
+      new CardStack({ zTier:5+i, baseX:COL_X[i], baseY:TOP_Y })
+    )
+  );
+  const foundSt = useRef(
+    Array.from({length:4}, (_, i) =>
+      new CardStack({ zTier:1+i, baseX:COL_X[4+i], baseY:TOP_Y })
+    )
+  );
+
+  function allLayouts(ms = 250): Record<string, CardVisualState> {
+    const r: Record<string, CardVisualState> = {};
+    for (const s of cascSt.current)  Object.assign(r, s.layout(ms));
+    for (const s of fcSt.current)    Object.assign(r, s.layout(ms));
+    for (const s of foundSt.current) Object.assign(r, s.layout(ms));
+    return r;
+  }
+
+  function syncStacks(g: FCGame): void {
+    for (let i = 0; i < 8; i++) {
+      cascSt.current[i].clear();
+      for (const c of g.cascades[i]) cascSt.current[i].addCard(c, { toTop:true, faceDown:false });
+    }
+    for (let i = 0; i < 4; i++) {
+      fcSt.current[i].clear();
+      if (g.freeCells[i]) fcSt.current[i].addCard(g.freeCells[i]!, { toTop:true, faceDown:false });
+    }
+    for (let i = 0; i < 4; i++) {
+      foundSt.current[i].clear();
+      for (const c of g.foundations[i]) foundSt.current[i].addCard(c, { toTop:true, faceDown:false });
+    }
+  }
+
+  function applyAutoMoves(g: FCGame): FCGame {
+    let changed = true, s = g;
+    while (changed) {
+      changed = false;
+      for (let i = 0; i < 4; i++) {
+        const c = s.freeCells[i]; if (!c) continue;
+        const fi = SUITS.indexOf(c.suit as Suit);
+        if (fi >= 0 && canFound(c, s.foundations[fi]) && isSafeAuto(c, s.foundations)) {
+          s = { ...s,
+            foundations: s.foundations.map((f,j) => j===fi ? [...f,c] : f),
+            freeCells: s.freeCells.map((fc,j): Card|null => j===i ? null : fc),
+          };
+          changed = true;
+        }
+      }
+      for (let col = 0; col < 8; col++) {
+        if (s.cascades[col].length === 0) continue;
+        const c = s.cascades[col][s.cascades[col].length - 1];
+        const fi = SUITS.indexOf(c.suit as Suit);
+        if (fi >= 0 && canFound(c, s.foundations[fi]) && isSafeAuto(c, s.foundations)) {
+          s = { ...s,
+            foundations: s.foundations.map((f,j) => j===fi ? [...f,c] : f),
+            cascades: s.cascades.map((col2,j) => j===col ? col2.slice(0,-1) : col2),
+          };
+          changed = true;
+        }
+      }
+    }
+    return s;
+  }
+
+  function completeMove(newG: FCGame): void {
+    const withAuto = applyAutoMoves(newG);
+    syncStacks(withAuto);
+    gameRef.current = withAuto;
+    setGame(withAuto);
+    setCardStates(allLayouts(0));
+    setMoves(m => m + 1);
+    isAnim.current = false;
+    setPhase(withAuto.foundations.every(f => f.length === 13) ? "won" : "playing");
+  }
+
+  // Scale to fit container
   useEffect(() => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(([entry]) => {
-      const { width, height } = entry.contentRect;
-      setContainerSize({ w: width, h: height });
+    const el = containerRef.current; if (!el) return;
+    const obs = new ResizeObserver(e => {
+      const { width, height } = e[0].contentRect;
+      setScale(Math.min(1, width / STAGE_W, height / STAGE_H));
     });
-    ro.observe(el);
-    return () => ro.disconnect();
+    obs.observe(el);
+    return () => obs.disconnect();
   }, []);
 
-  const isNarrow = containerSize.w > 0 && containerSize.w < 500;
+  // ── startGame ────────────────────────────────────────────────────────────────
 
-  // ── Game actions ──────────────────────────────────────────────────────────
+  const startGame = useCallback(() => {
+    clearTimers();
+    isAnim.current = false;
+    setSelected(null);
+    setMoves(0);
+    setPhase("dealing");
 
-  const restart = useCallback(() => {
-    setState(makeInitialState());
-  }, []);
+    const deck: Card[] = [];
+    for (const suit of SUITS) for (const rank of RANKS) deck.push({ suit, rank, id:`${suit}-${rank}` });
+    const shuffled = shuffle(deck);
 
-  const handleAutoMove = useCallback(() => {
-    setState((s) => {
-      if (s.phase === "won") return s;
-      const next = autoMoveToFoundation(s);
-      const won = checkWin(next);
-      return { ...next, phase: won ? "won" : "playing" };
-    });
-  }, []);
+    for (const s of cascSt.current)  s.clear();
+    for (const s of fcSt.current)    s.clear();
+    for (const s of foundSt.current) s.clear();
 
-  // ── Selection & move logic ────────────────────────────────────────────────
+    const cascades: Card[][] = Array.from({length:8}, () => []);
+    let idx = 0;
+    for (let col = 0; col < 8; col++) {
+      const count = col < 4 ? 7 : 6;
+      for (let i = 0; i < count; i++) {
+        cascades[col].push(shuffled[idx]);
+        cascSt.current[col].addCard(shuffled[idx], { toTop:true, faceDown:false });
+        idx++;
+      }
+    }
 
-  const handleFreeCellClick = useCallback((cellIdx: number) => {
-    setState((s) => {
-      if (s.phase === "won") return s;
-      const cellCard = s.freeCells[cellIdx];
+    const newG: FCGame = { cascades, freeCells:[null,null,null,null], foundations:[[],[],[],[]] };
+    gameRef.current = newG;
+    setAllCards(shuffled);
+    setGame(newG);
 
-      // If something is selected, try to move it here
-      if (s.selected) {
-        // Can only move single card to free cell from cascade
-        if (s.selected.cards.length === 1) {
-          const movingCard = s.selected.cards[0];
+    const initStates: Record<string, CardVisualState> = {};
+    for (const c of shuffled) initStates[c.id] = { x:STAGE_W/2, y:-80, z:100, rotation:0, faceDown:false, transitionMs:0 };
+    setCardStates(initStates);
 
-          // Move to empty free cell
-          if (cellCard === null && s.selected.from === "cascade") {
-            const newFreeCells = s.freeCells.map((c, i) => i === cellIdx ? movingCard : c);
-            const newCascades = s.cascades.map((col, i) =>
-              i === s.selected!.colIndex ? col.slice(0, s.selected!.cardIndex) : col
-            );
-            const next: FreeCellState = {
-              ...s,
-              freeCells: newFreeCells,
-              cascades: newCascades,
-              selected: null,
-              moves: s.moves + 1,
-            };
-            return autoMoveToFoundation(next);
-          }
-
-          // Move from free cell to free cell (if destination empty)
-          if (cellCard === null && s.selected.from === "freecell") {
-            if (cellIdx === s.selected.colIndex) {
-              return { ...s, selected: null };
-            }
-            const newFreeCells = s.freeCells.map((c, i) => {
-              if (i === cellIdx) return movingCard;
-              if (i === s.selected!.colIndex) return null;
-              return c;
-            });
-            const next: FreeCellState = {
-              ...s,
-              freeCells: newFreeCells,
-              selected: null,
-              moves: s.moves + 1,
-            };
-            return autoMoveToFoundation(next);
-          }
-        }
-
-        // Click same free cell card — deselect
-        if (s.selected.from === "freecell" && s.selected.colIndex === cellIdx) {
-          return { ...s, selected: null };
-        }
-
-        // Try selecting the free cell card instead
-        if (cellCard) {
-          return {
-            ...s,
-            selected: {
-              from: "freecell",
-              colIndex: cellIdx,
-              cardIndex: 0,
-              cards: [cellCard],
-            },
+    after(80, () => {
+      const dealStates: Record<string, CardVisualState> = {};
+      let di = 0;
+      for (let col = 0; col < 8; col++) {
+        const count = col < 4 ? 7 : 6;
+        for (let i = 0; i < count; i++) {
+          const c = shuffled[di++];
+          dealStates[c.id] = {
+            x:COL_X[col], y:CASC_Y + i * FAN_STEP, z:(10+col)*100+i,
+            rotation:0, faceDown:false, transitionMs:240, transitionDelay:(col + i) * 28,
           };
         }
-
-        return { ...s, selected: null };
       }
-
-      // No selection — select the free cell card
-      if (cellCard) {
-        return {
-          ...s,
-          selected: {
-            from: "freecell",
-            colIndex: cellIdx,
-            cardIndex: 0,
-            cards: [cellCard],
-          },
-        };
-      }
-
-      return s;
+      setCardStates(dealStates);
+      after(240 + 14 * 28 + 120, () => { setCardStates(allLayouts(0)); setPhase("playing"); });
     });
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings, clearTimers]);
 
-  const handleFoundationClick = useCallback((foundIdx: number) => {
-    setState((s) => {
-      if (s.phase === "won") return s;
-      if (!s.selected || s.selected.cards.length !== 1) return s;
+  useEffect(() => { startGame(); return clearTimers; }, []); // eslint-disable-line
 
-      const movingCard = s.selected.cards[0];
-      if (!canPlaceOnFoundation(movingCard, s.foundations[foundIdx])) {
-        return { ...s, selected: null };
-      }
+  // ── Move executors ────────────────────────────────────────────────────────────
 
-      const newFounds = s.foundations.map((f, fi) =>
-        fi === foundIdx ? [...f, movingCard] : f
-      );
+  function execAnimSteps(steps: AnimStep[], onDone: () => void): void {
+    setPhase("animating"); isAnim.current = true; setSelected(null);
+    let t = 0;
+    for (const step of steps) {
+      const s = step;
+      after(t, () => setCardStates(prev => ({
+        ...prev, [s.cardId]: { ...prev[s.cardId], x:s.x, y:s.y, z:s.z, transitionMs:ANIM_MS, transitionDelay:0 }
+      })));
+      t += STEP_MS;
+    }
+    after(t + ANIM_MS, onDone);
+  }
 
-      let newCascades = s.cascades;
-      let newFreeCells = s.freeCells;
+  function doMoveToCol(sel: Selection, destColIdx: number): boolean {
+    const g = gameRef.current;
+    const destCol = g.cascades[destColIdx];
+    const movingCards = sel.cards;
 
-      if (s.selected.from === "cascade") {
-        newCascades = s.cascades.map((col, i) =>
-          i === s.selected!.colIndex ? col.slice(0, s.selected!.cardIndex) : col
-        );
-      } else {
-        newFreeCells = s.freeCells.map((c, i) =>
-          i === s.selected!.colIndex ? null : c
-        );
-      }
+    if (destCol.length > 0 && !canStack(movingCards[0], destCol[destCol.length - 1])) return false;
+    const excl = sel.from === "cascade" ? sel.idx : -1;
+    if (movingCards.length > maxMovable(g.freeCells, g.cascades, destColIdx)) return false;
 
-      const next: FreeCellState = {
-        ...s,
-        foundations: newFounds,
-        cascades: newCascades,
-        freeCells: newFreeCells,
-        selected: null,
-        moves: s.moves + 1,
-      };
-      const afterAuto = autoMoveToFoundation(next);
-      const won = checkWin(afterAuto);
-      return { ...afterAuto, phase: won ? "won" : "playing" };
-    });
-  }, []);
+    const availFC = g.freeCells
+      .map((c, i): {x:number;y:number}|null => c === null ? { x:COL_X[i], y:TOP_Y } : null)
+      .filter((x): x is {x:number;y:number} => x !== null);
+    const availCC = g.cascades
+      .map((c, i): {x:number;y:number}|null =>
+        (i !== destColIdx && i !== excl && c.length === 0) ? { x:COL_X[i], y:CASC_Y } : null)
+      .filter((x): x is {x:number;y:number} => x !== null);
 
-  const handleCascadeClick = useCallback((colIndex: number, cardIdx: number) => {
-    setState((s) => {
-      if (s.phase === "won") return s;
-      const col = s.cascades[colIndex];
+    const steps: AnimStep[] = [];
+    planSteps(movingCards, COL_X[destColIdx], CASC_Y, destCol.length, availFC, availCC, steps);
+    if (steps.length === 0) return false;
 
-      // If nothing selected, try to select from this cascade
-      if (!s.selected) {
-        if (col.length === 0) return s;
-        // cardIdx is the index in the array (last = top of pile)
-        const seq = col.slice(cardIdx);
-        if (!isValidSequence(seq)) return s;
-        return {
-          ...s,
-          selected: {
-            from: "cascade",
-            colIndex,
-            cardIndex: cardIdx,
-            cards: seq,
-          },
-        };
-      }
-
-      // Something is selected — try to move it here
-      const { selected } = s;
-
-      // Click same card to deselect
-      if (
-        selected.from === "cascade" &&
-        selected.colIndex === colIndex &&
-        selected.cardIndex === cardIdx
-      ) {
-        return { ...s, selected: null };
-      }
-
-      const movingCards = selected.cards;
-      const movingTop = movingCards[0]; // first card = top of sequence (placed last)
-
-      // Can we place here?
-      let canPlace = false;
-      if (col.length === 0) {
-        canPlace = true;
-      } else {
-        const destTop = col[col.length - 1];
-        canPlace = canStackOnCascade(movingTop, destTop);
-      }
-
-      if (!canPlace) {
-        // Try to change selection to the clicked column
-        if (col.length > 0 && cardIdx < col.length) {
-          const seq = col.slice(cardIdx);
-          if (isValidSequence(seq)) {
-            return {
-              ...s,
-              selected: {
-                from: "cascade",
-                colIndex,
-                cardIndex: cardIdx,
-                cards: seq,
-              },
-            };
-          }
-        }
-        return { ...s, selected: null };
-      }
-
-      // Check supermove limit
-      const maxMove = maxMovableCards(s.freeCells, s.cascades, colIndex);
-      if (movingCards.length > maxMove) {
-        return { ...s, selected: null };
-      }
-
-      // Perform the move
-      const newCascades = s.cascades.map((c, i) => {
-        if (i === colIndex) return [...c, ...movingCards];
-        if (selected.from === "cascade" && i === selected.colIndex) {
-          return c.slice(0, selected.cardIndex);
-        }
-        return c;
-      });
-
-      let newFreeCells = s.freeCells;
-      if (selected.from === "freecell") {
-        newFreeCells = s.freeCells.map((c, i) =>
-          i === selected.colIndex ? null : c
-        );
-      }
-
-      const next: FreeCellState = {
-        ...s,
-        cascades: newCascades,
-        freeCells: newFreeCells,
-        selected: null,
-        moves: s.moves + 1,
-      };
-      const afterAuto = autoMoveToFoundation(next);
-      const won = checkWin(afterAuto);
-      return { ...afterAuto, phase: won ? "won" : "playing" };
-    });
-  }, []);
-
-  const handleEmptyCascadeClick = useCallback((colIndex: number) => {
-    setState((s) => {
-      if (s.phase === "won") return s;
-      if (!s.selected) return s;
-
-      const { selected } = s;
-      const movingCards = selected.cards;
-
-      const maxMove = maxMovableCards(s.freeCells, s.cascades, colIndex);
-      if (movingCards.length > maxMove) {
-        return { ...s, selected: null };
-      }
-
-      const newCascades = s.cascades.map((col, i) => {
-        if (i === colIndex) return [...col, ...movingCards];
-        if (selected.from === "cascade" && i === selected.colIndex) {
-          return col.slice(0, selected.cardIndex);
-        }
+    const capSel = { ...sel }, capDest = destColIdx, capCards = [...movingCards];
+    execAnimSteps(steps, () => {
+      const prev = gameRef.current;
+      const newCascades = prev.cascades.map((col, i): Card[] => {
+        if (capSel.from === "cascade" && i === capSel.idx) return col.slice(0, capSel.startDepth);
+        if (i === capDest) return [...col, ...capCards];
         return col;
       });
+      const newFCs = prev.freeCells.map((c, i): Card|null =>
+        capSel.from === "freecell" && i === capSel.idx ? null : c
+      );
+      completeMove({ cascades:newCascades, freeCells:newFCs, foundations:prev.foundations });
+    });
+    return true;
+  }
 
-      let newFreeCells = s.freeCells;
-      if (selected.from === "freecell") {
-        newFreeCells = s.freeCells.map((c, i) =>
-          i === selected.colIndex ? null : c
-        );
+  function doMoveToFC(sel: Selection, fcIdx: number): boolean {
+    const g = gameRef.current;
+    if (g.freeCells[fcIdx] !== null || sel.cards.length !== 1) return false;
+    const card = sel.cards[0];
+    const steps: AnimStep[] = [{ cardId:card.id, x:COL_X[fcIdx], y:TOP_Y, z:ANIM_Z }];
+    const capSel = { ...sel }, capFC = fcIdx, capCard = card;
+    execAnimSteps(steps, () => {
+      const prev = gameRef.current;
+      const newFCs = prev.freeCells.map((c, i): Card|null => i === capFC ? capCard : c);
+      const newCascades = capSel.from === "cascade"
+        ? prev.cascades.map((col, i) => i === capSel.idx ? col.slice(0, capSel.startDepth) : col)
+        : prev.cascades;
+      completeMove({ cascades:newCascades, freeCells:newFCs, foundations:prev.foundations });
+    });
+    return true;
+  }
+
+  function doMoveToFoundation(sel: Selection, foundIdx: number): boolean {
+    const g = gameRef.current;
+    if (sel.cards.length !== 1) return false;
+    const card = sel.cards[0];
+    if (!canFound(card, g.foundations[foundIdx])) return false;
+    const steps: AnimStep[] = [{ cardId:card.id, x:COL_X[4+foundIdx], y:TOP_Y, z:ANIM_Z }];
+    const capSel = { ...sel }, capFI = foundIdx, capCard = card;
+    execAnimSteps(steps, () => {
+      const prev = gameRef.current;
+      const newFounds = prev.foundations.map((f, i) => i === capFI ? [...f, capCard] : f);
+      const newCascades = capSel.from === "cascade"
+        ? prev.cascades.map((col, i) => i === capSel.idx ? col.slice(0, capSel.startDepth) : col)
+        : prev.cascades;
+      const newFCs = prev.freeCells.map((c, i): Card|null =>
+        capSel.from === "freecell" && i === capSel.idx ? null : c
+      );
+      completeMove({ cascades:newCascades, freeCells:newFCs, foundations:newFounds });
+    });
+    return true;
+  }
+
+  // ── Click handlers ────────────────────────────────────────────────────────────
+
+  const handleCardClick = useCallback((cardId: string) => {
+    if (isAnim.current || phase !== "playing") return;
+    const g = gameRef.current;
+
+    let kind: "cascade"|"freecell"|"foundation" = "cascade";
+    let col = -1, depth = -1;
+    found: {
+      for (let c = 0; c < 8; c++) {
+        const d = g.cascades[c].findIndex(x => x.id === cardId);
+        if (d >= 0) { kind="cascade"; col=c; depth=d; break found; }
       }
+      for (let i = 0; i < 4; i++) {
+        if (g.freeCells[i]?.id === cardId) { kind="freecell"; col=i; depth=0; break found; }
+      }
+      for (let i = 0; i < 4; i++) {
+        const d = g.foundations[i].findIndex(x => x.id === cardId);
+        if (d >= 0) { kind="foundation"; col=i; depth=d; break found; }
+      }
+      return;
+    }
 
-      const next: FreeCellState = {
-        ...s,
-        cascades: newCascades,
-        freeCells: newFreeCells,
-        selected: null,
-        moves: s.moves + 1,
-      };
-      const afterAuto = autoMoveToFoundation(next);
-      const won = checkWin(afterAuto);
-      return { ...afterAuto, phase: won ? "won" : "playing" };
-    });
-  }, []);
+    const sel = selected;
 
-  // ── Computed highlight state ──────────────────────────────────────────────
+    if (!sel) {
+      if (kind === "foundation") return;
+      if (kind === "freecell") {
+        setSelected({ from:"freecell", idx:col, startDepth:0, cards:[g.freeCells[col]!] });
+        return;
+      }
+      const seq = g.cascades[col].slice(depth);
+      if (isValidSeq(seq)) setSelected({ from:"cascade", idx:col, startDepth:depth, cards:seq });
+      return;
+    }
 
-  const validDestinations = useMemo(() => {
-    if (!state.selected) return null;
-    const sel = state.selected;
-    const movingCards = sel.cards;
-    const movingTop = movingCards[0];
+    if (kind === "foundation") {
+      if (!doMoveToFoundation(sel, col)) setSelected(null);
+      return;
+    }
+    if (kind === "freecell") {
+      if (sel.from === "freecell" && sel.idx === col) { setSelected(null); return; }
+      if (g.freeCells[col] === null) {
+        if (!doMoveToFC(sel, col)) setSelected(null);
+      } else {
+        setSelected({ from:"freecell", idx:col, startDepth:0, cards:[g.freeCells[col]!] });
+      }
+      return;
+    }
+    // cascade
+    if (sel.from === "cascade" && sel.idx === col && sel.startDepth === depth) { setSelected(null); return; }
+    const destCol = g.cascades[col];
+    if (depth === destCol.length - 1 || destCol.length === 0) {
+      if (!doMoveToCol(sel, col)) {
+        const seq = destCol.slice(depth);
+        if (seq.length > 0 && isValidSeq(seq)) setSelected({ from:"cascade", idx:col, startDepth:depth, cards:seq });
+        else setSelected(null);
+      }
+      return;
+    }
+    const seq2 = destCol.slice(depth);
+    if (isValidSeq(seq2)) setSelected({ from:"cascade", idx:col, startDepth:depth, cards:seq2 });
+    else setSelected(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selected]);
 
-    const maxMove = maxMovableCards(state.freeCells, state.cascades, sel.from === "cascade" ? sel.colIndex : -1);
+  const handleEmptyColClick = useCallback((colIdx: number) => {
+    if (isAnim.current || phase !== "playing" || !selected) return;
+    if (!doMoveToCol(selected, colIdx)) setSelected(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selected]);
 
-    const cascadeValid: boolean[] = state.cascades.map((col, i) => {
-      if (sel.from === "cascade" && i === sel.colIndex) return false;
-      if (movingCards.length > maxMove) return false;
-      if (col.length === 0) return true;
-      const destTop = col[col.length - 1];
-      return canStackOnCascade(movingTop, destTop);
-    });
+  const handleEmptyFCClick = useCallback((fcIdx: number) => {
+    if (isAnim.current || phase !== "playing" || !selected) return;
+    if (!doMoveToFC(selected, fcIdx)) setSelected(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selected]);
 
-    const freeCellValid: boolean[] = state.freeCells.map((c, i) => {
-      if (sel.from === "freecell" && i === sel.colIndex) return false;
-      return c === null && movingCards.length === 1;
-    });
+  const handleFoundationSlotClick = useCallback((foundIdx: number) => {
+    if (isAnim.current || phase !== "playing" || !selected) return;
+    if (!doMoveToFoundation(selected, foundIdx)) setSelected(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selected]);
 
-    const foundationValid: boolean[] = state.foundations.map((f, fi) => {
-      return movingCards.length === 1 && canPlaceOnFoundation(movingTop, f) &&
-        FOUNDATION_SUITS[fi] === movingTop.suit;
-    });
+  const handleAutoMove = useCallback(() => {
+    if (isAnim.current || phase !== "playing") return;
+    const g = applyAutoMoves(gameRef.current);
+    syncStacks(g);
+    gameRef.current = g;
+    setGame(g);
+    setCardStates(allLayouts(0));
+    setPhase(g.foundations.every(f => f.length === 13) ? "won" : "playing");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
 
-    return { cascadeValid, freeCellValid, foundationValid };
-  }, [state]);
+  // ── Derived render state ──────────────────────────────────────────────────────
 
-  // ── Menus ─────────────────────────────────────────────────────────────────
+  const selectedIds = useMemo(() => new Set(selected?.cards.map(c => c.id) ?? []), [selected]);
+
+  const cardLocs = useMemo(() => {
+    const m = new Map<string, {kind:"cascade"|"freecell"|"foundation"; col:number; depth:number}>();
+    game.cascades.forEach((col, ci) => col.forEach((c, di) => m.set(c.id, {kind:"cascade",col:ci,depth:di})));
+    game.freeCells.forEach((c, i) => { if (c) m.set(c.id, {kind:"freecell",col:i,depth:0}); });
+    game.foundations.forEach((f, i) => f.forEach((c, di) => m.set(c.id, {kind:"foundation",col:i,depth:di})));
+    return m;
+  }, [game]);
+
+  // ── Menus ─────────────────────────────────────────────────────────────────────
 
   const menus = useMemo<MenuBarMenu[]>(() => {
-    const gameItems: MenuBarMenu["items"] = [
-      { label: "Restart", onClick: restart },
-      ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
-      ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+    const items: MenuBarMenu["items"] = [
+      { label:"New Game", onClick: startGame },
+      ...(onNewGame ? [{ label:"Change Game…", onClick: onNewGame }] : []),
+      ...(onQuit    ? [{ separator:true as const }, { label:"Exit", onClick: onQuit }] : []),
     ];
     return [
-      { label: "Game", items: gameItems },
-      {
-        label: "Options",
-        items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }],
-      },
+      { label:"Game",    items },
+      { label:"Options", items:[{ label:"Card Appearance…", onClick:() => setShowDeckModal(true) }] },
     ];
-  }, [restart, onNewGame, onQuit]);
+  }, [startGame, onNewGame, onQuit]);
 
   useWindowMenus(menus);
 
-  // ── Render ────────────────────────────────────────────────────────────────
-
-  const { cascades, freeCells, foundations, selected, moves, phase } = state;
-
-  const SUIT_SYMBOL: Record<string, string> = {
-    spades: "♠",
-    hearts: "♥",
-    diamonds: "♦",
-    clubs: "♣",
-  };
-
-  // Cascades split for 2×4 portrait grid layout
-  const cascadesTop = cascades.slice(0, 4);
-  const cascadesBottom = cascades.slice(4, 8);
-
-  const gameContent = (
-    <>
-      {showDeckModal && (
-        <DeckModal
-          appearance={appearance}
-          onUpdate={setAppearance}
-          onClose={() => setShowDeckModal(false)}
-        />
-      )}
-
-      {/* Top area: free cells + foundations */}
-      <div className="freecell__top-row">
-        {/* Free cells */}
-        <div className="freecell__free-cells">
-          {freeCells.map((card, i) => {
-            const isSelected = selected?.from === "freecell" && selected.colIndex === i;
-            const isValid = validDestinations?.freeCellValid[i] ?? false;
-            return (
-              <div
-                key={i}
-                className={
-                  "freecell__cell-slot" +
-                  (isSelected ? " freecell__cell-slot--selected" : "") +
-                  (isValid ? " freecell__cell-slot--valid" : "")
-                }
-                onClick={() => handleFreeCellClick(i)}
-                title="Free Cell"
-              >
-                {card ? (
-                  <PlayingCard card={card} appearance={appearance} size="sm" />
-                ) : (
-                  <div className="freecell__empty-slot freecell__empty-slot--freecell" />
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Spacer / status */}
-        <div className="freecell__center-status">
-          <div className="freecell__moves">Moves: {moves}</div>
-          <button
-            className="freecell__auto-btn"
-            onClick={handleAutoMove}
-            disabled={phase === "won"}
-            title="Auto-move safe cards to foundations"
-          >
-            Auto
-          </button>
-        </div>
-
-        {/* Foundations */}
-        <div className="freecell__foundations">
-          {FOUNDATION_SUITS.map((suit, i) => {
-            const pile = foundations[i];
-            const topCard = pile.length > 0 ? pile[pile.length - 1] : null;
-            const isValid = validDestinations?.foundationValid[i] ?? false;
-            return (
-              <div
-                key={suit}
-                className={
-                  "freecell__cell-slot freecell__cell-slot--foundation" +
-                  (isValid ? " freecell__cell-slot--valid" : "")
-                }
-                onClick={() => handleFoundationClick(i)}
-                title={`${suit} foundation`}
-              >
-                {topCard ? (
-                  <PlayingCard card={topCard} appearance={appearance} size="sm" />
-                ) : (
-                  <div className="freecell__empty-slot freecell__empty-slot--foundation">
-                    <span className="freecell__suit-hint">{SUIT_SYMBOL[suit]}</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Cascade area — normal 8-column or 2×4 grid */}
-      {isNarrow && portraitLayout === "grid" ? (
-        <>
-          <div className="freecell__cascades">
-            {cascadesTop.map((col, i) => {
-              const colIdx = i;
-              return renderCascadeCol(col, colIdx);
-            })}
-          </div>
-          <div className="freecell__cascades">
-            {cascadesBottom.map((col, i) => {
-              const colIdx = i + 4;
-              return renderCascadeCol(col, colIdx);
-            })}
-          </div>
-        </>
-      ) : (
-        <div className="freecell__cascades">
-          {cascades.map((col, colIdx) => renderCascadeCol(col, colIdx))}
-        </div>
-      )}
-
-      {/* Win banner */}
-      {phase === "won" && (
-        <div className="freecell__win-overlay">
-          <div className="freecell__win-banner">
-            <div className="freecell__win-title">You Win!</div>
-            <div className="freecell__win-moves">Completed in {moves} moves</div>
-            <div className="freecell__win-btns">
-              <button className="freecell__btn freecell__btn--primary" onClick={restart}>
-                Play Again
-              </button>
-              {onNewGame && (
-                <button className="freecell__btn freecell__btn--secondary" onClick={onNewGame}>
-                  New Game
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-    </>
-  );
-
-  function renderCascadeCol(col: Card[], colIdx: number) {
-    const isCascadeValid = validDestinations?.cascadeValid[colIdx] ?? false;
-    const colHeight = col.length === 0 ? 72 : (col.length - 1) * 22 + 72;
-    return (
-      <div
-        key={colIdx}
-        className={
-          "freecell__cascade" +
-          (isCascadeValid ? " freecell__cascade--valid" : "")
-        }
-        style={{ height: colHeight }}
-        onClick={col.length === 0 ? () => handleEmptyCascadeClick(colIdx) : undefined}
-      >
-        {col.length === 0 ? (
-          <div className="freecell__empty-slot freecell__empty-slot--cascade" />
-        ) : (
-          col.map((card, cardIdx) => {
-            const isSeqStart = selected?.from === "cascade" &&
-              selected.colIndex === colIdx &&
-              selected.cardIndex === cardIdx;
-            const isInSelected = selected?.from === "cascade" &&
-              selected.colIndex === colIdx &&
-              cardIdx >= selected.cardIndex;
-            const isTop = cardIdx === col.length - 1;
-            const offsetY = cardIdx * 22;
-            return (
-              <div
-                key={card.id}
-                className={
-                  "freecell__cascade-card" +
-                  (isInSelected ? " freecell__cascade-card--selected" : "") +
-                  (isSeqStart ? " freecell__cascade-card--seq-start" : "")
-                }
-                style={{ top: `${offsetY}px`, zIndex: cardIdx + 1 }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCascadeClick(colIdx, cardIdx);
-                }}
-                title={isTop ? `${card.rank} of ${card.suit}` : undefined}
-              >
-                <PlayingCard card={card} appearance={appearance} size="sm" />
-              </div>
-            );
-          })
-        )}
-      </div>
-    );
-  }
-
-  if (isNarrow && portraitLayout === "rotate") {
-    // Rotate the game 90° CW so landscape content fills a portrait container.
-    // Container: W×H (portrait). Landscape element: H×W.
-    // After `translateY(H) rotate(90deg)` (rotate first, then translate):
-    //   rotated bounds → x=[0,W], y=[0,H]. Fills container exactly.
-    const gameW = containerSize.h;  // landscape width  = portrait height (H)
-    const gameH = containerSize.w;  // landscape height = portrait width  (W)
-    const wrapHeight = gameW || 400; // outer height = H (portrait height)
-    return (
-      <div
-        ref={wrapperRef}
-        className="freecell-wrapper freecell-wrapper--rotate"
-        style={{ position: "relative", height: wrapHeight, overflow: "hidden" }}
-      >
-        <div className="freecell__portrait-toggle freecell__portrait-toggle--overlay">
-          <button
-            className="freecell__portrait-btn"
-            onClick={() => setPortraitLayout("grid")}
-            title="Switch to 2×4 grid layout"
-          >▦ 2×4</button>
-        </div>
-        <div
-          className="freecell"
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: gameW,
-            height: gameH,
-            transform: `translateY(${gameW}px) rotate(90deg)`,
-            transformOrigin: "top left",
-          }}
-        >
-          {gameContent}
-        </div>
-      </div>
-    );
-  }
+  // ── Render ────────────────────────────────────────────────────────────────────
 
   return (
-    <div ref={wrapperRef} className="freecell-wrapper">
-      {isNarrow && (
-        <div className="freecell__portrait-toggle">
-          <button
-            className={"freecell__portrait-btn" + (portraitLayout === "rotate" ? " freecell__portrait-btn--active" : "")}
-            onClick={() => setPortraitLayout("rotate")}
-            title="Rotate 90°"
-          >⟳ Rotate</button>
-          <button
-            className={"freecell__portrait-btn" + (portraitLayout === "grid" ? " freecell__portrait-btn--active" : "")}
-            onClick={() => setPortraitLayout("grid")}
-            title="2×4 grid layout"
-          >▦ 2×4</button>
-        </div>
+    <div className="freecell">
+      {showDeckModal && (
+        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
-      <div className="freecell">
-        {gameContent}
+
+      <div ref={containerRef} className="freecell__stage-container">
+        <div
+          className="freecell__stage"
+          style={{ width:STAGE_W, height:STAGE_H, transform:`scale(${scale})`, transformOrigin:"top left" }}
+        >
+          {/* Free cell slots */}
+          {game.freeCells.map((fc, i) => (
+            <div
+              key={`fc-${i}`}
+              className="freecell__slot freecell__slot--freecell"
+              style={{ left:COL_X[i] - CARD_W/2, top:TOP_Y - CARD_H/2 }}
+              onClick={fc === null ? () => handleEmptyFCClick(i) : undefined}
+            />
+          ))}
+
+          {/* Foundation slots */}
+          {FOUNDATION_SUITS.map((suit, i) => (
+            <div
+              key={suit}
+              className="freecell__slot freecell__slot--foundation"
+              style={{ left:COL_X[4+i] - CARD_W/2, top:TOP_Y - CARD_H/2 }}
+              onClick={() => handleFoundationSlotClick(i)}
+            >
+              {game.foundations[i].length === 0 &&
+                <span className="freecell__suit-hint">{SUIT_SYMBOL[suit]}</span>}
+            </div>
+          ))}
+
+          {/* Empty cascade column slots */}
+          {game.cascades.map((col, i) => col.length === 0 && (
+            <div
+              key={`casc-${i}`}
+              className="freecell__slot"
+              style={{ left:COL_X[i] - CARD_W/2, top:CASC_Y - CARD_H/2 }}
+              onClick={() => handleEmptyColClick(i)}
+            />
+          ))}
+
+          {/* All 52 cards permanently mounted */}
+          {allCards.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            const loc = cardLocs.get(card.id);
+            const isHighlighted = selectedIds.has(card.id);
+            let onClick: (() => void) | undefined;
+            if (phase === "playing" && loc) {
+              if (loc.kind === "foundation") {
+                if (loc.depth === game.foundations[loc.col].length - 1)
+                  onClick = () => handleFoundationSlotClick(loc.col);
+              } else {
+                onClick = () => handleCardClick(card.id);
+              }
+            }
+            return (
+              <PermCard
+                key={card.id}
+                card={card}
+                cs={cs}
+                appearance={appearance}
+                size="sm"
+                highlightColor={isHighlighted ? "#cc4400" : undefined}
+                onClick={onClick}
+              />
+            );
+          })}
+
+          {/* Win overlay */}
+          {phase === "won" && (
+            <div className="freecell__win-overlay">
+              <div className="freecell__win-banner">
+                <div className="freecell__win-title">You Win!</div>
+                <div className="freecell__win-moves">Completed in {moves} moves</div>
+                <div className="freecell__win-btns">
+                  <button className="freecell__btn freecell__btn--primary" onClick={startGame}>Play Again</button>
+                  {onNewGame && (
+                    <button className="freecell__btn freecell__btn--secondary" onClick={onNewGame}>New Game</button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="freecell__statusbar">
+        <span>Moves: {moves}</span>
+        <button className="freecell__auto-btn" onClick={handleAutoMove} disabled={phase !== "playing"}>
+          Auto
+        </button>
+      </div>
+
+      <div className="freecell__controls">
+        <button className="freecell__btn freecell__btn--primary" onClick={startGame}>New Game</button>
+        {onNewGame && (
+          <button className="freecell__btn freecell__btn--secondary" onClick={onNewGame}>Change Game</button>
+        )}
       </div>
     </div>
   );

--- a/src/experiences/Cards/FreeCell.tsx
+++ b/src/experiences/Cards/FreeCell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import "./Cards.css";
 import "./FreeCell.css";
 import { PlayingCard } from "./PlayingCard";
@@ -182,10 +182,30 @@ interface FreeCellProps {
   onQuit?: () => void;
 }
 
+type PortraitLayout = "rotate" | "grid";
+
 export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps) {
   const [state, setState] = useState<FreeCellState>(() => makeInitialState());
   const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
+
+  // Portrait-mode detection
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ w: 800, h: 600 });
+  const [portraitLayout, setPortraitLayout] = useState<PortraitLayout>("rotate");
+
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      setContainerSize({ w: width, h: height });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const isNarrow = containerSize.w > 0 && containerSize.w < 500;
 
   // ── Game actions ──────────────────────────────────────────────────────────
 
@@ -532,8 +552,12 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps)
     clubs: "♣",
   };
 
-  return (
-    <div className="freecell">
+  // Cascades split for 2×4 portrait grid layout
+  const cascadesTop = cascades.slice(0, 4);
+  const cascadesBottom = cascades.slice(4, 8);
+
+  const gameContent = (
+    <>
       {showDeckModal && (
         <DeckModal
           appearance={appearance}
@@ -612,62 +636,27 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps)
         </div>
       </div>
 
-      {/* Cascade area */}
-      <div className="freecell__cascades">
-        {cascades.map((col, colIdx) => {
-          const isCascadeValid = validDestinations?.cascadeValid[colIdx] ?? false;
-          // Height: (n-1) slivers * 22px + full card height 72px; or 72 if empty
-          const colHeight = col.length === 0 ? 72 : (col.length - 1) * 22 + 72;
-          return (
-            <div
-              key={colIdx}
-              className={
-                "freecell__cascade" +
-                (isCascadeValid ? " freecell__cascade--valid" : "")
-              }
-              style={{ height: colHeight }}
-              onClick={col.length === 0 ? () => handleEmptyCascadeClick(colIdx) : undefined}
-            >
-              {col.length === 0 ? (
-                <div className="freecell__empty-slot freecell__empty-slot--cascade" />
-              ) : (
-                col.map((card, cardIdx) => {
-                  const isSeqStart = selected?.from === "cascade" &&
-                    selected.colIndex === colIdx &&
-                    selected.cardIndex === cardIdx;
-                  const isInSelected = selected?.from === "cascade" &&
-                    selected.colIndex === colIdx &&
-                    cardIdx >= selected.cardIndex;
-                  const isTop = cardIdx === col.length - 1;
-                  const offsetY = cardIdx * 22;
-
-                  return (
-                    <div
-                      key={card.id}
-                      className={
-                        "freecell__cascade-card" +
-                        (isInSelected ? " freecell__cascade-card--selected" : "") +
-                        (isSeqStart ? " freecell__cascade-card--seq-start" : "")
-                      }
-                      style={{
-                        top: `${offsetY}px`,
-                        zIndex: cardIdx + 1,
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCascadeClick(colIdx, cardIdx);
-                      }}
-                      title={isTop ? `${card.rank} of ${card.suit}` : undefined}
-                    >
-                      <PlayingCard card={card} appearance={appearance} size="sm" />
-                    </div>
-                  );
-                })
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {/* Cascade area — normal 8-column or 2×4 grid */}
+      {isNarrow && portraitLayout === "grid" ? (
+        <>
+          <div className="freecell__cascades">
+            {cascadesTop.map((col, i) => {
+              const colIdx = i;
+              return renderCascadeCol(col, colIdx);
+            })}
+          </div>
+          <div className="freecell__cascades">
+            {cascadesBottom.map((col, i) => {
+              const colIdx = i + 4;
+              return renderCascadeCol(col, colIdx);
+            })}
+          </div>
+        </>
+      ) : (
+        <div className="freecell__cascades">
+          {cascades.map((col, colIdx) => renderCascadeCol(col, colIdx))}
+        </div>
+      )}
 
       {/* Win banner */}
       {phase === "won" && (
@@ -688,6 +677,116 @@ export default function FreeCell({ settings, onNewGame, onQuit }: FreeCellProps)
           </div>
         </div>
       )}
+    </>
+  );
+
+  function renderCascadeCol(col: Card[], colIdx: number) {
+    const isCascadeValid = validDestinations?.cascadeValid[colIdx] ?? false;
+    const colHeight = col.length === 0 ? 72 : (col.length - 1) * 22 + 72;
+    return (
+      <div
+        key={colIdx}
+        className={
+          "freecell__cascade" +
+          (isCascadeValid ? " freecell__cascade--valid" : "")
+        }
+        style={{ height: colHeight }}
+        onClick={col.length === 0 ? () => handleEmptyCascadeClick(colIdx) : undefined}
+      >
+        {col.length === 0 ? (
+          <div className="freecell__empty-slot freecell__empty-slot--cascade" />
+        ) : (
+          col.map((card, cardIdx) => {
+            const isSeqStart = selected?.from === "cascade" &&
+              selected.colIndex === colIdx &&
+              selected.cardIndex === cardIdx;
+            const isInSelected = selected?.from === "cascade" &&
+              selected.colIndex === colIdx &&
+              cardIdx >= selected.cardIndex;
+            const isTop = cardIdx === col.length - 1;
+            const offsetY = cardIdx * 22;
+            return (
+              <div
+                key={card.id}
+                className={
+                  "freecell__cascade-card" +
+                  (isInSelected ? " freecell__cascade-card--selected" : "") +
+                  (isSeqStart ? " freecell__cascade-card--seq-start" : "")
+                }
+                style={{ top: `${offsetY}px`, zIndex: cardIdx + 1 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCascadeClick(colIdx, cardIdx);
+                }}
+                title={isTop ? `${card.rank} of ${card.suit}` : undefined}
+              >
+                <PlayingCard card={card} appearance={appearance} size="sm" />
+              </div>
+            );
+          })
+        )}
+      </div>
+    );
+  }
+
+  if (isNarrow && portraitLayout === "rotate") {
+    // Rotate the game 90° CW so landscape content fills a portrait container.
+    // Container: W×H (portrait). Landscape element: H×W.
+    // After `translateY(H) rotate(90deg)` (rotate first, then translate):
+    //   rotated bounds → x=[0,W], y=[0,H]. Fills container exactly.
+    const gameW = containerSize.h;  // landscape width  = portrait height (H)
+    const gameH = containerSize.w;  // landscape height = portrait width  (W)
+    const wrapHeight = gameW || 400; // outer height = H (portrait height)
+    return (
+      <div
+        ref={wrapperRef}
+        className="freecell-wrapper freecell-wrapper--rotate"
+        style={{ position: "relative", height: wrapHeight, overflow: "hidden" }}
+      >
+        <div className="freecell__portrait-toggle freecell__portrait-toggle--overlay">
+          <button
+            className="freecell__portrait-btn"
+            onClick={() => setPortraitLayout("grid")}
+            title="Switch to 2×4 grid layout"
+          >▦ 2×4</button>
+        </div>
+        <div
+          className="freecell"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: gameW,
+            height: gameH,
+            transform: `translateY(${gameW}px) rotate(90deg)`,
+            transformOrigin: "top left",
+          }}
+        >
+          {gameContent}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={wrapperRef} className="freecell-wrapper">
+      {isNarrow && (
+        <div className="freecell__portrait-toggle">
+          <button
+            className={"freecell__portrait-btn" + (portraitLayout === "rotate" ? " freecell__portrait-btn--active" : "")}
+            onClick={() => setPortraitLayout("rotate")}
+            title="Rotate 90°"
+          >⟳ Rotate</button>
+          <button
+            className={"freecell__portrait-btn" + (portraitLayout === "grid" ? " freecell__portrait-btn--active" : "")}
+            onClick={() => setPortraitLayout("grid")}
+            title="2×4 grid layout"
+          >▦ 2×4</button>
+        </div>
+      )}
+      <div className="freecell">
+        {gameContent}
+      </div>
     </div>
   );
 }

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -16,9 +16,7 @@
 /* ── Stage ───────────────────────────────────────────────────────────── */
 
 .hearts__stage-container {
-  flex: 1;
-  min-height: 200px;
-  position: relative;
+  flex-shrink: 0;
   background: #1a4a1a;
   overflow: hidden;
 }
@@ -27,6 +25,7 @@
   background: #1a4a1a;
   isolation: isolate;
   position: relative;
+  overflow: hidden;
 }
 
 /* ── Player labels ───────────────────────────────────────────────────── */
@@ -37,41 +36,41 @@
   align-items: center;
   gap: 4px;
   font-size: 6px;
-  color: rgba(255, 255, 255, 0.75);
+  color: rgba(255, 255, 255, 0.9);
   white-space: nowrap;
   pointer-events: none;
   z-index: 3000;
 }
 
 .hearts__label--north {
-  top: 4px;
+  top: 88px;   /* just below North's card row (centered at y=52, bottom at y=88) */
   left: 50%;
   transform: translateX(-50%);
 }
 
 .hearts__label--south {
-  bottom: 64px;   /* just above the human hand arc */
+  bottom: 86px;   /* just above human hand (centered at y=460, top at y=424) */
   left: 50%;
   transform: translateX(-50%);
   color: #fff;
 }
 
 .hearts__label--west {
-  left: 4px;
+  left: 68px;   /* just right of West's cards (right edge at ~66px) */
   top: 50%;
   transform: translateY(-50%);
-  flex-direction: column;
-  gap: 2px;
-  font-size: 5px;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  gap: 3px;
 }
 
 .hearts__label--east {
-  right: 4px;
+  right: 68px;   /* just left of East's cards (left edge at ~414px) */
   top: 50%;
   transform: translateY(-50%);
-  flex-direction: column;
-  gap: 2px;
-  font-size: 5px;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  gap: 3px;
 }
 
 .hearts__score-inline {
@@ -135,14 +134,17 @@
 
 .hearts__pass-overlay {
   position: absolute;
-  bottom: 66px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
-  z-index: 3000;
+  gap: 8px;
+  z-index: 6000;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .hearts__pass-hint {
@@ -156,14 +158,16 @@
 
 .hearts__play-hint {
   position: absolute;
-  bottom: 66px;
+  top: 380px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 5px;
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.5);
   white-space: nowrap;
   pointer-events: none;
-  z-index: 3000;
+  z-index: 6000;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 3px 6px;
 }
 
 /* ── Status bar ──────────────────────────────────────────────────────── */

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -40,7 +40,7 @@
   color: rgba(255, 255, 255, 0.75);
   white-space: nowrap;
   pointer-events: none;
-  z-index: 200;
+  z-index: 3000;
 }
 
 .hearts__label--north {
@@ -117,7 +117,7 @@
   align-items: center;
   gap: 5px;
   pointer-events: none;
-  z-index: 50;
+  z-index: 3000;
 }
 
 .hearts__trick-count {
@@ -142,7 +142,7 @@
   flex-direction: column;
   align-items: center;
   gap: 5px;
-  z-index: 200;
+  z-index: 3000;
 }
 
 .hearts__pass-hint {
@@ -163,7 +163,7 @@
   color: rgba(255, 255, 255, 0.4);
   white-space: nowrap;
   pointer-events: none;
-  z-index: 200;
+  z-index: 3000;
 }
 
 /* ── Status bar ──────────────────────────────────────────────────────── */

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -1,75 +1,5 @@
 /* ─── Hearts ──────────────────────────────────────────────────────────── */
 
-/* ── Flying card overlay ─────────────────────────────────────────────── */
-
-@keyframes hearts-fly-card {
-  from {
-    transform: translate(var(--from-tx), var(--from-ty)) rotate(0deg) scale(1.08);
-  }
-  to {
-    transform: translate(var(--to-tx), var(--to-ty)) rotate(var(--land-angle)) scale(1);
-  }
-}
-
-/* 3D flip for AI cards: back → front */
-@keyframes hearts-card-flip {
-  from { transform: rotateY(0deg); }
-  to   { transform: rotateY(180deg); }
-}
-
-.hearts__flying-card {
-  position: absolute;
-  left: 0;
-  top: 0;
-  pointer-events: none;
-  z-index: 60;
-  animation: hearts-fly-card 320ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
-  will-change: transform;
-}
-
-/* Inner flipper — two faces stacked with 3D perspective */
-.hearts__fcard-flipper {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  transform-style: preserve-3d;
-  /* Flip starts halfway through the flight */
-  animation: hearts-card-flip 160ms ease-in-out forwards;
-  animation-delay: 160ms;
-  animation-fill-mode: both;
-}
-
-.hearts__fcard-back,
-.hearts__fcard-front {
-  position: absolute;
-  inset: 0;
-  backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-}
-
-/* Front starts rotated away so back is visible first */
-.hearts__fcard-front {
-  transform: rotateY(180deg);
-}
-
-/* ── Deal fan animation ───────────────────────────────────────────────── */
-
-@keyframes hearts-deal-fan {
-  from {
-    opacity: 0;
-    transform: rotate(var(--fan-angle, 0deg)) translateY(-22px) scale(0.72);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(var(--fan-angle, 0deg)) translateY(0px) scale(1);
-  }
-}
-
-@keyframes hearts-trick-play {
-  from { opacity: 0; transform: scale(0.65) translateY(-12px); }
-  to   { opacity: 1; transform: scale(1)    translateY(0); }
-}
-
 /* ── Outer shell ─────────────────────────────────────────────────────── */
 
 .hearts {
@@ -79,97 +9,86 @@
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
   user-select: none;
-  position: relative;
-  /* Fill whatever container the window gives us */
-  min-height: 420px;
-  height: 100%;
-}
-
-/* ── Felt table — all children absolutely positioned ─────────────────── */
-
-.hearts__table {
   flex: 1;
-  background: #1a4a1a;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
-  margin: 6px 6px 4px;
+  min-height: 0;
+}
+
+/* ── Stage ───────────────────────────────────────────────────────────── */
+
+.hearts__stage-container {
+  flex: 1;
+  min-height: 200px;
   position: relative;
+  background: #1a4a1a;
   overflow: hidden;
-  min-height: 360px;
 }
 
-/* ── Zones ───────────────────────────────────────────────────────────── */
-
-.hearts__zone {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-}
-
-.hearts__zone--north {
-  top: 7px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.hearts__zone--south {
-  bottom: 6px;
-  left: 50%;
-  transform: translateX(-50%);
-  gap: 4px;
-}
-
-.hearts__zone--west {
-  left: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.hearts__zone--east {
-  right: 6px;
-  top: 50%;
-  transform: translateY(-50%);
+.hearts__stage {
+  background: #1a4a1a;
+  isolation: isolate;
+  position: relative;
 }
 
 /* ── Player labels ───────────────────────────────────────────────────── */
 
-.hearts__player-label {
-  font-size: 6px;
-  color: #ffffff;
+.hearts__label {
+  position: absolute;
   display: flex;
   align-items: center;
   gap: 4px;
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.75);
   white-space: nowrap;
+  pointer-events: none;
+  z-index: 200;
 }
 
-.hearts__player-label--ai {
-  color: rgba(255, 255, 255, 0.65);
+.hearts__label--north {
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
-.hearts__player-label--side {
+.hearts__label--south {
+  bottom: 64px;   /* just above the human hand arc */
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+}
+
+.hearts__label--west {
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
   flex-direction: column;
   gap: 2px;
-  align-items: center;
+  font-size: 5px;
+}
+
+.hearts__label--east {
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: column;
+  gap: 2px;
   font-size: 5px;
 }
 
 .hearts__score-inline {
   font-size: 5px;
   color: rgba(255, 255, 255, 0.45);
-  margin-left: 4px;
 }
 
-.hearts__hand-score-badge {
+.hearts__badge {
   font-size: 5px;
   color: #ff9944;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.35);
   padding: 1px 3px;
   border-radius: 2px;
 }
 
-/* Turn dot */
+/* ── Turn dot ────────────────────────────────────────────────────────── */
+
 .hearts__turn-dot {
   width: 5px;
   height: 5px;
@@ -186,186 +105,70 @@
   50%       { opacity: 0.3; }
 }
 
-/* ── AI fans ─────────────────────────────────────────────────────────── */
+/* ── Center info ─────────────────────────────────────────────────────── */
 
-.hearts__ai-fan {
-  display: flex;
-}
-
-/* North: horizontal overlap */
-.hearts__ai-fan--horiz {
-  flex-direction: row;
-  align-items: center;
-}
-
-.hearts__ai-fan--horiz .playing-card--sm + .playing-card--sm {
-  margin-left: calc(-1 * var(--ai-overlap, 28px));
-}
-
-/* West / East: vertical overlap, max 8 visible */
-.hearts__ai-fan--vert {
-  flex-direction: column;
-  align-items: center;
-}
-
-.hearts__ai-fan--vert .playing-card--sm + .playing-card--sm {
-  margin-top: -58px;
-}
-
-.hearts__ai-extra {
-  font-size: 5px;
-  color: rgba(255, 255, 255, 0.5);
-  margin-top: 2px;
-  text-align: center;
-}
-
-/* ── Trick area ──────────────────────────────────────────────────────── */
-
-.hearts__trick-area {
+.hearts__center-info {
   position: absolute;
-  top: 50%;
   left: 50%;
+  top: 50%;
   transform: translate(-50%, -50%);
-  /* 3-column grid: west | center | east */
-  display: grid;
-  grid-template-columns: 60px 56px 60px;
-  grid-template-rows: 80px 52px 80px;
-  align-items: center;
-  justify-items: center;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 5px;
-  padding: 6px;
-}
-
-.hearts__trick-slot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 56px;
-  height: 76px;
-}
-
-.hearts__trick-slot--n { grid-column: 2; grid-row: 1; }
-.hearts__trick-slot--w { grid-column: 1; grid-row: 2; }
-.hearts__trick-center-info {
-  grid-column: 2;
-  grid-row: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-}
-.hearts__trick-slot--e { grid-column: 3; grid-row: 2; }
-.hearts__trick-slot--s { grid-column: 2; grid-row: 3; }
-
-.hearts__trick-card {
-  /* Delay slightly so the flying card overlay arrives before the real card appears */
-  animation: hearts-trick-play 0.16s ease backwards;
-  animation-delay: 0.26s;
+  gap: 5px;
+  pointer-events: none;
+  z-index: 50;
 }
 
 .hearts__trick-count {
   font-size: 6px;
-  color: rgba(255, 255, 255, 0.55);
-  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .hearts__broken {
-  font-size: 13px;
+  font-size: 14px;
   color: #ff4444;
   line-height: 1;
 }
 
-/* ── Human fan hand ──────────────────────────────────────────────────── */
+/* ── Passing overlay ─────────────────────────────────────────────────── */
 
-.hearts__human-hand {
+.hearts__pass-overlay {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  justify-content: center;
-  /* padding-bottom leaves room for cards that arc up at edges */
-  padding: 4px 8px 16px;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  z-index: 200;
 }
-
-.hearts__fan-item {
-  position: relative;
-  flex-shrink: 0;
-  /* Pivot below card bottom for natural fan arc */
-  transform-origin: center 115%;
-  transform: rotate(var(--fan-angle, 0deg)) translateY(0px);
-  transition: transform 0.12s ease, z-index 0s;
-  /* Deal-in animation — plays once on mount */
-  animation: hearts-deal-fan 0.24s ease backwards;
-  animation-delay: calc(var(--fan-i, 0) * 44ms);
-}
-
-.hearts__fan-item + .hearts__fan-item {
-  margin-left: calc(-1 * var(--hand-overlap, 0px));
-}
-
-/* Hover lift (non-selected, clickable) */
-.hearts__fan-item--clickable:hover:not(.hearts__fan-item--selected) {
-  transform: rotate(var(--fan-angle, 0deg)) translateY(-9px);
-  z-index: 15 !important;
-}
-
-/* Selected — lift further + subtle scale */
-.hearts__fan-item--selected {
-  transform: rotate(var(--fan-angle, 0deg)) translateY(-20px) scale(1.04) !important;
-}
-
-/* Valid play outline */
-.hearts__fan-item--valid .playing-card {
-  box-shadow: 0 0 0 2px #ffdd44, 0 0 8px rgba(255, 221, 68, 0.5);
-}
-
-/* Selected glow */
-.hearts__fan-item--selected .playing-card {
-  box-shadow: 0 0 0 2px #ff6600, 0 0 10px rgba(255, 102, 0, 0.65);
-}
-
-/* Received card in passing phase */
-.hearts__fan-item--received .playing-card {
-  box-shadow: 0 0 0 2px #9966cc, 0 0 8px rgba(153, 102, 204, 0.5);
-}
-
-.hearts__fan-item--clickable { cursor: pointer; }
-
-/* Passing phase: slightly wider spread */
-.hearts__human-hand--passing .hearts__fan-item + .hearts__fan-item {
-  margin-left: calc(-1 * max(0px, var(--hand-overlap, 0px) - 10px));
-}
-
-/* ── Passing hints ───────────────────────────────────────────────────── */
 
 .hearts__pass-hint {
   font-size: 6px;
   color: #ffdd88;
-  text-align: center;
-  padding: 1px 0;
   white-space: nowrap;
-}
-
-.hearts__pass-actions {
-  display: flex;
-  gap: 8px;
-  justify-content: center;
+  text-align: center;
 }
 
 /* ── Play hint ───────────────────────────────────────────────────────── */
 
 .hearts__play-hint {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 5px;
-  color: rgba(255, 255, 255, 0.45);
-  text-align: center;
-  height: 11px;
+  color: rgba(255, 255, 255, 0.4);
   white-space: nowrap;
+  pointer-events: none;
+  z-index: 200;
 }
 
 /* ── Status bar ──────────────────────────────────────────────────────── */
 
-.hearts__status-bar {
+.hearts__statusbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -373,6 +176,7 @@
   font-size: 6px;
   color: #000;
   border-top: 1px solid #808080;
+  background: #c0c0c0;
   gap: 8px;
   flex-wrap: wrap;
   flex-shrink: 0;
@@ -384,9 +188,7 @@
   flex-wrap: wrap;
 }
 
-.hearts__score-item {
-  white-space: nowrap;
-}
+.hearts__score-item { white-space: nowrap; }
 
 /* ── Buttons ─────────────────────────────────────────────────────────── */
 
@@ -416,8 +218,8 @@
   font-size: 6px;
 }
 
-.hearts-btn--sm:hover:not(:disabled)  { background: #d4d0c8; }
-.hearts-btn--sm:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
+.hearts-btn--sm:hover  { background: #d4d0c8; }
+.hearts-btn--sm:active { border-color: #808080 #ffffff #ffffff #808080; }
 
 /* ── Modal ───────────────────────────────────────────────────────────── */
 
@@ -428,7 +230,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 1000;
 }
 
 .hearts-modal {

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -1,5 +1,59 @@
 /* ─── Hearts ──────────────────────────────────────────────────────────── */
 
+/* ── Flying card overlay ─────────────────────────────────────────────── */
+
+@keyframes hearts-fly-card {
+  from {
+    transform: translate(var(--from-tx), var(--from-ty)) rotate(0deg) scale(1.08);
+  }
+  to {
+    transform: translate(var(--to-tx), var(--to-ty)) rotate(var(--land-angle)) scale(1);
+  }
+}
+
+/* 3D flip for AI cards: back → front */
+@keyframes hearts-card-flip {
+  from { transform: rotateY(0deg); }
+  to   { transform: rotateY(180deg); }
+}
+
+.hearts__flying-card {
+  position: absolute;
+  left: 0;
+  top: 0;
+  pointer-events: none;
+  z-index: 60;
+  animation: hearts-fly-card 320ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  will-change: transform;
+}
+
+/* Inner flipper — two faces stacked with 3D perspective */
+.hearts__fcard-flipper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  /* Flip starts halfway through the flight */
+  animation: hearts-card-flip 160ms ease-in-out forwards;
+  animation-delay: 160ms;
+  animation-fill-mode: both;
+}
+
+.hearts__fcard-back,
+.hearts__fcard-front {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+/* Front starts rotated away so back is visible first */
+.hearts__fcard-front {
+  transform: rotateY(180deg);
+}
+
+/* ── Deal fan animation ───────────────────────────────────────────────── */
+
 @keyframes hearts-deal-fan {
   from {
     opacity: 0;
@@ -206,7 +260,9 @@
 .hearts__trick-slot--s { grid-column: 2; grid-row: 3; }
 
 .hearts__trick-card {
-  animation: hearts-trick-play 0.18s ease backwards;
+  /* Delay slightly so the flying card overlay arrives before the real card appears */
+  animation: hearts-trick-play 0.16s ease backwards;
+  animation-delay: 0.26s;
 }
 
 .hearts__trick-count {

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -1,0 +1,420 @@
+/* ─── Hearts ──────────────────────────────────────────────────────────── */
+
+.hearts {
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+  min-height: 480px;
+  position: relative;
+}
+
+/* ── Table (felt) ────────────────────────────────────────────────────── */
+
+.hearts__table {
+  flex: 1;
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 6px 6px 4px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 400px;
+  position: relative;
+}
+
+/* ── North (AI top) ──────────────────────────────────────────────────── */
+
+.hearts__north {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ── Middle row ──────────────────────────────────────────────────────── */
+
+.hearts__middle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── West / East AI ──────────────────────────────────────────────────── */
+
+.hearts__west,
+.hearts__east {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  min-width: 60px;
+}
+
+/* ── Center trick area ───────────────────────────────────────────────── */
+
+.hearts__center {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 88px auto 88px;
+  grid-template-rows: auto auto auto;
+  gap: 6px;
+  align-items: center;
+  justify-items: center;
+  min-height: 240px;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 8px;
+}
+
+.hearts__trick-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 108px;
+}
+
+.hearts__trick-slot--north  { grid-column: 2; grid-row: 1; }
+.hearts__trick-slot--west   { grid-column: 1; grid-row: 2; }
+.hearts__trick-center       { grid-column: 2; grid-row: 2; display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.hearts__trick-slot--east   { grid-column: 3; grid-row: 2; }
+.hearts__trick-slot--south  { grid-column: 2; grid-row: 3; }
+
+.hearts__trick-count {
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.6);
+  white-space: nowrap;
+}
+
+.hearts__broken {
+  font-size: 14px;
+  color: #ff4444;
+  line-height: 1;
+}
+
+/* ── South (Human) ───────────────────────────────────────────────────── */
+
+.hearts__south {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ── Player labels ───────────────────────────────────────────────────── */
+
+.hearts__player-label {
+  font-size: 6px;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.hearts__player-label--ai {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hearts__score-inline {
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-left: 6px;
+}
+
+.hearts__hand-score {
+  font-size: 6px;
+  color: #ff9944;
+  min-height: 10px;
+}
+
+/* Turn indicator dot */
+.hearts__turn-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffdd44;
+  flex-shrink: 0;
+  animation: hearts-pulse 1s ease-in-out infinite;
+}
+
+.hearts__turn-dot--human {
+  background: #ff8844;
+}
+
+@keyframes hearts-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.35; }
+}
+
+/* ── AI hands (face-down rows/columns) ───────────────────────────────── */
+
+.hearts__ai-hand {
+  display: flex;
+}
+
+.hearts__ai-hand--horiz {
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+
+.hearts__ai-hand--horiz .playing-card--sm + .playing-card--sm {
+  margin-left: -30px;
+}
+
+.hearts__ai-hand--vert {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: center;
+}
+
+.hearts__ai-hand--vert .playing-card--sm + .playing-card--sm {
+  margin-top: -44px;
+}
+
+/* ── Human hand ──────────────────────────────────────────────────────── */
+
+.hearts__human-hand {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 4px 8px 2px;
+}
+
+.hearts__human-hand .hearts__card-wrap + .hearts__card-wrap {
+  margin-left: -20px;
+}
+
+/* Extra spacing in passing phase so cards don't feel cramped */
+.hearts__human-hand--passing .hearts__card-wrap + .hearts__card-wrap {
+  margin-left: -12px;
+}
+
+/* ── Card wrappers (selection / validity) ────────────────────────────── */
+
+.hearts__card-wrap {
+  position: relative;
+  transition: transform 0.12s ease;
+}
+
+.hearts__card-wrap--clickable {
+  cursor: pointer;
+}
+
+.hearts__card-wrap--clickable:hover {
+  transform: translateY(-8px);
+  z-index: 2;
+}
+
+/* Valid play — yellow glow */
+.hearts__card-wrap--valid .playing-card {
+  box-shadow: 0 0 0 2px #ffdd44, 0 0 8px rgba(255, 221, 68, 0.6);
+}
+
+/* Selected — orange glow + lifted */
+.hearts__card-wrap--selected {
+  transform: translateY(-14px) !important;
+  z-index: 5;
+}
+
+.hearts__card-wrap--selected .playing-card {
+  box-shadow: 0 0 0 2px #ff6600, 0 0 10px rgba(255, 102, 0, 0.7);
+}
+
+/* Newly received card in passing phase — subtle purple highlight */
+.hearts__card-wrap--received .playing-card {
+  box-shadow: 0 0 0 2px #9966cc, 0 0 8px rgba(153, 102, 204, 0.5);
+}
+
+/* ── Passing hints ───────────────────────────────────────────────────── */
+
+.hearts__pass-hint {
+  font-size: 6px;
+  color: #ffdd88;
+  text-align: center;
+  padding: 2px 0;
+}
+
+.hearts__pass-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 2px;
+}
+
+/* ── Play hint ───────────────────────────────────────────────────────── */
+
+.hearts__play-hint {
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.5);
+  text-align: center;
+  height: 12px;
+}
+
+/* ── Status bar ──────────────────────────────────────────────────────── */
+
+.hearts__status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-size: 6px;
+  color: #000;
+  border-top: 1px solid #808080;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.hearts__scores-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.hearts__score-item {
+  white-space: nowrap;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────── */
+
+.hearts-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  border: 2px solid;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.hearts-btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  padding: 6px 12px;
+}
+
+.hearts-btn--primary:hover { background: #ee5500; }
+.hearts-btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+
+.hearts-btn--sm {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 3px 7px;
+  font-size: 6px;
+}
+
+.hearts-btn--sm:hover:not(:disabled) { background: #d4d0c8; }
+.hearts-btn--sm:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
+
+/* ── Modal ───────────────────────────────────────────────────────────── */
+
+.hearts-modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.hearts-modal {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.5);
+  min-width: 260px;
+  max-width: 340px;
+}
+
+.hearts-modal__titlebar {
+  background: linear-gradient(to right, #cc4400, #881a00);
+  color: #fff;
+  font-size: 8px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hearts-modal__close {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  color: #000;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.hearts-modal__close:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.hearts-modal__body {
+  padding: 12px 16px;
+}
+
+.hearts-modal__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 7px;
+}
+
+.hearts-modal__table th,
+.hearts-modal__table td {
+  padding: 4px 8px;
+  text-align: center;
+  border-bottom: 1px solid #808080;
+}
+
+.hearts-modal__table th {
+  font-size: 6px;
+  color: #444;
+  border-bottom: 2px solid #808080;
+}
+
+.hearts-modal__table td:first-child {
+  text-align: left;
+  font-size: 6px;
+  color: #333;
+}
+
+.hearts-modal__winner-row td {
+  color: #228833;
+  font-weight: normal;
+}
+
+.hearts-modal__winner-label {
+  font-size: 6px;
+  color: #228833;
+  white-space: nowrap;
+}
+
+.hearts-modal__moon {
+  color: #5b2d8e;
+}
+
+.hearts-modal__footer {
+  padding: 8px 16px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  border-top: 1px solid #808080;
+}

--- a/src/experiences/Cards/Hearts.css
+++ b/src/experiences/Cards/Hearts.css
@@ -1,5 +1,23 @@
 /* ─── Hearts ──────────────────────────────────────────────────────────── */
 
+@keyframes hearts-deal-fan {
+  from {
+    opacity: 0;
+    transform: rotate(var(--fan-angle, 0deg)) translateY(-22px) scale(0.72);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(var(--fan-angle, 0deg)) translateY(0px) scale(1);
+  }
+}
+
+@keyframes hearts-trick-play {
+  from { opacity: 0; transform: scale(0.65) translateY(-12px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+
+/* ── Outer shell ─────────────────────────────────────────────────────── */
+
 .hearts {
   display: flex;
   flex-direction: column;
@@ -7,11 +25,13 @@
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
   user-select: none;
-  min-height: 480px;
   position: relative;
+  /* Fill whatever container the window gives us */
+  min-height: 420px;
+  height: 100%;
 }
 
-/* ── Table (felt) ────────────────────────────────────────────────────── */
+/* ── Felt table — all children absolutely positioned ─────────────────── */
 
 .hearts__table {
   flex: 1;
@@ -19,93 +39,44 @@
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   margin: 6px 6px 4px;
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 400px;
   position: relative;
+  overflow: hidden;
+  min-height: 360px;
 }
 
-/* ── North (AI top) ──────────────────────────────────────────────────── */
+/* ── Zones ───────────────────────────────────────────────────────────── */
 
-.hearts__north {
+.hearts__zone {
+  position: absolute;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 3px;
 }
 
-/* ── Middle row ──────────────────────────────────────────────────────── */
-
-.hearts__middle {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.hearts__zone--north {
+  top: 7px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
-/* ── West / East AI ──────────────────────────────────────────────────── */
-
-.hearts__west,
-.hearts__east {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  min-width: 60px;
-}
-
-/* ── Center trick area ───────────────────────────────────────────────── */
-
-.hearts__center {
-  flex: 1;
-  display: grid;
-  grid-template-columns: 88px auto 88px;
-  grid-template-rows: auto auto auto;
-  gap: 6px;
-  align-items: center;
-  justify-items: center;
-  min-height: 240px;
-  background: rgba(0, 0, 0, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-  padding: 8px;
-}
-
-.hearts__trick-slot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 80px;
-  height: 108px;
-}
-
-.hearts__trick-slot--north  { grid-column: 2; grid-row: 1; }
-.hearts__trick-slot--west   { grid-column: 1; grid-row: 2; }
-.hearts__trick-center       { grid-column: 2; grid-row: 2; display: flex; flex-direction: column; align-items: center; gap: 4px; }
-.hearts__trick-slot--east   { grid-column: 3; grid-row: 2; }
-.hearts__trick-slot--south  { grid-column: 2; grid-row: 3; }
-
-.hearts__trick-count {
-  font-size: 7px;
-  color: rgba(255, 255, 255, 0.6);
-  white-space: nowrap;
-}
-
-.hearts__broken {
-  font-size: 14px;
-  color: #ff4444;
-  line-height: 1;
-}
-
-/* ── South (Human) ───────────────────────────────────────────────────── */
-
-.hearts__south {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+.hearts__zone--south {
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
   gap: 4px;
+}
+
+.hearts__zone--west {
+  left: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.hearts__zone--east {
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 /* ── Player labels ───────────────────────────────────────────────────── */
@@ -115,124 +86,199 @@
   color: #ffffff;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   white-space: nowrap;
 }
 
 .hearts__player-label--ai {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.hearts__player-label--side {
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  font-size: 5px;
 }
 
 .hearts__score-inline {
-  font-size: 6px;
-  color: rgba(255, 255, 255, 0.55);
-  margin-left: 6px;
+  font-size: 5px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-left: 4px;
 }
 
-.hearts__hand-score {
-  font-size: 6px;
+.hearts__hand-score-badge {
+  font-size: 5px;
   color: #ff9944;
-  min-height: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1px 3px;
+  border-radius: 2px;
 }
 
-/* Turn indicator dot */
+/* Turn dot */
 .hearts__turn-dot {
-  width: 6px;
-  height: 6px;
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
   background: #ffdd44;
   flex-shrink: 0;
   animation: hearts-pulse 1s ease-in-out infinite;
 }
 
-.hearts__turn-dot--human {
-  background: #ff8844;
-}
+.hearts__turn-dot--human { background: #ff8844; }
 
 @keyframes hearts-pulse {
   0%, 100% { opacity: 1; }
-  50%       { opacity: 0.35; }
+  50%       { opacity: 0.3; }
 }
 
-/* ── AI hands (face-down rows/columns) ───────────────────────────────── */
+/* ── AI fans ─────────────────────────────────────────────────────────── */
 
-.hearts__ai-hand {
+.hearts__ai-fan {
   display: flex;
 }
 
-.hearts__ai-hand--horiz {
+/* North: horizontal overlap */
+.hearts__ai-fan--horiz {
   flex-direction: row;
-  flex-wrap: nowrap;
-}
-
-.hearts__ai-hand--horiz .playing-card--sm + .playing-card--sm {
-  margin-left: -30px;
-}
-
-.hearts__ai-hand--vert {
-  flex-direction: column;
-  flex-wrap: nowrap;
   align-items: center;
 }
 
-.hearts__ai-hand--vert .playing-card--sm + .playing-card--sm {
-  margin-top: -44px;
+.hearts__ai-fan--horiz .playing-card--sm + .playing-card--sm {
+  margin-left: calc(-1 * var(--ai-overlap, 28px));
 }
 
-/* ── Human hand ──────────────────────────────────────────────────────── */
+/* West / East: vertical overlap, max 8 visible */
+.hearts__ai-fan--vert {
+  flex-direction: column;
+  align-items: center;
+}
+
+.hearts__ai-fan--vert .playing-card--sm + .playing-card--sm {
+  margin-top: -58px;
+}
+
+.hearts__ai-extra {
+  font-size: 5px;
+  color: rgba(255, 255, 255, 0.5);
+  margin-top: 2px;
+  text-align: center;
+}
+
+/* ── Trick area ──────────────────────────────────────────────────────── */
+
+.hearts__trick-area {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  /* 3-column grid: west | center | east */
+  display: grid;
+  grid-template-columns: 60px 56px 60px;
+  grid-template-rows: 80px 52px 80px;
+  align-items: center;
+  justify-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  padding: 6px;
+}
+
+.hearts__trick-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 76px;
+}
+
+.hearts__trick-slot--n { grid-column: 2; grid-row: 1; }
+.hearts__trick-slot--w { grid-column: 1; grid-row: 2; }
+.hearts__trick-center-info {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.hearts__trick-slot--e { grid-column: 3; grid-row: 2; }
+.hearts__trick-slot--s { grid-column: 2; grid-row: 3; }
+
+.hearts__trick-card {
+  animation: hearts-trick-play 0.18s ease backwards;
+}
+
+.hearts__trick-count {
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+}
+
+.hearts__broken {
+  font-size: 13px;
+  color: #ff4444;
+  line-height: 1;
+}
+
+/* ── Human fan hand ──────────────────────────────────────────────────── */
 
 .hearts__human-hand {
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: center;
   align-items: flex-end;
-  padding: 4px 8px 2px;
+  justify-content: center;
+  /* padding-bottom leaves room for cards that arc up at edges */
+  padding: 4px 8px 16px;
 }
 
-.hearts__human-hand .hearts__card-wrap + .hearts__card-wrap {
-  margin-left: -20px;
-}
-
-/* Extra spacing in passing phase so cards don't feel cramped */
-.hearts__human-hand--passing .hearts__card-wrap + .hearts__card-wrap {
-  margin-left: -12px;
-}
-
-/* ── Card wrappers (selection / validity) ────────────────────────────── */
-
-.hearts__card-wrap {
+.hearts__fan-item {
   position: relative;
-  transition: transform 0.12s ease;
+  flex-shrink: 0;
+  /* Pivot below card bottom for natural fan arc */
+  transform-origin: center 115%;
+  transform: rotate(var(--fan-angle, 0deg)) translateY(0px);
+  transition: transform 0.12s ease, z-index 0s;
+  /* Deal-in animation — plays once on mount */
+  animation: hearts-deal-fan 0.24s ease backwards;
+  animation-delay: calc(var(--fan-i, 0) * 44ms);
 }
 
-.hearts__card-wrap--clickable {
-  cursor: pointer;
+.hearts__fan-item + .hearts__fan-item {
+  margin-left: calc(-1 * var(--hand-overlap, 0px));
 }
 
-.hearts__card-wrap--clickable:hover {
-  transform: translateY(-8px);
-  z-index: 2;
+/* Hover lift (non-selected, clickable) */
+.hearts__fan-item--clickable:hover:not(.hearts__fan-item--selected) {
+  transform: rotate(var(--fan-angle, 0deg)) translateY(-9px);
+  z-index: 15 !important;
 }
 
-/* Valid play — yellow glow */
-.hearts__card-wrap--valid .playing-card {
-  box-shadow: 0 0 0 2px #ffdd44, 0 0 8px rgba(255, 221, 68, 0.6);
+/* Selected — lift further + subtle scale */
+.hearts__fan-item--selected {
+  transform: rotate(var(--fan-angle, 0deg)) translateY(-20px) scale(1.04) !important;
 }
 
-/* Selected — orange glow + lifted */
-.hearts__card-wrap--selected {
-  transform: translateY(-14px) !important;
-  z-index: 5;
+/* Valid play outline */
+.hearts__fan-item--valid .playing-card {
+  box-shadow: 0 0 0 2px #ffdd44, 0 0 8px rgba(255, 221, 68, 0.5);
 }
 
-.hearts__card-wrap--selected .playing-card {
-  box-shadow: 0 0 0 2px #ff6600, 0 0 10px rgba(255, 102, 0, 0.7);
+/* Selected glow */
+.hearts__fan-item--selected .playing-card {
+  box-shadow: 0 0 0 2px #ff6600, 0 0 10px rgba(255, 102, 0, 0.65);
 }
 
-/* Newly received card in passing phase — subtle purple highlight */
-.hearts__card-wrap--received .playing-card {
+/* Received card in passing phase */
+.hearts__fan-item--received .playing-card {
   box-shadow: 0 0 0 2px #9966cc, 0 0 8px rgba(153, 102, 204, 0.5);
+}
+
+.hearts__fan-item--clickable { cursor: pointer; }
+
+/* Passing phase: slightly wider spread */
+.hearts__human-hand--passing .hearts__fan-item + .hearts__fan-item {
+  margin-left: calc(-1 * max(0px, var(--hand-overlap, 0px) - 10px));
 }
 
 /* ── Passing hints ───────────────────────────────────────────────────── */
@@ -241,23 +287,24 @@
   font-size: 6px;
   color: #ffdd88;
   text-align: center;
-  padding: 2px 0;
+  padding: 1px 0;
+  white-space: nowrap;
 }
 
 .hearts__pass-actions {
   display: flex;
   gap: 8px;
   justify-content: center;
-  margin-top: 2px;
 }
 
 /* ── Play hint ───────────────────────────────────────────────────────── */
 
 .hearts__play-hint {
-  font-size: 6px;
-  color: rgba(255, 255, 255, 0.5);
+  font-size: 5px;
+  color: rgba(255, 255, 255, 0.45);
   text-align: center;
-  height: 12px;
+  height: 11px;
+  white-space: nowrap;
 }
 
 /* ── Status bar ──────────────────────────────────────────────────────── */
@@ -272,11 +319,12 @@
   border-top: 1px solid #808080;
   gap: 8px;
   flex-wrap: wrap;
+  flex-shrink: 0;
 }
 
 .hearts__scores-row {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -301,7 +349,7 @@
   padding: 6px 12px;
 }
 
-.hearts-btn--primary:hover { background: #ee5500; }
+.hearts-btn--primary:hover  { background: #ee5500; }
 .hearts-btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
 
 .hearts-btn--sm {
@@ -312,7 +360,7 @@
   font-size: 6px;
 }
 
-.hearts-btn--sm:hover:not(:disabled) { background: #d4d0c8; }
+.hearts-btn--sm:hover:not(:disabled)  { background: #d4d0c8; }
 .hearts-btn--sm:active:not(:disabled) { border-color: #808080 #ffffff #ffffff #808080; }
 
 /* ── Modal ───────────────────────────────────────────────────────────── */
@@ -363,13 +411,9 @@
   line-height: 1;
 }
 
-.hearts-modal__close:active {
-  border-color: #808080 #ffffff #ffffff #808080;
-}
+.hearts-modal__close:active { border-color: #808080 #ffffff #ffffff #808080; }
 
-.hearts-modal__body {
-  padding: 12px 16px;
-}
+.hearts-modal__body { padding: 12px 16px; }
 
 .hearts-modal__table {
   width: 100%;
@@ -396,10 +440,7 @@
   color: #333;
 }
 
-.hearts-modal__winner-row td {
-  color: #228833;
-  font-weight: normal;
-}
+.hearts-modal__winner-row td { color: #228833; }
 
 .hearts-modal__winner-label {
   font-size: 6px;
@@ -407,9 +448,7 @@
   white-space: nowrap;
 }
 
-.hearts-modal__moon {
-  color: #5b2d8e;
-}
+.hearts-modal__moon { color: #5b2d8e; }
 
 .hearts-modal__footer {
   padding: 8px 16px;

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -1,0 +1,881 @@
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import "./Hearts.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
+import {
+  dealHands,
+  getValidHeartPlays,
+  resolveTrick,
+  trickPoints,
+  rankValue,
+  type TrickPlay,
+} from "./trickTakingEngine";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { DeckModal } from "./DeckModal";
+
+// ── Deck helpers ──────────────────────────────────────────────────────────────
+
+const RANKS_ORD = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"] as const;
+const ALL_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function buildDeck(): Card[] {
+  const cards: Card[] = [];
+  for (const suit of ALL_SUITS) {
+    for (const rank of RANKS_ORD) {
+      cards.push({ suit, rank, id: `${suit}-${rank}` });
+    }
+  }
+  return shuffle(cards);
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type HeartsPhase =
+  | "passing"
+  | "playing"
+  | "trick-end"
+  | "hand-end"
+  | "game-over";
+
+type PassDir = "left" | "right" | "across" | "none";
+
+interface HeartsState {
+  hands: Card[][];
+  scores: number[];
+  handScores: number[];
+  phase: HeartsPhase;
+  passDir: PassDir;
+  passedCards: Card[];
+  receivedCards: Card[];
+  currentTrick: TrickPlay[];
+  ledSuit: Suit | null;
+  trickLeader: number;
+  currentPlayer: number;
+  heartsAreBroken: boolean;
+  isFirstTrick: boolean;
+  tricksThisHand: number;
+  handNumber: number;
+  selectedCard: string | null;
+}
+
+const PLAYER_NAMES = ["You", "West", "North", "East"];
+
+function passDirection(handNumber: number): PassDir {
+  const dirs: PassDir[] = ["left", "right", "across", "none"];
+  return dirs[handNumber % 4];
+}
+
+function passTarget(from: number, dir: PassDir): number {
+  if (dir === "left")   return (from + 1) % 4;
+  if (dir === "right")  return (from + 3) % 4;
+  if (dir === "across") return (from + 2) % 4;
+  return from;
+}
+
+// ── AI Helpers ────────────────────────────────────────────────────────────────
+
+/** Score a card for "how bad is it to keep" — higher = pass first */
+function problemScore(card: Card): number {
+  if (card.suit === "spades") {
+    if (card.rank === "A") return 200;
+    if (card.rank === "K") return 180;
+    if (card.rank === "Q") return 160;
+  }
+  if (card.suit === "hearts") return 100 + rankValue(card.rank as string);
+  // high spades (J, 10, 9, 8 = bad supports)
+  if (card.suit === "spades") return rankValue(card.rank as string);
+  return 0;
+}
+
+function aiSelectCardsToPass(hand: Card[]): Card[] {
+  const sorted = [...hand].sort((a, b) => problemScore(b) - problemScore(a));
+  return sorted.slice(0, 3);
+}
+
+function aiChooseCard(
+  valid: Card[],
+  trick: TrickPlay[],
+  ledSuit: Suit | null,
+): Card {
+  // Leading
+  if (trick.length === 0 || ledSuit === null) {
+    // Lead lowest non-heart if possible
+    const nonHearts = valid.filter((c) => c.suit !== "hearts");
+    const pool = nonHearts.length > 0 ? nonHearts : valid;
+    return pool.reduce((best, c) =>
+      rankValue(c.rank as string) < rankValue(best.rank as string) ? c : best
+    );
+  }
+
+  // Following suit
+  const canFollowSuit = valid.some((c) => c.suit === ledSuit);
+  if (canFollowSuit) {
+    const suitCards = valid.filter((c) => c.suit === ledSuit);
+    // Find current winner value
+    let winnerVal = -1;
+    for (const play of trick) {
+      if (play.card.suit === ledSuit) {
+        const v = rankValue(play.card.rank as string);
+        if (v > winnerVal) winnerVal = v;
+      }
+    }
+    // Try to play highest card that won't win, or lowest if all would win
+    const losers = suitCards.filter((c) => rankValue(c.rank as string) < winnerVal);
+    if (losers.length > 0) {
+      return losers.reduce((best, c) =>
+        rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
+      );
+    }
+    // All cards win or no hearts broken — play lowest
+    return suitCards.reduce((best, c) =>
+      rankValue(c.rank as string) < rankValue(best.rank as string) ? c : best
+    );
+  }
+
+  // Can't follow suit — discard
+  // Dump Q♠ first
+  const qs = valid.find((c) => c.suit === "spades" && c.rank === "Q");
+  if (qs) return qs;
+  // Highest heart
+  const hearts = valid.filter((c) => c.suit === "hearts");
+  if (hearts.length > 0) {
+    return hearts.reduce((best, c) =>
+      rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
+    );
+  }
+  // Highest remaining
+  return valid.reduce((best, c) =>
+    rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
+  );
+}
+
+// ── Shoot the moon check ──────────────────────────────────────────────────────
+
+function applyHandScores(
+  handScores: number[],
+  cumulativeScores: number[],
+): number[] {
+  // Check shoot the moon: did any player score all 26?
+  const moonShooterIdx = handScores.findIndex((s) => s === 26);
+  if (moonShooterIdx !== -1) {
+    return cumulativeScores.map((s, i) => (i === moonShooterIdx ? s : s + 26));
+  }
+  return cumulativeScores.map((s, i) => s + handScores[i]);
+}
+
+// ── Initial state factory ─────────────────────────────────────────────────────
+
+function makeInitialState(handNumber: number, prevScores: number[]): HeartsState {
+  const deck = buildDeck();
+  const hands = dealHands(deck, 4);
+  // Sort hands for display: by suit then rank
+  const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
+  const sortHand = (hand: Card[]) =>
+    [...hand].sort((a, b) => {
+      const sd = suitOrder[a.suit] - suitOrder[b.suit];
+      if (sd !== 0) return sd;
+      return rankValue(a.rank as string) - rankValue(b.rank as string);
+    });
+
+  const dir = passDirection(handNumber);
+
+  // Find who has 2♣
+  let trickLeader = 0;
+  for (let i = 0; i < 4; i++) {
+    if (hands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
+      trickLeader = i;
+      break;
+    }
+  }
+
+  return {
+    hands: hands.map(sortHand),
+    scores: prevScores,
+    handScores: [0, 0, 0, 0],
+    phase: dir === "none" ? "playing" : "passing",
+    passDir: dir,
+    passedCards: [],
+    receivedCards: [],
+    currentTrick: [],
+    ledSuit: null,
+    trickLeader,
+    currentPlayer: trickLeader,
+    heartsAreBroken: false,
+    isFirstTrick: true,
+    tricksThisHand: 0,
+    handNumber,
+    selectedCard: null,
+  };
+}
+
+function freshGame(): HeartsState {
+  return makeInitialState(0, [0, 0, 0, 0]);
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface HeartsProps {
+  settings: DeckSettings;
+  onNewGame?: () => void;
+  onQuit?: () => void;
+}
+
+export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
+  const [state, setState] = useState<HeartsState>(freshGame);
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [showDeckModal, setShowDeckModal] = useState(false);
+  const [showScores, setShowScores] = useState(false);
+  // Ref to track if an AI step is currently scheduled (prevents double-firing)
+  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Derived ────────────────────────────────────────────────────────────────
+
+  const { hands, scores, handScores, phase, passDir, passedCards, receivedCards,
+    currentTrick, ledSuit, currentPlayer,
+    heartsAreBroken, isFirstTrick, tricksThisHand, handNumber, selectedCard } = state;
+
+  const humanHand = hands[0];
+  const isHumanTurn = phase === "playing" && currentPlayer === 0;
+  const validPlays = isHumanTurn
+    ? getValidHeartPlays(humanHand, ledSuit, heartsAreBroken, isFirstTrick)
+    : [];
+  const validIds = new Set<string>(validPlays.map((c) => c.id));
+
+  // ── Pass phase ─────────────────────────────────────────────────────────────
+
+  const togglePassCard = useCallback((cardId: string) => {
+    if (phase !== "passing") return;
+    setState((s) => {
+      const already = s.passedCards.find((c) => c.id === cardId);
+      if (already) {
+        return { ...s, passedCards: s.passedCards.filter((c) => c.id !== cardId) };
+      }
+      if (s.passedCards.length >= 3) return s;
+      const card = s.hands[0].find((c) => c.id === cardId);
+      if (!card) return s;
+      return { ...s, passedCards: [...s.passedCards, card] };
+    });
+  }, [phase]);
+
+  const confirmPass = useCallback(() => {
+    setState((s) => {
+      if (s.passedCards.length !== 3) return s;
+
+      // AI passes
+      const aiPasses: Card[][] = [[], [], [], []];
+      aiPasses[0] = s.passedCards;
+      for (let i = 1; i < 4; i++) {
+        aiPasses[i] = aiSelectCardsToPass(s.hands[i]);
+      }
+
+      // Exchange cards
+      const newHands = s.hands.map((hand) => [...hand]);
+      for (let from = 0; from < 4; from++) {
+        const to = passTarget(from, s.passDir);
+        if (to === from) continue;
+        const passing = aiPasses[from];
+        // Remove from sender
+        newHands[from] = newHands[from].filter(
+          (c) => !passing.some((p) => p.id === c.id)
+        );
+        // Add to receiver
+        newHands[to] = [...newHands[to], ...passing];
+      }
+
+      // Re-sort hands
+      const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
+      const sortHand = (hand: Card[]) =>
+        [...hand].sort((a, b) => {
+          const sd = suitOrder[a.suit] - suitOrder[b.suit];
+          if (sd !== 0) return sd;
+          return rankValue(a.rank as string) - rankValue(b.rank as string);
+        });
+
+      const sortedHands = newHands.map(sortHand);
+
+      // Find who has 2♣ after passing
+      let trickLeader = 0;
+      for (let i = 0; i < 4; i++) {
+        if (sortedHands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
+          trickLeader = i;
+          break;
+        }
+      }
+
+      // Determine what human received: find who passes TO player 0
+      const humanReceivedFrom: number[] = [];
+      for (let from = 0; from < 4; from++) {
+        if (passTarget(from, s.passDir) === 0 && from !== 0) {
+          humanReceivedFrom.push(from);
+        }
+      }
+      const receivedCards = humanReceivedFrom.flatMap((from) => aiPasses[from]);
+
+      return {
+        ...s,
+        hands: sortedHands,
+        phase: "playing",
+        passedCards: [],
+        receivedCards,
+        trickLeader,
+        currentPlayer: trickLeader,
+        currentTrick: [],
+        ledSuit: null,
+      };
+    });
+  }, []);
+
+  // ── Play a card ────────────────────────────────────────────────────────────
+
+  const playCard = useCallback((playerIndex: number, card: Card) => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+      if (s.currentPlayer !== playerIndex) return s;
+
+      // Validate
+      const valid = getValidHeartPlays(
+        s.hands[playerIndex],
+        s.ledSuit,
+        s.heartsAreBroken,
+        s.isFirstTrick
+      );
+      if (!valid.some((c) => c.id === card.id)) return s;
+
+      const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex, card }];
+      const newHands = s.hands.map((hand, i) =>
+        i === playerIndex ? hand.filter((c) => c.id !== card.id) : hand
+      );
+
+      const newLedSuit: Suit | null =
+        s.currentTrick.length === 0 ? (card.suit as Suit) : s.ledSuit;
+
+      const newHeartsAreBroken =
+        s.heartsAreBroken || card.suit === "hearts";
+
+      // Not all 4 played yet
+      if (newTrick.length < 4) {
+        const nextPlayer = (playerIndex + 1) % 4;
+        return {
+          ...s,
+          hands: newHands,
+          currentTrick: newTrick,
+          ledSuit: newLedSuit,
+          currentPlayer: nextPlayer,
+          heartsAreBroken: newHeartsAreBroken,
+          selectedCard: null,
+        };
+      }
+
+      // Trick complete — resolve
+      const winner = resolveTrick(newTrick, newLedSuit!);
+      const pts = trickPoints(newTrick.map((p) => p.card));
+      const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
+      const newTricksThisHand = s.tricksThisHand + 1;
+      const newIsFirstTrick = false;
+
+      if (newTricksThisHand === 13) {
+        // Hand over
+        const newCumulative = applyHandScores(newHandScores, s.scores);
+        const gameOver = newCumulative.some((sc) => sc >= 100);
+        return {
+          ...s,
+          hands: newHands,
+          handScores: newHandScores,
+          scores: newCumulative,
+          currentTrick: newTrick,
+          ledSuit: newLedSuit,
+          heartsAreBroken: newHeartsAreBroken,
+          isFirstTrick: newIsFirstTrick,
+          tricksThisHand: newTricksThisHand,
+          currentPlayer: winner,
+          trickLeader: winner,
+          phase: gameOver ? "game-over" : "hand-end",
+          selectedCard: null,
+        };
+      }
+
+      // Brief pause to show trick before clearing
+      return {
+        ...s,
+        hands: newHands,
+        handScores: newHandScores,
+        currentTrick: newTrick,
+        ledSuit: newLedSuit,
+        heartsAreBroken: newHeartsAreBroken,
+        isFirstTrick: newIsFirstTrick,
+        tricksThisHand: newTricksThisHand,
+        currentPlayer: winner,
+        trickLeader: winner,
+        phase: "trick-end",
+        selectedCard: null,
+      };
+    });
+  }, []);
+
+  // ── Human card click ───────────────────────────────────────────────────────
+
+  const handleCardClick = useCallback((card: Card) => {
+    if (phase === "passing") {
+      togglePassCard(card.id);
+      return;
+    }
+    if (!isHumanTurn) return;
+    if (!validIds.has(card.id)) return;
+
+    if (selectedCard === card.id) {
+      // Second click = confirm play
+      playCard(0, card);
+    } else {
+      setState((s) => ({ ...s, selectedCard: card.id }));
+    }
+  }, [phase, isHumanTurn, validIds, selectedCard, togglePassCard, playCard]);
+
+  // ── Trick-end pause → clear trick ─────────────────────────────────────────
+
+  useEffect(() => {
+    if (phase !== "trick-end") return;
+    const t = setTimeout(() => {
+      setState((s) => {
+        if (s.phase !== "trick-end") return s;
+        return {
+          ...s,
+          phase: "playing",
+          currentTrick: [],
+          ledSuit: null,
+        };
+      });
+    }, 900);
+    return () => clearTimeout(t);
+  }, [phase, tricksThisHand]);
+
+  // ── AI turns ───────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (phase !== "playing" && phase !== "trick-end") return;
+    if (currentPlayer === 0) return;
+    if (phase === "trick-end") return;
+
+    // Cancel any stale timer
+    if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+
+    aiTimerRef.current = setTimeout(() => {
+      setState((s) => {
+        if (s.phase !== "playing") return s;
+        if (s.currentPlayer === 0) return s;
+
+        const ai = s.currentPlayer;
+        const valid = getValidHeartPlays(
+          s.hands[ai],
+          s.ledSuit,
+          s.heartsAreBroken,
+          s.isFirstTrick
+        );
+        if (valid.length === 0) return s;
+
+        const chosen = aiChooseCard(valid, s.currentTrick, s.ledSuit);
+
+        const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex: ai, card: chosen }];
+        const newHands = s.hands.map((hand, i) =>
+          i === ai ? hand.filter((c) => c.id !== chosen.id) : hand
+        );
+        const newLedSuit: Suit | null =
+          s.currentTrick.length === 0 ? (chosen.suit as Suit) : s.ledSuit;
+        const newHeartsAreBroken =
+          s.heartsAreBroken || chosen.suit === "hearts";
+
+        if (newTrick.length < 4) {
+          const nextPlayer = (ai + 1) % 4;
+          return {
+            ...s,
+            hands: newHands,
+            currentTrick: newTrick,
+            ledSuit: newLedSuit,
+            currentPlayer: nextPlayer,
+            heartsAreBroken: newHeartsAreBroken,
+          };
+        }
+
+        // Trick complete
+        const winner = resolveTrick(newTrick, newLedSuit!);
+        const pts = trickPoints(newTrick.map((p) => p.card));
+        const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
+        const newTricksThisHand = s.tricksThisHand + 1;
+
+        if (newTricksThisHand === 13) {
+          const newCumulative = applyHandScores(newHandScores, s.scores);
+          const gameOver = newCumulative.some((sc) => sc >= 100);
+          return {
+            ...s,
+            hands: newHands,
+            handScores: newHandScores,
+            scores: newCumulative,
+            currentTrick: newTrick,
+            ledSuit: newLedSuit,
+            heartsAreBroken: newHeartsAreBroken,
+            isFirstTrick: false,
+            tricksThisHand: newTricksThisHand,
+            currentPlayer: winner,
+            trickLeader: winner,
+            phase: gameOver ? "game-over" : "hand-end",
+          };
+        }
+
+        return {
+          ...s,
+          hands: newHands,
+          handScores: newHandScores,
+          currentTrick: newTrick,
+          ledSuit: newLedSuit,
+          heartsAreBroken: newHeartsAreBroken,
+          isFirstTrick: false,
+          tricksThisHand: newTricksThisHand,
+          currentPlayer: winner,
+          trickLeader: winner,
+          phase: "trick-end",
+        };
+      });
+    }, 600);
+
+    return () => {
+      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+    };
+  }, [phase, currentPlayer, tricksThisHand]);
+
+  // ── Between-hand: start next hand ─────────────────────────────────────────
+
+  const startNextHand = useCallback(() => {
+    setState((s) => {
+      const nextHandNum = s.handNumber + 1;
+      const next = makeInitialState(nextHandNum, s.scores);
+      return next;
+    });
+  }, []);
+
+  const startNewGame = useCallback(() => {
+    setState(freshGame());
+  }, []);
+
+  // ── Menus ──────────────────────────────────────────────────────────────────
+
+  const heartsMenus = useMemo<MenuBarMenu[]>(() => {
+    const gameItems: MenuBarMenu["items"] = [
+      { label: "New Hand", onClick: startNextHand },
+      { label: "Show Scores", onClick: () => setShowScores(true) },
+      { separator: true },
+      ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
+      ...(onQuit ? [{ label: "Exit", onClick: onQuit }] : []),
+    ];
+    return [
+      { label: "Game", items: gameItems },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
+    ];
+  }, [startNextHand, onNewGame, onQuit]);
+
+  useWindowMenus(heartsMenus);
+
+  // ── Render helpers ─────────────────────────────────────────────────────────
+
+  const passTargetName = passDir !== "none"
+    ? PLAYER_NAMES[passTarget(0, passDir)]
+    : "";
+
+  /** Card played by a given player in current trick */
+  function trickCardFor(playerIdx: number): Card | null {
+    return currentTrick.find((p) => p.playerIndex === playerIdx)?.card ?? null;
+  }
+
+  function passLabel(): string {
+    if (passDir === "left")   return "→ Pass Left";
+    if (passDir === "right")  return "← Pass Right";
+    if (passDir === "across") return "↑ Pass Across";
+    return "";
+  }
+
+  const gameOverWinnerIdx = state.scores.indexOf(Math.min(...state.scores));
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="hearts">
+      {showDeckModal && (
+        <DeckModal
+          appearance={appearance}
+          onUpdate={setAppearance}
+          onClose={() => setShowDeckModal(false)}
+        />
+      )}
+
+      {/* Hand-end / Game-over scorecard modal */}
+      {(phase === "hand-end" || phase === "game-over" || showScores) && (
+        <div className="hearts-modal-overlay" onClick={showScores ? () => setShowScores(false) : undefined}>
+          <div className="hearts-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="hearts-modal__titlebar">
+              <span>{phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}</span>
+              {showScores && (
+                <button className="hearts-modal__close" onClick={() => setShowScores(false)} aria-label="Close">✕</button>
+              )}
+            </div>
+            <div className="hearts-modal__body">
+              <table className="hearts-modal__table">
+                <thead>
+                  <tr>
+                    <th>Player</th>
+                    {(phase === "hand-end" || phase === "game-over") && <th>This Hand</th>}
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {PLAYER_NAMES.map((name, i) => (
+                    <tr key={i} className={phase === "game-over" && i === gameOverWinnerIdx ? "hearts-modal__winner-row" : ""}>
+                      <td>{name}</td>
+                      {(phase === "hand-end" || phase === "game-over") && (
+                        <td className={handScores[i] === 26 ? "hearts-modal__moon" : ""}>
+                          {handScores[i] === 26 ? "🌙" : `+${handScores[i]}`}
+                        </td>
+                      )}
+                      <td>{scores[i]}</td>
+                      {phase === "game-over" && i === gameOverWinnerIdx && (
+                        <td className="hearts-modal__winner-label">WINNER</td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="hearts-modal__footer">
+              {phase === "game-over" ? (
+                <>
+                  {onNewGame && (
+                    <button className="hearts-btn hearts-btn--primary" onClick={onNewGame}>
+                      Choose Game
+                    </button>
+                  )}
+                  <button className="hearts-btn hearts-btn--primary" onClick={startNewGame}>
+                    Play Again
+                  </button>
+                </>
+              ) : !showScores ? (
+                <button className="hearts-btn hearts-btn--primary" onClick={startNextHand}>
+                  Continue →
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="hearts__table">
+
+        {/* North AI (top) */}
+        <div className="hearts__north">
+          <div className="hearts__player-label hearts__player-label--ai">
+            {PLAYER_NAMES[2]}
+            {currentPlayer === 2 && phase === "playing" && (
+              <span className="hearts__turn-dot" />
+            )}
+          </div>
+          <div className="hearts__ai-hand hearts__ai-hand--horiz">
+            {hands[2].map((card) => (
+              <PlayingCard
+                key={card.id}
+                card={card}
+                faceDown
+                appearance={appearance}
+                size="sm"
+              />
+            ))}
+          </div>
+          <div className="hearts__hand-score">
+            {handScores[2] > 0 && `${handScores[2]}pt`}
+          </div>
+        </div>
+
+        {/* Middle row: West, Center, East */}
+        <div className="hearts__middle">
+          {/* West AI */}
+          <div className="hearts__west">
+            <div className="hearts__player-label hearts__player-label--ai">
+              {PLAYER_NAMES[1]}
+              {currentPlayer === 1 && phase === "playing" && (
+                <span className="hearts__turn-dot" />
+              )}
+            </div>
+            <div className="hearts__ai-hand hearts__ai-hand--vert">
+              {hands[1].map((card) => (
+                <PlayingCard
+                  key={card.id}
+                  card={card}
+                  faceDown
+                  appearance={appearance}
+                  size="sm"
+                />
+              ))}
+            </div>
+            <div className="hearts__hand-score">
+              {handScores[1] > 0 && `${handScores[1]}pt`}
+            </div>
+          </div>
+
+          {/* Center trick area */}
+          <div className="hearts__center">
+            {/* North slot */}
+            <div className="hearts__trick-slot hearts__trick-slot--north">
+              {trickCardFor(2) && (
+                <PlayingCard card={trickCardFor(2)!} appearance={appearance} />
+              )}
+            </div>
+            {/* West slot */}
+            <div className="hearts__trick-slot hearts__trick-slot--west">
+              {trickCardFor(1) && (
+                <PlayingCard card={trickCardFor(1)!} appearance={appearance} />
+              )}
+            </div>
+            {/* Center indicator */}
+            <div className="hearts__trick-center">
+              {phase === "playing" || phase === "trick-end" ? (
+                <span className="hearts__trick-count">{tricksThisHand}/13</span>
+              ) : null}
+              {heartsAreBroken && <span className="hearts__broken">♥</span>}
+            </div>
+            {/* East slot */}
+            <div className="hearts__trick-slot hearts__trick-slot--east">
+              {trickCardFor(3) && (
+                <PlayingCard card={trickCardFor(3)!} appearance={appearance} />
+              )}
+            </div>
+            {/* South (human) slot */}
+            <div className="hearts__trick-slot hearts__trick-slot--south">
+              {trickCardFor(0) && (
+                <PlayingCard card={trickCardFor(0)!} appearance={appearance} />
+              )}
+            </div>
+          </div>
+
+          {/* East AI */}
+          <div className="hearts__east">
+            <div className="hearts__player-label hearts__player-label--ai">
+              {PLAYER_NAMES[3]}
+              {currentPlayer === 3 && phase === "playing" && (
+                <span className="hearts__turn-dot" />
+              )}
+            </div>
+            <div className="hearts__ai-hand hearts__ai-hand--vert">
+              {hands[3].map((card) => (
+                <PlayingCard
+                  key={card.id}
+                  card={card}
+                  faceDown
+                  appearance={appearance}
+                  size="sm"
+                />
+              ))}
+            </div>
+            <div className="hearts__hand-score">
+              {handScores[3] > 0 && `${handScores[3]}pt`}
+            </div>
+          </div>
+        </div>
+
+        {/* Human (South) */}
+        <div className="hearts__south">
+          <div className="hearts__player-label">
+            {PLAYER_NAMES[0]}
+            {isHumanTurn && phase === "playing" && (
+              <span className="hearts__turn-dot hearts__turn-dot--human" />
+            )}
+            <span className="hearts__score-inline">{scores[0]}pts total</span>
+          </div>
+
+          {/* Passing phase instruction */}
+          {phase === "passing" && (
+            <div className="hearts__pass-hint">
+              Select 3 cards to pass to {passTargetName}
+              {passedCards.length > 0 && ` (${passedCards.length}/3 selected)`}
+            </div>
+          )}
+
+          <div className={`hearts__human-hand${phase === "passing" ? " hearts__human-hand--passing" : ""}`}>
+            {humanHand.map((card) => {
+              const isSelected = phase === "passing"
+                ? passedCards.some((c) => c.id === card.id)
+                : selectedCard === card.id;
+              const isValid = phase === "playing" && isHumanTurn && validIds.has(card.id);
+              const isPlayable = phase === "passing" || isValid;
+              const hasReceived = receivedCards.some((c) => c.id === card.id);
+
+              return (
+                <div
+                  key={card.id}
+                  className={[
+                    "hearts__card-wrap",
+                    isSelected ? "hearts__card-wrap--selected" : "",
+                    isValid && !isSelected ? "hearts__card-wrap--valid" : "",
+                    isPlayable ? "hearts__card-wrap--clickable" : "",
+                    hasReceived ? "hearts__card-wrap--received" : "",
+                  ].filter(Boolean).join(" ")}
+                  onClick={() => handleCardClick(card)}
+                >
+                  <PlayingCard card={card} appearance={appearance} />
+                </div>
+              );
+            })}
+          </div>
+
+          {phase === "passing" && passedCards.length === 3 && (
+            <div className="hearts__pass-actions">
+              <button
+                className="hearts-btn hearts-btn--primary"
+                onClick={confirmPass}
+              >
+                {passLabel()} →
+              </button>
+            </div>
+          )}
+
+          {phase === "playing" && isHumanTurn && selectedCard && (
+            <div className="hearts__play-hint">
+              Click again to play
+            </div>
+          )}
+          {phase === "playing" && !isHumanTurn && currentPlayer !== 0 && (
+            <div className="hearts__play-hint">
+              {PLAYER_NAMES[currentPlayer]}{"'s turn..."}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="hearts__status-bar">
+        <span>
+          Hand {handNumber + 1} &nbsp;·&nbsp; Trick {Math.min(tricksThisHand + 1, 13)}/13
+          &nbsp;·&nbsp; Pass: {passDir === "none" ? "None" : passDir}
+        </span>
+        <span className="hearts__scores-row">
+          {PLAYER_NAMES.map((name, i) => (
+            <span key={i} className="hearts__score-item">
+              {name}: {scores[i]}
+            </span>
+          ))}
+        </span>
+        <button
+          className="hearts-btn hearts-btn--sm"
+          onClick={() => setShowScores(true)}
+        >
+          Scores
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -1,6 +1,9 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Hearts.css";
-import { PlayingCard } from "./PlayingCard";
+import "./Cards.css";
+import { PermCard } from "./PermCard";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
 import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
 import {
   dealHands,
@@ -14,10 +17,32 @@ import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
+// ── Stage layout ──────────────────────────────────────────────────────────────
+
+const STAGE_W = 480;
+const STAGE_H = 500;
+
+// Hand fan centers (card center x/y)
+const HAND_CX = [240, 240,  40, 440] as const;  // [human, north, west, east]
+const HAND_CY = [460,  52, 258, 258] as const;
+
+// Where a played card lands in the trick area
+const TRICK_X = [240, 152, 240, 328] as const;  // indexed by playerIndex
+const TRICK_Y = [352, 258, 168, 258] as const;
+
+// Off-screen pile per player (won tricks fly here)
+const PILE_X = [240,  -80, 240, 560] as const;
+const PILE_Y = [620,  258,  -80, 258] as const;
+
 // ── Deck helpers ──────────────────────────────────────────────────────────────
 
-const RANKS_ORD = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"] as const;
-const ALL_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+const RANKS_ORD = ["2","3","4","5","6","7","8","9","10","J","Q","K","A"] as const;
+const ALL_SUITS: Suit[] = ["spades","hearts","diamonds","clubs"];
+
+// Stable 52-card array — IDs are always "suit-rank", same every hand.
+const FIXED_DECK: Card[] = ALL_SUITS.flatMap(suit =>
+  RANKS_ORD.map(rank => ({ suit, rank, id: `${suit}-${rank}` }))
+);
 
 function shuffle<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -28,15 +53,7 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-function buildDeck(): Card[] {
-  const cards: Card[] = [];
-  for (const suit of ALL_SUITS) {
-    for (const rank of RANKS_ORD) {
-      cards.push({ suit, rank, id: `${suit}-${rank}` });
-    }
-  }
-  return shuffle(cards);
-}
+function buildDeck(): Card[] { return shuffle(FIXED_DECK); }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -62,22 +79,10 @@ interface HeartsState {
   selectedCard: string | null;
 }
 
-interface FlyingCard {
-  id: string;
-  card: Card;
-  fromX: number;     // source center, table-relative px
-  fromY: number;
-  toX: number;       // dest center, table-relative px
-  toY: number;
-  landAngle: number; // random ±12° landing rotation
-  doFlip: boolean;   // true = AI card, flip back→front mid-flight
-  sm: boolean;       // true = use sm card size
-}
-
 const PLAYER_NAMES = ["You", "West", "North", "East"];
 
 function passDirection(handNumber: number): PassDir {
-  const dirs: PassDir[] = ["left", "right", "across", "none"];
+  const dirs: PassDir[] = ["left","right","across","none"];
   return dirs[handNumber % 4];
 }
 
@@ -107,43 +112,42 @@ function aiSelectCardsToPass(hand: Card[]): Card[] {
 
 function aiChooseCard(valid: Card[], trick: TrickPlay[], ledSuit: Suit | null): Card {
   if (trick.length === 0 || ledSuit === null) {
-    const pool = valid.filter((c) => c.suit !== "hearts");
-    const src = pool.length > 0 ? pool : valid;
+    const pool = valid.filter(c => c.suit !== "hearts");
+    const src  = pool.length > 0 ? pool : valid;
     return src.reduce((b, c) => rankValue(c.rank as string) < rankValue(b.rank as string) ? c : b);
   }
-  const canFollow = valid.some((c) => c.suit === ledSuit);
+  const canFollow = valid.some(c => c.suit === ledSuit);
   if (canFollow) {
-    const suit = valid.filter((c) => c.suit === ledSuit);
-    let winV = -1;
-    for (const p of trick) {
-      if (p.card.suit === ledSuit) winV = Math.max(winV, rankValue(p.card.rank as string));
-    }
-    const losers = suit.filter((c) => rankValue(c.rank as string) < winV);
-    const pool = losers.length > 0 ? losers : suit;
-    const op = losers.length > 0 ? (a: Card, b: Card) => rankValue(b.rank as string) - rankValue(a.rank as string)
-                                  : (a: Card, b: Card) => rankValue(a.rank as string) - rankValue(b.rank as string);
+    const suit  = valid.filter(c => c.suit === ledSuit);
+    let winV    = -1;
+    for (const p of trick) if (p.card.suit === ledSuit) winV = Math.max(winV, rankValue(p.card.rank as string));
+    const losers = suit.filter(c => rankValue(c.rank as string) < winV);
+    const pool   = losers.length > 0 ? losers : suit;
+    const op     = losers.length > 0
+      ? (a: Card, b: Card) => rankValue(b.rank as string) - rankValue(a.rank as string)
+      : (a: Card, b: Card) => rankValue(a.rank as string) - rankValue(b.rank as string);
     return pool.reduce((best, c) => op(c, best) < 0 ? c : best);
   }
-  const qs = valid.find((c) => c.suit === "spades" && c.rank === "Q");
+  const qs = valid.find(c => c.suit === "spades" && c.rank === "Q");
   if (qs) return qs;
-  const hearts = valid.filter((c) => c.suit === "hearts");
+  const hearts = valid.filter(c => c.suit === "hearts");
   if (hearts.length > 0)
     return hearts.reduce((b, c) => rankValue(c.rank as string) > rankValue(b.rank as string) ? c : b);
   return valid.reduce((b, c) => rankValue(c.rank as string) > rankValue(b.rank as string) ? c : b);
 }
 
 function applyHandScores(handScores: number[], cumulative: number[]): number[] {
-  const moon = handScores.findIndex((s) => s === 26);
-  if (moon !== -1) return cumulative.map((s, i) => (i === moon ? s : s + 26));
+  const moon = handScores.findIndex(s => s === 26);
+  if (moon !== -1) return cumulative.map((s, i) => i === moon ? s : s + 26);
   return cumulative.map((s, i) => s + handScores[i]);
 }
 
 // ── State factory ─────────────────────────────────────────────────────────────
 
 function makeInitialState(handNumber: number, prevScores: number[]): HeartsState {
-  const deck = buildDeck();
+  const deck  = buildDeck();
   const hands = dealHands(deck, 4);
-  const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
+  const suitOrder: Record<string,number> = { spades:0, hearts:1, diamonds:2, clubs:3 };
   const sortHand = (hand: Card[]) =>
     [...hand].sort((a, b) => {
       const sd = suitOrder[a.suit] - suitOrder[b.suit];
@@ -152,12 +156,12 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
   const dir = passDirection(handNumber);
   let trickLeader = 0;
   for (let i = 0; i < 4; i++) {
-    if (hands[i].some((c) => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
+    if (hands[i].some(c => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
   }
   return {
     hands: hands.map(sortHand),
     scores: prevScores,
-    handScores: [0, 0, 0, 0],
+    handScores: [0,0,0,0],
     phase: dir === "none" ? "playing" : "passing",
     passDir: dir,
     passedCards: [],
@@ -174,20 +178,7 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
   };
 }
 
-function freshGame(): HeartsState { return makeInitialState(0, [0, 0, 0, 0]); }
-
-// ── Fan helpers ───────────────────────────────────────────────────────────────
-
-function fanAngle(idx: number, total: number): number {
-  if (total <= 1) return 0;
-  const mid = (total - 1) / 2;
-  return ((idx - mid) / mid) * 11;
-}
-
-function handOverlap(count: number, cardW: number, maxW: number): number {
-  if (count <= 1) return 0;
-  return Math.max(0, Math.round((count * cardW - maxW) / (count - 1)));
-}
+function freshGame(): HeartsState { return makeInitialState(0, [0,0,0,0]); }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -198,120 +189,170 @@ interface HeartsProps {
 }
 
 export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
-  const [state, setState] = useState<HeartsState>(freshGame);
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [state,         setState]        = useState<HeartsState>(freshGame);
+  const [cardStates,    setCardStates]   = useState<Record<string, CardVisualState>>({});
+  const [appearance,    setAppearance]   = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
-  const [showScores, setShowScores] = useState(false);
-  const [dealKey, setDealKey] = useState(0);
-  const [flyingCards, setFlyingCards] = useState<FlyingCard[]>([]);
+  const [showScores,    setShowScores]   = useState(false);
+  const [scale,         setScale]        = useState(1);
 
-  // Refs for flying card coordinate math
-  const tableRef       = useRef<HTMLDivElement>(null);
-  const northZoneRef   = useRef<HTMLDivElement>(null);
-  const westZoneRef    = useRef<HTMLDivElement>(null);
-  const eastZoneRef    = useRef<HTMLDivElement>(null);
-  const humanCardRefs  = useRef<Map<string, HTMLDivElement>>(new Map());
-  const trickSlotRefs  = useRef<Map<number, HTMLDivElement>>(new Map());
-  const prevTrickLen   = useRef(0);
-  const aiTimerRef     = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevHandNumRef = useRef(state.handNumber);
+  const containerRef  = useRef<HTMLDivElement>(null);
+  const aiTimerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevHandNum   = useRef(-1);
+  const wonByRef      = useRef<Record<string, number>>({});  // cardId → winning playerIndex
 
-  // Increment dealKey when hand changes (triggers deal animation)
+  // ── CardStack refs for the 4 hands ────────────────────────────────────────
+  // Player 0 (human): horizontal fan, centered, with arc
+  // Player 1 (west):  vertical fan, all cards rotated 90°
+  // Player 2 (north): horizontal fan, centered, flat
+  // Player 3 (east):  vertical fan, all cards rotated -90°
+  const handSt = useRef([
+    new CardStack({ zTier:15, baseX:HAND_CX[0], baseY:HAND_CY[0], offsetX:28,  centered:true, startRotation:-9,  endRotation:9   }),
+    new CardStack({ zTier:12, baseX:HAND_CX[2], baseY:HAND_CY[2], offsetY:16,  centered:true, startRotation:90,  endRotation:90  }),
+    new CardStack({ zTier:11, baseX:HAND_CX[1], baseY:HAND_CY[1], offsetX:20,  centered:true, startRotation:0,   endRotation:0   }),
+    new CardStack({ zTier:13, baseX:HAND_CX[3], baseY:HAND_CY[3], offsetY:16,  centered:true, startRotation:-90, endRotation:-90 }),
+  ]);
+
+  // ── Scale observer ────────────────────────────────────────────────────────
+
   useEffect(() => {
-    if (state.handNumber !== prevHandNumRef.current) {
-      prevHandNumRef.current = state.handNumber;
-      setDealKey((k) => k + 1);
-    }
-  }, [state.handNumber]);
-
-  // Clear flying cards on new deal
-  useEffect(() => {
-    setFlyingCards([]);
-    prevTrickLen.current = 0;
-  }, [dealKey]);
-
-  // ── Derived ────────────────────────────────────────────────────────────────
-
-  const { hands, scores, handScores, phase, passDir, passedCards, receivedCards,
-    currentTrick, ledSuit, currentPlayer,
-    heartsAreBroken, isFirstTrick, tricksThisHand, handNumber, selectedCard } = state;
-
-  const humanHand   = hands[0];
-  const isHumanTurn = phase === "playing" && currentPlayer === 0;
-  const validPlays  = isHumanTurn
-    ? getValidHeartPlays(humanHand, ledSuit, heartsAreBroken, isFirstTrick)
-    : [];
-  const validIds = new Set<string>(validPlays.map((c) => c.id));
-
-  // ── Flying card launcher ───────────────────────────────────────────────────
-
-  const launchCard = useCallback((
-    card: Card,
-    fromEl: HTMLElement | null,
-    toSlotPlayer: number,
-    doFlip: boolean,
-    sm: boolean,
-  ) => {
-    const toEl = trickSlotRefs.current.get(toSlotPlayer) ?? null;
-    if (!tableRef.current || !fromEl || !toEl) return;
-    const tr  = tableRef.current.getBoundingClientRect();
-    const fr  = fromEl.getBoundingClientRect();
-    const tor = toEl.getBoundingClientRect();
-    setFlyingCards((prev) => [...prev, {
-      id: `fly-${card.id}-${Date.now()}`,
-      card,
-      fromX: fr.left  - tr.left + fr.width  / 2,
-      fromY: fr.top   - tr.top  + fr.height / 2,
-      toX:  tor.left  - tr.left + tor.width  / 2,
-      toY:  tor.top   - tr.top  + tor.height / 2,
-      landAngle: (Math.random() - 0.5) * 24,
-      doFlip,
-      sm,
-    }]);
+    const el = containerRef.current; if (!el) return;
+    const obs = new ResizeObserver(e => {
+      const { width, height } = e[0].contentRect;
+      setScale(Math.min(1, width / STAGE_W, height / STAGE_H));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
   }, []);
 
-  // Detect AI card plays and launch flying card
-  useEffect(() => {
-    if (currentTrick.length === 0) { prevTrickLen.current = 0; return; }
-    if (currentTrick.length <= prevTrickLen.current) return;
-    const latest = currentTrick[currentTrick.length - 1];
-    if (latest.playerIndex !== 0) {
-      const pi = latest.playerIndex;
-      const fromEl = pi === 1 ? westZoneRef.current
-                   : pi === 2 ? northZoneRef.current
-                   : eastZoneRef.current;
-      launchCard(latest.card, fromEl, pi, true, true);
+  // ── Position computation ──────────────────────────────────────────────────
+
+  function computePositions(s: HeartsState, ms: number): Record<string, CardVisualState> {
+    // Rebuild hand stacks from current game state.
+    // handSt index order: [0=human, 1=west, 2=north, 3=east]
+    // Maps to player index: human=0, west=1, north=2, east=3
+    const playerToStack = [0, 1, 2, 3]; // player i → handSt[playerToStack[i]]
+    for (const pi of playerToStack) {
+      handSt.current[pi].clear();
+      for (const c of s.hands[pi]) {
+        handSt.current[pi].addCard(c, { toTop: true, faceDown: pi !== 0 });
+      }
     }
-    prevTrickLen.current = currentTrick.length;
-  }, [currentTrick, launchCard]);
+
+    const result: Record<string, CardVisualState> = {};
+
+    // Hand positions
+    for (const st of handSt.current) Object.assign(result, st.layout(ms));
+
+    // Trick slot positions
+    for (const play of s.currentTrick) {
+      const pi = play.playerIndex;
+      result[play.card.id] = {
+        x: TRICK_X[pi], y: TRICK_Y[pi],
+        z: 5000 + pi, rotation: 0, faceDown: false, transitionMs: ms,
+      };
+    }
+
+    // Won cards → off-screen pile (skip if still in current trick during pause)
+    for (const [cardId, winnerIdxRaw] of Object.entries(wonByRef.current)) {
+      const winnerIdx = winnerIdxRaw as number;
+      if (!s.currentTrick.some(p => p.card.id === cardId)) {
+        result[cardId] = {
+          x: PILE_X[winnerIdx], y: PILE_Y[winnerIdx],
+          z: 50 + winnerIdx, rotation: 0, faceDown: false, transitionMs: ms,
+        };
+      }
+    }
+
+    // Selected card lift (playing phase)
+    if (s.selectedCard && result[s.selectedCard]) {
+      result[s.selectedCard] = { ...result[s.selectedCard], y: result[s.selectedCard].y - 22 };
+    }
+
+    // Pass-selected cards lift
+    if (s.phase === "passing") {
+      for (const c of s.passedCards) {
+        if (result[c.id]) result[c.id] = { ...result[c.id], y: result[c.id].y - 22 };
+      }
+    }
+
+    return result;
+  }
+
+  // ── Track trick winners (for off-screen pile positioning) ─────────────────
+
+  useEffect(() => {
+    if (state.currentTrick.length !== 4) return;
+    // trickLeader is updated to the winner in the same state update as the 4th play
+    const winner = state.trickLeader;
+    for (const play of state.currentTrick) wonByRef.current[play.card.id] = winner;
+  }, [state.currentTrick, state.trickLeader]);
+
+  // ── Main position sync: fires on every state change ───────────────────────
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+
+    if (prevHandNum.current !== state.handNumber) {
+      // New hand: reset won pile, deal animation
+      prevHandNum.current = state.handNumber;
+      wonByRef.current = {};
+
+      // Phase 1: all cards to deck position (no transition)
+      const init: Record<string, CardVisualState> = {};
+      for (const c of FIXED_DECK) {
+        init[c.id] = { x: STAGE_W / 2, y: -80, z: 500, rotation: 0, faceDown: true, transitionMs: 0 };
+      }
+      setCardStates(init);
+
+      // Phase 2: deal to hands with stagger
+      const t = setTimeout(() => {
+        const positions = computePositions(state, 320);
+        for (let p = 0; p < 4; p++) {
+          state.hands[p].forEach((c, idx) => {
+            const pos = positions[c.id];
+            if (pos) positions[c.id] = { ...pos, transitionDelay: (p * 13 + idx) * 18 };
+          });
+        }
+        setCardStates(positions);
+      }, 80);
+
+      cleanup = () => clearTimeout(t);
+    } else {
+      setCardStates(computePositions(state, 200));
+    }
+
+    return cleanup;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
 
   // ── Pass phase ─────────────────────────────────────────────────────────────
 
   const togglePassCard = useCallback((cardId: string) => {
-    if (phase !== "passing") return;
-    setState((s) => {
-      const already = s.passedCards.find((c) => c.id === cardId);
-      if (already) return { ...s, passedCards: s.passedCards.filter((c) => c.id !== cardId) };
+    if (state.phase !== "passing") return;
+    setState(s => {
+      const already = s.passedCards.find(c => c.id === cardId);
+      if (already) return { ...s, passedCards: s.passedCards.filter(c => c.id !== cardId) };
       if (s.passedCards.length >= 3) return s;
-      const card = s.hands[0].find((c) => c.id === cardId);
+      const card = s.hands[0].find(c => c.id === cardId);
       if (!card) return s;
       return { ...s, passedCards: [...s.passedCards, card] };
     });
-  }, [phase]);
+  }, [state.phase]);
 
   const confirmPass = useCallback(() => {
-    setState((s) => {
+    setState(s => {
       if (s.passedCards.length !== 3) return s;
       const aiPasses: Card[][] = [s.passedCards, [], [], []];
       for (let i = 1; i < 4; i++) aiPasses[i] = aiSelectCardsToPass(s.hands[i]);
-      const newHands = s.hands.map((h) => [...h]);
+      const newHands = s.hands.map(h => [...h]);
       for (let from = 0; from < 4; from++) {
         const to = passTarget(from, s.passDir);
         if (to === from) continue;
-        newHands[from] = newHands[from].filter((c) => !aiPasses[from].some((p) => p.id === c.id));
-        newHands[to] = [...newHands[to], ...aiPasses[from]];
+        newHands[from] = newHands[from].filter(c => !aiPasses[from].some(p => p.id === c.id));
+        newHands[to]   = [...newHands[to], ...aiPasses[from]];
       }
-      const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
+      const suitOrder: Record<string,number> = { spades:0, hearts:1, diamonds:2, clubs:3 };
       const sort = (h: Card[]) => [...h].sort((a, b) => {
         const sd = suitOrder[a.suit] - suitOrder[b.suit];
         return sd !== 0 ? sd : rankValue(a.rank as string) - rankValue(b.rank as string);
@@ -319,7 +360,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       const sorted = newHands.map(sort);
       let trickLeader = 0;
       for (let i = 0; i < 4; i++) {
-        if (sorted[i].some((c) => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
+        if (sorted[i].some(c => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
       }
       const received = Array.from({ length: 4 }, (_, from) =>
         passTarget(from, s.passDir) === 0 && from !== 0 ? aiPasses[from] : []
@@ -334,13 +375,13 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   // ── Play a card ────────────────────────────────────────────────────────────
 
   const playCard = useCallback((playerIndex: number, card: Card) => {
-    setState((s) => {
+    setState(s => {
       if (s.phase !== "playing" || s.currentPlayer !== playerIndex) return s;
       const valid = getValidHeartPlays(s.hands[playerIndex], s.ledSuit, s.heartsAreBroken, s.isFirstTrick);
-      if (!valid.some((c) => c.id === card.id)) return s;
+      if (!valid.some(c => c.id === card.id)) return s;
 
       const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex, card }];
-      const newHands = s.hands.map((h, i) => i === playerIndex ? h.filter((c) => c.id !== card.id) : h);
+      const newHands  = s.hands.map((h, i) => i === playerIndex ? h.filter(c => c.id !== card.id) : h);
       const newLed: Suit | null = s.currentTrick.length === 0 ? (card.suit as Suit) : s.ledSuit;
       const newBroken = s.heartsAreBroken || card.suit === "hearts";
 
@@ -349,23 +390,23 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
           currentPlayer: (playerIndex + 1) % 4, heartsAreBroken: newBroken, selectedCard: null };
       }
 
-      const winner = resolveTrick(newTrick, newLed!);
-      const pts = trickPoints(newTrick.map((p) => p.card));
-      const newHandScores = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
+      const winner    = resolveTrick(newTrick, newLed!);
+      const pts       = trickPoints(newTrick.map(p => p.card));
+      const newHS     = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
       const newTricks = s.tricksThisHand + 1;
 
       if (newTricks === 13) {
-        const newCum = applyHandScores(newHandScores, s.scores);
+        const newCum = applyHandScores(newHS, s.scores);
         return {
-          ...s, hands: newHands, handScores: newHandScores, scores: newCum,
+          ...s, hands: newHands, handScores: newHS, scores: newCum,
           currentTrick: newTrick, ledSuit: newLed, heartsAreBroken: newBroken,
           isFirstTrick: false, tricksThisHand: newTricks, currentPlayer: winner,
-          trickLeader: winner, phase: newCum.some((sc) => sc >= 100) ? "game-over" : "hand-end",
+          trickLeader: winner, phase: newCum.some(sc => sc >= 100) ? "game-over" : "hand-end",
           selectedCard: null,
         };
       }
       return {
-        ...s, hands: newHands, handScores: newHandScores, currentTrick: newTrick,
+        ...s, hands: newHands, handScores: newHS, currentTrick: newTrick,
         ledSuit: newLed, heartsAreBroken: newBroken, isFirstTrick: false,
         tricksThisHand: newTricks, currentPlayer: winner, trickLeader: winner,
         phase: "trick-end", selectedCard: null,
@@ -375,24 +416,33 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
   // ── Human card click ───────────────────────────────────────────────────────
 
+  const { phase, currentPlayer, hands, scores, handScores, passDir, passedCards,
+    receivedCards, ledSuit, heartsAreBroken, isFirstTrick,
+    tricksThisHand, handNumber, selectedCard } = state;
+
+  const isHumanTurn = phase === "playing" && currentPlayer === 0;
+  const validPlays  = isHumanTurn
+    ? getValidHeartPlays(hands[0], ledSuit, heartsAreBroken, isFirstTrick)
+    : [];
+  const validIds    = useMemo(() => new Set(validPlays.map(c => c.id)), [validPlays]);
+  const receivedIds = useMemo(() => new Set(receivedCards.map(c => c.id)), [receivedCards]);
+
   const handleCardClick = useCallback((card: Card) => {
     if (phase === "passing") { togglePassCard(card.id); return; }
     if (!isHumanTurn || !validIds.has(card.id)) return;
     if (selectedCard === card.id) {
-      // Launch flying card before state update so ref is still in DOM
-      launchCard(card, humanCardRefs.current.get(card.id) ?? null, 0, false, false);
       playCard(0, card);
     } else {
-      setState((s) => ({ ...s, selectedCard: card.id }));
+      setState(s => ({ ...s, selectedCard: card.id }));
     }
-  }, [phase, isHumanTurn, validIds, selectedCard, togglePassCard, playCard, launchCard]);
+  }, [phase, isHumanTurn, validIds, selectedCard, togglePassCard, playCard]);
 
   // ── Trick-end pause ────────────────────────────────────────────────────────
 
   useEffect(() => {
     if (phase !== "trick-end") return;
     const t = setTimeout(() => {
-      setState((s) => s.phase !== "trick-end" ? s
+      setState(s => s.phase !== "trick-end" ? s
         : { ...s, phase: "playing", currentTrick: [], ledSuit: null });
     }, 900);
     return () => clearTimeout(t);
@@ -404,29 +454,29 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     if (phase !== "playing" || currentPlayer === 0) return;
     if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
     aiTimerRef.current = setTimeout(() => {
-      setState((s) => {
+      setState(s => {
         if (s.phase !== "playing" || s.currentPlayer === 0) return s;
-        const ai = s.currentPlayer;
+        const ai    = s.currentPlayer;
         const valid = getValidHeartPlays(s.hands[ai], s.ledSuit, s.heartsAreBroken, s.isFirstTrick);
         if (valid.length === 0) return s;
-        const chosen = aiChooseCard(valid, s.currentTrick, s.ledSuit);
+        const chosen  = aiChooseCard(valid, s.currentTrick, s.ledSuit);
         const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex: ai, card: chosen }];
-        const newHands = s.hands.map((h, i) => i === ai ? h.filter((c) => c.id !== chosen.id) : h);
+        const newHands = s.hands.map((h, i) => i === ai ? h.filter(c => c.id !== chosen.id) : h);
         const newLed: Suit | null = s.currentTrick.length === 0 ? (chosen.suit as Suit) : s.ledSuit;
         const newBroken = s.heartsAreBroken || chosen.suit === "hearts";
         if (newTrick.length < 4)
           return { ...s, hands: newHands, currentTrick: newTrick, ledSuit: newLed,
             currentPlayer: (ai + 1) % 4, heartsAreBroken: newBroken };
         const winner = resolveTrick(newTrick, newLed!);
-        const pts = trickPoints(newTrick.map((p) => p.card));
-        const newHS = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
-        const newT = s.tricksThisHand + 1;
+        const pts    = trickPoints(newTrick.map(p => p.card));
+        const newHS  = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
+        const newT   = s.tricksThisHand + 1;
         if (newT === 13) {
           const newCum = applyHandScores(newHS, s.scores);
           return { ...s, hands: newHands, handScores: newHS, scores: newCum,
             currentTrick: newTrick, ledSuit: newLed, heartsAreBroken: newBroken,
-            isFirstTrick: false, tricksThisHand: newT, currentPlayer: winner, trickLeader: winner,
-            phase: newCum.some((sc) => sc >= 100) ? "game-over" : "hand-end" };
+            isFirstTrick: false, tricksThisHand: newT, currentPlayer: winner,
+            trickLeader: winner, phase: newCum.some(sc => sc >= 100) ? "game-over" : "hand-end" };
         }
         return { ...s, hands: newHands, handScores: newHS, currentTrick: newTrick,
           ledSuit: newLed, heartsAreBroken: newBroken, isFirstTrick: false,
@@ -436,19 +486,28 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     return () => { if (aiTimerRef.current) clearTimeout(aiTimerRef.current); };
   }, [phase, currentPlayer, tricksThisHand]);
 
-  // ── Between-hand ───────────────────────────────────────────────────────────
+  // ── Between hands ──────────────────────────────────────────────────────────
 
   const startNextHand = useCallback(() => {
-    setState((s) => makeInitialState(s.handNumber + 1, s.scores));
+    setState(s => makeInitialState(s.handNumber + 1, s.scores));
   }, []);
 
   const startNewGame = useCallback(() => { setState(freshGame()); }, []);
 
+  // ── Pass label ─────────────────────────────────────────────────────────────
+
+  function passLabel(): string {
+    if (passDir === "left")   return "→ Pass Left";
+    if (passDir === "right")  return "← Pass Right";
+    if (passDir === "across") return "↑ Pass Across";
+    return "";
+  }
+
   // ── Menus ──────────────────────────────────────────────────────────────────
 
-  const heartsMenus = useMemo<MenuBarMenu[]>(() => ([
+  const menus = useMemo<MenuBarMenu[]>(() => ([
     { label: "Game", items: [
-      { label: "New Hand", onClick: startNextHand },
+      { label: "New Hand",    onClick: startNextHand },
       { label: "Show Scores", onClick: () => setShowScores(true) },
       { separator: true },
       ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
@@ -459,26 +518,12 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     ]},
   ]), [startNextHand, onNewGame, onQuit]);
 
-  useWindowMenus(heartsMenus);
-
-  // ── Render helpers ─────────────────────────────────────────────────────────
-
-  function trickCardFor(pi: number): Card | null {
-    return currentTrick.find((p) => p.playerIndex === pi)?.card ?? null;
-  }
-  function passLabel(): string {
-    if (passDir === "left")   return "→ Pass Left";
-    if (passDir === "right")  return "← Pass Right";
-    if (passDir === "across") return "↑ Pass Across";
-    return "";
-  }
-
-  const passTargetName     = passDir !== "none" ? PLAYER_NAMES[passTarget(0, passDir)] : "";
-  const gameOverWinnerIdx  = state.scores.indexOf(Math.min(...state.scores));
-  const hOverlap           = handOverlap(humanHand.length, 72, 300);
-  const nOverlap           = handOverlap(hands[2].length, 52, 280);
+  useWindowMenus(menus);
 
   // ── Render ─────────────────────────────────────────────────────────────────
+
+  const gameOverWinnerIdx = scores.indexOf(Math.min(...scores));
+  const passTargetName    = passDir !== "none" ? PLAYER_NAMES[passTarget(0, passDir)] : "";
 
   return (
     <div className="hearts">
@@ -489,11 +534,11 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       {/* Score / hand-end modal */}
       {(phase === "hand-end" || phase === "game-over" || showScores) && (
         <div className="hearts-modal-overlay" onClick={showScores ? () => setShowScores(false) : undefined}>
-          <div className="hearts-modal" onClick={(e) => e.stopPropagation()}>
+          <div className="hearts-modal" onClick={e => e.stopPropagation()}>
             <div className="hearts-modal__titlebar">
               <span>{phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}</span>
               {showScores && (
-                <button className="hearts-modal__close" onClick={() => setShowScores(false)} aria-label="Close">✕</button>
+                <button className="hearts-modal__close" onClick={() => setShowScores(false)}>✕</button>
               )}
             </div>
             <div className="hearts-modal__body">
@@ -537,206 +582,96 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         </div>
       )}
 
-      {/* ── Table ── */}
-      <div className="hearts__table" ref={tableRef}>
-
-        {/* Flying card overlays */}
-        {flyingCards.map((fc) => {
-          const cw = fc.sm ? 52 : 72;
-          const ch = fc.sm ? 72 : 100;
-          return (
-            <div
-              key={fc.id}
-              className="hearts__flying-card"
-              style={{
-                width: cw,
-                height: ch,
-                "--from-tx": `${fc.fromX - cw / 2}px`,
-                "--from-ty": `${fc.fromY - ch / 2}px`,
-                "--to-tx":   `${fc.toX   - cw / 2}px`,
-                "--to-ty":   `${fc.toY   - ch / 2}px`,
-                "--land-angle": `${fc.landAngle}deg`,
-              } as React.CSSProperties}
-              onAnimationEnd={(e: React.AnimationEvent<HTMLDivElement>) => {
-                if (e.animationName === "hearts-fly-card")
-                  setFlyingCards((prev) => prev.filter((f) => f.id !== fc.id));
-              }}
-            >
-              {fc.doFlip ? (
-                <div className="hearts__fcard-flipper">
-                  <div className="hearts__fcard-back">
-                    <PlayingCard card={fc.card} faceDown appearance={appearance} size={fc.sm ? "sm" : undefined} />
-                  </div>
-                  <div className="hearts__fcard-front">
-                    <PlayingCard card={fc.card} appearance={appearance} size={fc.sm ? "sm" : undefined} />
-                  </div>
-                </div>
-              ) : (
-                <PlayingCard card={fc.card} appearance={appearance} size={fc.sm ? "sm" : undefined} />
-              )}
-            </div>
-          );
-        })}
-
-        {/* North AI */}
-        <div className="hearts__zone hearts__zone--north" ref={northZoneRef}>
-          <div className="hearts__player-label hearts__player-label--ai">
+      {/* Stage */}
+      <div ref={containerRef} className="hearts__stage-container">
+        <div
+          className="hearts__stage"
+          style={{ width: STAGE_W, height: STAGE_H, transform: `scale(${scale})`, transformOrigin: "top left" }}
+        >
+          {/* Player labels — absolutely positioned within stage */}
+          <div className="hearts__label hearts__label--north">
             {PLAYER_NAMES[2]}
             {currentPlayer === 2 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[2] > 0 && <span className="hearts__hand-score-badge">{handScores[2]}pt</span>}
+            {handScores[2] > 0 && <span className="hearts__badge">{handScores[2]}pt</span>}
           </div>
-          <div className="hearts__ai-fan hearts__ai-fan--horiz"
-            style={{ "--ai-overlap": `${nOverlap}px` } as React.CSSProperties}>
-            {hands[2].map((card, idx) => (
-              <PlayingCard key={`n-${dealKey}-${card.id}`} card={card} faceDown
-                appearance={appearance} size="sm" dealIndex={idx} />
-            ))}
-          </div>
-        </div>
-
-        {/* West AI */}
-        <div className="hearts__zone hearts__zone--west" ref={westZoneRef}>
-          <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
+          <div className="hearts__label hearts__label--west">
             {PLAYER_NAMES[1]}
             {currentPlayer === 1 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[1] > 0 && <span className="hearts__hand-score-badge">{handScores[1]}pt</span>}
+            {handScores[1] > 0 && <span className="hearts__badge">{handScores[1]}pt</span>}
           </div>
-          <div className="hearts__ai-fan hearts__ai-fan--vert">
-            {hands[1].slice(0, 8).map((card, idx) => (
-              <PlayingCard key={`w-${dealKey}-${card.id}`} card={card} faceDown
-                appearance={appearance} size="sm" dealIndex={idx} />
-            ))}
-            {hands[1].length > 8 && <div className="hearts__ai-extra">+{hands[1].length - 8}</div>}
+          <div className="hearts__label hearts__label--east">
+            {PLAYER_NAMES[3]}
+            {currentPlayer === 3 && phase === "playing" && <span className="hearts__turn-dot" />}
+            {handScores[3] > 0 && <span className="hearts__badge">{handScores[3]}pt</span>}
           </div>
-        </div>
+          <div className="hearts__label hearts__label--south">
+            {PLAYER_NAMES[0]}
+            {isHumanTurn && <span className="hearts__turn-dot hearts__turn-dot--human" />}
+            <span className="hearts__score-inline">{scores[0]}pts</span>
+          </div>
 
-        {/* Trick area */}
-        <div className="hearts__trick-area">
-          <div className="hearts__trick-slot hearts__trick-slot--n"
-            ref={(el) => { if (el) trickSlotRefs.current.set(2, el); }}>
-            {trickCardFor(2) && (
-              <div key={trickCardFor(2)!.id} className="hearts__trick-card">
-                <PlayingCard card={trickCardFor(2)!} appearance={appearance} size="sm" />
-              </div>
-            )}
-          </div>
-          <div className="hearts__trick-slot hearts__trick-slot--w"
-            ref={(el) => { if (el) trickSlotRefs.current.set(1, el); }}>
-            {trickCardFor(1) && (
-              <div key={trickCardFor(1)!.id} className="hearts__trick-card">
-                <PlayingCard card={trickCardFor(1)!} appearance={appearance} size="sm" />
-              </div>
-            )}
-          </div>
-          <div className="hearts__trick-center-info">
+          {/* Center info */}
+          <div className="hearts__center-info">
             {(phase === "playing" || phase === "trick-end") && (
               <span className="hearts__trick-count">{tricksThisHand}/13</span>
             )}
             {heartsAreBroken && <span className="hearts__broken">♥</span>}
           </div>
-          <div className="hearts__trick-slot hearts__trick-slot--e"
-            ref={(el) => { if (el) trickSlotRefs.current.set(3, el); }}>
-            {trickCardFor(3) && (
-              <div key={trickCardFor(3)!.id} className="hearts__trick-card">
-                <PlayingCard card={trickCardFor(3)!} appearance={appearance} size="sm" />
-              </div>
-            )}
-          </div>
-          <div className="hearts__trick-slot hearts__trick-slot--s"
-            ref={(el) => { if (el) trickSlotRefs.current.set(0, el); }}>
-            {trickCardFor(0) && (
-              <div key={trickCardFor(0)!.id} className="hearts__trick-card">
-                <PlayingCard card={trickCardFor(0)!} appearance={appearance} size="sm" />
-              </div>
-            )}
-          </div>
-        </div>
 
-        {/* East AI */}
-        <div className="hearts__zone hearts__zone--east" ref={eastZoneRef}>
-          <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
-            {PLAYER_NAMES[3]}
-            {currentPlayer === 3 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[3] > 0 && <span className="hearts__hand-score-badge">{handScores[3]}pt</span>}
-          </div>
-          <div className="hearts__ai-fan hearts__ai-fan--vert">
-            {hands[3].slice(0, 8).map((card, idx) => (
-              <PlayingCard key={`e-${dealKey}-${card.id}`} card={card} faceDown
-                appearance={appearance} size="sm" dealIndex={idx} />
-            ))}
-            {hands[3].length > 8 && <div className="hearts__ai-extra">+{hands[3].length - 8}</div>}
-          </div>
-        </div>
-
-        {/* South — human */}
-        <div className="hearts__zone hearts__zone--south">
-          <div className="hearts__player-label">
-            {PLAYER_NAMES[0]}
-            {isHumanTurn && phase === "playing" && <span className="hearts__turn-dot hearts__turn-dot--human" />}
-            <span className="hearts__score-inline">{scores[0]}pts</span>
-          </div>
-
+          {/* Passing UI */}
           {phase === "passing" && (
-            <div className="hearts__pass-hint">
-              Select 3 to pass to {passTargetName}
-              {passedCards.length > 0 && ` (${passedCards.length}/3)`}
+            <div className="hearts__pass-overlay">
+              <div className="hearts__pass-hint">
+                Select 3 · {passLabel()} · to {passTargetName}
+                {passedCards.length > 0 && ` (${passedCards.length}/3)`}
+              </div>
+              {passedCards.length === 3 && (
+                <button className="hearts-btn hearts-btn--primary hearts-btn--sm" onClick={confirmPass}>
+                  {passLabel()} →
+                </button>
+              )}
             </div>
           )}
 
-          <div
-            className={`hearts__human-hand${phase === "passing" ? " hearts__human-hand--passing" : ""}`}
-            style={{ "--hand-overlap": `${hOverlap}px` } as React.CSSProperties}
-          >
-            {humanHand.map((card, idx) => {
-              const angle = fanAngle(idx, humanHand.length);
-              const isSelected = phase === "passing"
-                ? passedCards.some((c) => c.id === card.id)
-                : selectedCard === card.id;
-              const isValid    = phase === "playing" && isHumanTurn && validIds.has(card.id);
-              const isPlayable = phase === "passing" || isValid;
-              const hasReceived = receivedCards.some((c) => c.id === card.id);
-              return (
-                <div
-                  key={`h-${dealKey}-${card.id}`}
-                  ref={(el) => { if (el) humanCardRefs.current.set(card.id, el); else humanCardRefs.current.delete(card.id); }}
-                  className={[
-                    "hearts__fan-item",
-                    isSelected  ? "hearts__fan-item--selected"  : "",
-                    isValid && !isSelected ? "hearts__fan-item--valid" : "",
-                    isPlayable  ? "hearts__fan-item--clickable" : "",
-                    hasReceived ? "hearts__fan-item--received"  : "",
-                  ].filter(Boolean).join(" ")}
-                  style={{
-                    "--fan-angle": `${angle}deg`,
-                    "--fan-i": idx,
-                    zIndex: isSelected ? 20 : idx + 1,
-                  } as React.CSSProperties}
-                  onClick={() => handleCardClick(card)}
-                >
-                  <PlayingCard card={card} appearance={appearance} />
-                </div>
-              );
-            })}
-          </div>
-
-          {phase === "passing" && passedCards.length === 3 && (
-            <div className="hearts__pass-actions">
-              <button className="hearts-btn hearts-btn--primary" onClick={confirmPass}>{passLabel()} →</button>
-            </div>
-          )}
+          {/* Play hint */}
           {phase === "playing" && isHumanTurn && selectedCard && (
-            <div className="hearts__play-hint">Click again to play</div>
+            <div className="hearts__play-hint">Tap again to play</div>
           )}
-          {phase === "playing" && !isHumanTurn && currentPlayer !== 0 && (
-            <div className="hearts__play-hint">{PLAYER_NAMES[currentPlayer]}{"'s turn..."}</div>
+          {phase === "playing" && !isHumanTurn && (
+            <div className="hearts__play-hint">{PLAYER_NAMES[currentPlayer]}{"'s turn…"}</div>
           )}
-        </div>
 
+          {/* All 52 cards — permanently mounted */}
+          {FIXED_DECK.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            const inHumanHand = hands[0].some(c => c.id === card.id);
+            const isPassSel   = passedCards.some(c => c.id === card.id);
+            const isPlaySel   = selectedCard === card.id;
+            const isValid     = validIds.has(card.id);
+            const isReceived  = receivedIds.has(card.id);
+            let highlightColor: string | undefined;
+            if (isPassSel || isPlaySel)                          highlightColor = "#cc4400";
+            else if (isValid && isHumanTurn)                     highlightColor = "#228833";
+            else if (isReceived)                                  highlightColor = "#5b2d8e";
+            return (
+              <PermCard
+                key={card.id}
+                card={card}
+                cs={cs}
+                appearance={appearance}
+                size="sm"
+                highlightColor={highlightColor}
+                onClick={inHumanHand || (phase === "passing" && isPassSel) ? () => handleCardClick(card) : undefined}
+              />
+            );
+          })}
+        </div>
       </div>
 
       {/* Status bar */}
-      <div className="hearts__status-bar">
-        <span>Hand {handNumber + 1} · Trick {Math.min(tricksThisHand + 1, 13)}/13 · Pass: {passDir === "none" ? "None" : passDir}</span>
+      <div className="hearts__statusbar">
+        <span>Hand {handNumber + 1} · Trick {Math.min(tricksThisHand + 1, 13)}/13</span>
         <span className="hearts__scores-row">
           {PLAYER_NAMES.map((name, i) => (
             <span key={i} className="hearts__score-item">{name}: {scores[i]}</span>

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -40,13 +40,7 @@ function buildDeck(): Card[] {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type HeartsPhase =
-  | "passing"
-  | "playing"
-  | "trick-end"
-  | "hand-end"
-  | "game-over";
-
+type HeartsPhase = "passing" | "playing" | "trick-end" | "hand-end" | "game-over";
 type PassDir = "left" | "right" | "across" | "none";
 
 interface HeartsState {
@@ -68,6 +62,18 @@ interface HeartsState {
   selectedCard: string | null;
 }
 
+interface FlyingCard {
+  id: string;
+  card: Card;
+  fromX: number;     // source center, table-relative px
+  fromY: number;
+  toX: number;       // dest center, table-relative px
+  toY: number;
+  landAngle: number; // random ±12° landing rotation
+  doFlip: boolean;   // true = AI card, flip back→front mid-flight
+  sm: boolean;       // true = use sm card size
+}
+
 const PLAYER_NAMES = ["You", "West", "North", "East"];
 
 function passDirection(handNumber: number): PassDir {
@@ -82,7 +88,7 @@ function passTarget(from: number, dir: PassDir): number {
   return from;
 }
 
-// ── AI Helpers ────────────────────────────────────────────────────────────────
+// ── AI helpers ────────────────────────────────────────────────────────────────
 
 function problemScore(card: Card): number {
   if (card.suit === "spades") {
@@ -96,71 +102,43 @@ function problemScore(card: Card): number {
 }
 
 function aiSelectCardsToPass(hand: Card[]): Card[] {
-  const sorted = [...hand].sort((a, b) => problemScore(b) - problemScore(a));
-  return sorted.slice(0, 3);
+  return [...hand].sort((a, b) => problemScore(b) - problemScore(a)).slice(0, 3);
 }
 
-function aiChooseCard(
-  valid: Card[],
-  trick: TrickPlay[],
-  ledSuit: Suit | null,
-): Card {
+function aiChooseCard(valid: Card[], trick: TrickPlay[], ledSuit: Suit | null): Card {
   if (trick.length === 0 || ledSuit === null) {
-    const nonHearts = valid.filter((c) => c.suit !== "hearts");
-    const pool = nonHearts.length > 0 ? nonHearts : valid;
-    return pool.reduce((best, c) =>
-      rankValue(c.rank as string) < rankValue(best.rank as string) ? c : best
-    );
+    const pool = valid.filter((c) => c.suit !== "hearts");
+    const src = pool.length > 0 ? pool : valid;
+    return src.reduce((b, c) => rankValue(c.rank as string) < rankValue(b.rank as string) ? c : b);
   }
-
-  const canFollowSuit = valid.some((c) => c.suit === ledSuit);
-  if (canFollowSuit) {
-    const suitCards = valid.filter((c) => c.suit === ledSuit);
-    let winnerVal = -1;
-    for (const play of trick) {
-      if (play.card.suit === ledSuit) {
-        const v = rankValue(play.card.rank as string);
-        if (v > winnerVal) winnerVal = v;
-      }
+  const canFollow = valid.some((c) => c.suit === ledSuit);
+  if (canFollow) {
+    const suit = valid.filter((c) => c.suit === ledSuit);
+    let winV = -1;
+    for (const p of trick) {
+      if (p.card.suit === ledSuit) winV = Math.max(winV, rankValue(p.card.rank as string));
     }
-    const losers = suitCards.filter((c) => rankValue(c.rank as string) < winnerVal);
-    if (losers.length > 0) {
-      return losers.reduce((best, c) =>
-        rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
-      );
-    }
-    return suitCards.reduce((best, c) =>
-      rankValue(c.rank as string) < rankValue(best.rank as string) ? c : best
-    );
+    const losers = suit.filter((c) => rankValue(c.rank as string) < winV);
+    const pool = losers.length > 0 ? losers : suit;
+    const op = losers.length > 0 ? (a: Card, b: Card) => rankValue(b.rank as string) - rankValue(a.rank as string)
+                                  : (a: Card, b: Card) => rankValue(a.rank as string) - rankValue(b.rank as string);
+    return pool.reduce((best, c) => op(c, best) < 0 ? c : best);
   }
-
   const qs = valid.find((c) => c.suit === "spades" && c.rank === "Q");
   if (qs) return qs;
   const hearts = valid.filter((c) => c.suit === "hearts");
-  if (hearts.length > 0) {
-    return hearts.reduce((best, c) =>
-      rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
-    );
-  }
-  return valid.reduce((best, c) =>
-    rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
-  );
+  if (hearts.length > 0)
+    return hearts.reduce((b, c) => rankValue(c.rank as string) > rankValue(b.rank as string) ? c : b);
+  return valid.reduce((b, c) => rankValue(c.rank as string) > rankValue(b.rank as string) ? c : b);
 }
 
-// ── Shoot the moon check ──────────────────────────────────────────────────────
-
-function applyHandScores(
-  handScores: number[],
-  cumulativeScores: number[],
-): number[] {
-  const moonShooterIdx = handScores.findIndex((s) => s === 26);
-  if (moonShooterIdx !== -1) {
-    return cumulativeScores.map((s, i) => (i === moonShooterIdx ? s : s + 26));
-  }
-  return cumulativeScores.map((s, i) => s + handScores[i]);
+function applyHandScores(handScores: number[], cumulative: number[]): number[] {
+  const moon = handScores.findIndex((s) => s === 26);
+  if (moon !== -1) return cumulative.map((s, i) => (i === moon ? s : s + 26));
+  return cumulative.map((s, i) => s + handScores[i]);
 }
 
-// ── Initial state factory ─────────────────────────────────────────────────────
+// ── State factory ─────────────────────────────────────────────────────────────
 
 function makeInitialState(handNumber: number, prevScores: number[]): HeartsState {
   const deck = buildDeck();
@@ -169,20 +147,13 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
   const sortHand = (hand: Card[]) =>
     [...hand].sort((a, b) => {
       const sd = suitOrder[a.suit] - suitOrder[b.suit];
-      if (sd !== 0) return sd;
-      return rankValue(a.rank as string) - rankValue(b.rank as string);
+      return sd !== 0 ? sd : rankValue(a.rank as string) - rankValue(b.rank as string);
     });
-
   const dir = passDirection(handNumber);
-
   let trickLeader = 0;
   for (let i = 0; i < 4; i++) {
-    if (hands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
-      trickLeader = i;
-      break;
-    }
+    if (hands[i].some((c) => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
   }
-
   return {
     hands: hands.map(sortHand),
     scores: prevScores,
@@ -203,20 +174,16 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
   };
 }
 
-function freshGame(): HeartsState {
-  return makeInitialState(0, [0, 0, 0, 0]);
-}
+function freshGame(): HeartsState { return makeInitialState(0, [0, 0, 0, 0]); }
 
 // ── Fan helpers ───────────────────────────────────────────────────────────────
 
-// Returns rotation angle in degrees for a card at position idx in a hand of total
 function fanAngle(idx: number, total: number): number {
   if (total <= 1) return 0;
   const mid = (total - 1) / 2;
   return ((idx - mid) / mid) * 11;
 }
 
-// Overlap in px to keep a horizontal hand within maxWidth
 function handOverlap(count: number, cardW: number, maxW: number): number {
   if (count <= 1) return 0;
   return Math.max(0, Math.round((count * cardW - maxW) / (count - 1)));
@@ -236,10 +203,20 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [showScores, setShowScores] = useState(false);
   const [dealKey, setDealKey] = useState(0);
-  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [flyingCards, setFlyingCards] = useState<FlyingCard[]>([]);
+
+  // Refs for flying card coordinate math
+  const tableRef       = useRef<HTMLDivElement>(null);
+  const northZoneRef   = useRef<HTMLDivElement>(null);
+  const westZoneRef    = useRef<HTMLDivElement>(null);
+  const eastZoneRef    = useRef<HTMLDivElement>(null);
+  const humanCardRefs  = useRef<Map<string, HTMLDivElement>>(new Map());
+  const trickSlotRefs  = useRef<Map<number, HTMLDivElement>>(new Map());
+  const prevTrickLen   = useRef(0);
+  const aiTimerRef     = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevHandNumRef = useRef(state.handNumber);
 
-  // Increment dealKey on each new hand so cards remount and re-animate
+  // Increment dealKey when hand changes (triggers deal animation)
   useEffect(() => {
     if (state.handNumber !== prevHandNumRef.current) {
       prevHandNumRef.current = state.handNumber;
@@ -247,18 +224,66 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     }
   }, [state.handNumber]);
 
+  // Clear flying cards on new deal
+  useEffect(() => {
+    setFlyingCards([]);
+    prevTrickLen.current = 0;
+  }, [dealKey]);
+
   // ── Derived ────────────────────────────────────────────────────────────────
 
   const { hands, scores, handScores, phase, passDir, passedCards, receivedCards,
     currentTrick, ledSuit, currentPlayer,
     heartsAreBroken, isFirstTrick, tricksThisHand, handNumber, selectedCard } = state;
 
-  const humanHand = hands[0];
+  const humanHand   = hands[0];
   const isHumanTurn = phase === "playing" && currentPlayer === 0;
-  const validPlays = isHumanTurn
+  const validPlays  = isHumanTurn
     ? getValidHeartPlays(humanHand, ledSuit, heartsAreBroken, isFirstTrick)
     : [];
   const validIds = new Set<string>(validPlays.map((c) => c.id));
+
+  // ── Flying card launcher ───────────────────────────────────────────────────
+
+  const launchCard = useCallback((
+    card: Card,
+    fromEl: HTMLElement | null,
+    toSlotPlayer: number,
+    doFlip: boolean,
+    sm: boolean,
+  ) => {
+    const toEl = trickSlotRefs.current.get(toSlotPlayer) ?? null;
+    if (!tableRef.current || !fromEl || !toEl) return;
+    const tr  = tableRef.current.getBoundingClientRect();
+    const fr  = fromEl.getBoundingClientRect();
+    const tor = toEl.getBoundingClientRect();
+    setFlyingCards((prev) => [...prev, {
+      id: `fly-${card.id}-${Date.now()}`,
+      card,
+      fromX: fr.left  - tr.left + fr.width  / 2,
+      fromY: fr.top   - tr.top  + fr.height / 2,
+      toX:  tor.left  - tr.left + tor.width  / 2,
+      toY:  tor.top   - tr.top  + tor.height / 2,
+      landAngle: (Math.random() - 0.5) * 24,
+      doFlip,
+      sm,
+    }]);
+  }, []);
+
+  // Detect AI card plays and launch flying card
+  useEffect(() => {
+    if (currentTrick.length === 0) { prevTrickLen.current = 0; return; }
+    if (currentTrick.length <= prevTrickLen.current) return;
+    const latest = currentTrick[currentTrick.length - 1];
+    if (latest.playerIndex !== 0) {
+      const pi = latest.playerIndex;
+      const fromEl = pi === 1 ? westZoneRef.current
+                   : pi === 2 ? northZoneRef.current
+                   : eastZoneRef.current;
+      launchCard(latest.card, fromEl, pi, true, true);
+    }
+    prevTrickLen.current = currentTrick.length;
+  }, [currentTrick, launchCard]);
 
   // ── Pass phase ─────────────────────────────────────────────────────────────
 
@@ -266,9 +291,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     if (phase !== "passing") return;
     setState((s) => {
       const already = s.passedCards.find((c) => c.id === cardId);
-      if (already) {
-        return { ...s, passedCards: s.passedCards.filter((c) => c.id !== cardId) };
-      }
+      if (already) return { ...s, passedCards: s.passedCards.filter((c) => c.id !== cardId) };
       if (s.passedCards.length >= 3) return s;
       const card = s.hands[0].find((c) => c.id === cardId);
       if (!card) return s;
@@ -279,60 +302,31 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   const confirmPass = useCallback(() => {
     setState((s) => {
       if (s.passedCards.length !== 3) return s;
-
-      const aiPasses: Card[][] = [[], [], [], []];
-      aiPasses[0] = s.passedCards;
-      for (let i = 1; i < 4; i++) {
-        aiPasses[i] = aiSelectCardsToPass(s.hands[i]);
-      }
-
-      const newHands = s.hands.map((hand) => [...hand]);
+      const aiPasses: Card[][] = [s.passedCards, [], [], []];
+      for (let i = 1; i < 4; i++) aiPasses[i] = aiSelectCardsToPass(s.hands[i]);
+      const newHands = s.hands.map((h) => [...h]);
       for (let from = 0; from < 4; from++) {
         const to = passTarget(from, s.passDir);
         if (to === from) continue;
-        const passing = aiPasses[from];
-        newHands[from] = newHands[from].filter(
-          (c) => !passing.some((p) => p.id === c.id)
-        );
-        newHands[to] = [...newHands[to], ...passing];
+        newHands[from] = newHands[from].filter((c) => !aiPasses[from].some((p) => p.id === c.id));
+        newHands[to] = [...newHands[to], ...aiPasses[from]];
       }
-
       const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
-      const sortHand = (hand: Card[]) =>
-        [...hand].sort((a, b) => {
-          const sd = suitOrder[a.suit] - suitOrder[b.suit];
-          if (sd !== 0) return sd;
-          return rankValue(a.rank as string) - rankValue(b.rank as string);
-        });
-
-      const sortedHands = newHands.map(sortHand);
-
+      const sort = (h: Card[]) => [...h].sort((a, b) => {
+        const sd = suitOrder[a.suit] - suitOrder[b.suit];
+        return sd !== 0 ? sd : rankValue(a.rank as string) - rankValue(b.rank as string);
+      });
+      const sorted = newHands.map(sort);
       let trickLeader = 0;
       for (let i = 0; i < 4; i++) {
-        if (sortedHands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
-          trickLeader = i;
-          break;
-        }
+        if (sorted[i].some((c) => c.suit === "clubs" && c.rank === "2")) { trickLeader = i; break; }
       }
-
-      const humanReceivedFrom: number[] = [];
-      for (let from = 0; from < 4; from++) {
-        if (passTarget(from, s.passDir) === 0 && from !== 0) {
-          humanReceivedFrom.push(from);
-        }
-      }
-      const receivedCards = humanReceivedFrom.flatMap((from) => aiPasses[from]);
-
+      const received = Array.from({ length: 4 }, (_, from) =>
+        passTarget(from, s.passDir) === 0 && from !== 0 ? aiPasses[from] : []
+      ).flat();
       return {
-        ...s,
-        hands: sortedHands,
-        phase: "playing",
-        passedCards: [],
-        receivedCards,
-        trickLeader,
-        currentPlayer: trickLeader,
-        currentTrick: [],
-        ledSuit: null,
+        ...s, hands: sorted, phase: "playing", passedCards: [], receivedCards: received,
+        trickLeader, currentPlayer: trickLeader, currentTrick: [], ledSuit: null,
       };
     });
   }, []);
@@ -341,80 +335,40 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
   const playCard = useCallback((playerIndex: number, card: Card) => {
     setState((s) => {
-      if (s.phase !== "playing") return s;
-      if (s.currentPlayer !== playerIndex) return s;
-
-      const valid = getValidHeartPlays(
-        s.hands[playerIndex],
-        s.ledSuit,
-        s.heartsAreBroken,
-        s.isFirstTrick
-      );
+      if (s.phase !== "playing" || s.currentPlayer !== playerIndex) return s;
+      const valid = getValidHeartPlays(s.hands[playerIndex], s.ledSuit, s.heartsAreBroken, s.isFirstTrick);
       if (!valid.some((c) => c.id === card.id)) return s;
 
       const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex, card }];
-      const newHands = s.hands.map((hand, i) =>
-        i === playerIndex ? hand.filter((c) => c.id !== card.id) : hand
-      );
-
-      const newLedSuit: Suit | null =
-        s.currentTrick.length === 0 ? (card.suit as Suit) : s.ledSuit;
-
-      const newHeartsAreBroken =
-        s.heartsAreBroken || card.suit === "hearts";
+      const newHands = s.hands.map((h, i) => i === playerIndex ? h.filter((c) => c.id !== card.id) : h);
+      const newLed: Suit | null = s.currentTrick.length === 0 ? (card.suit as Suit) : s.ledSuit;
+      const newBroken = s.heartsAreBroken || card.suit === "hearts";
 
       if (newTrick.length < 4) {
-        const nextPlayer = (playerIndex + 1) % 4;
-        return {
-          ...s,
-          hands: newHands,
-          currentTrick: newTrick,
-          ledSuit: newLedSuit,
-          currentPlayer: nextPlayer,
-          heartsAreBroken: newHeartsAreBroken,
-          selectedCard: null,
-        };
+        return { ...s, hands: newHands, currentTrick: newTrick, ledSuit: newLed,
+          currentPlayer: (playerIndex + 1) % 4, heartsAreBroken: newBroken, selectedCard: null };
       }
 
-      const winner = resolveTrick(newTrick, newLedSuit!);
+      const winner = resolveTrick(newTrick, newLed!);
       const pts = trickPoints(newTrick.map((p) => p.card));
-      const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
-      const newTricksThisHand = s.tricksThisHand + 1;
-      const newIsFirstTrick = false;
+      const newHandScores = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
+      const newTricks = s.tricksThisHand + 1;
 
-      if (newTricksThisHand === 13) {
-        const newCumulative = applyHandScores(newHandScores, s.scores);
-        const gameOver = newCumulative.some((sc) => sc >= 100);
+      if (newTricks === 13) {
+        const newCum = applyHandScores(newHandScores, s.scores);
         return {
-          ...s,
-          hands: newHands,
-          handScores: newHandScores,
-          scores: newCumulative,
-          currentTrick: newTrick,
-          ledSuit: newLedSuit,
-          heartsAreBroken: newHeartsAreBroken,
-          isFirstTrick: newIsFirstTrick,
-          tricksThisHand: newTricksThisHand,
-          currentPlayer: winner,
-          trickLeader: winner,
-          phase: gameOver ? "game-over" : "hand-end",
+          ...s, hands: newHands, handScores: newHandScores, scores: newCum,
+          currentTrick: newTrick, ledSuit: newLed, heartsAreBroken: newBroken,
+          isFirstTrick: false, tricksThisHand: newTricks, currentPlayer: winner,
+          trickLeader: winner, phase: newCum.some((sc) => sc >= 100) ? "game-over" : "hand-end",
           selectedCard: null,
         };
       }
-
       return {
-        ...s,
-        hands: newHands,
-        handScores: newHandScores,
-        currentTrick: newTrick,
-        ledSuit: newLedSuit,
-        heartsAreBroken: newHeartsAreBroken,
-        isFirstTrick: newIsFirstTrick,
-        tricksThisHand: newTricksThisHand,
-        currentPlayer: winner,
-        trickLeader: winner,
-        phase: "trick-end",
-        selectedCard: null,
+        ...s, hands: newHands, handScores: newHandScores, currentTrick: newTrick,
+        ledSuit: newLed, heartsAreBroken: newBroken, isFirstTrick: false,
+        tricksThisHand: newTricks, currentPlayer: winner, trickLeader: winner,
+        phase: "trick-end", selectedCard: null,
       };
     });
   }, []);
@@ -422,29 +376,24 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   // ── Human card click ───────────────────────────────────────────────────────
 
   const handleCardClick = useCallback((card: Card) => {
-    if (phase === "passing") {
-      togglePassCard(card.id);
-      return;
-    }
-    if (!isHumanTurn) return;
-    if (!validIds.has(card.id)) return;
-
+    if (phase === "passing") { togglePassCard(card.id); return; }
+    if (!isHumanTurn || !validIds.has(card.id)) return;
     if (selectedCard === card.id) {
+      // Launch flying card before state update so ref is still in DOM
+      launchCard(card, humanCardRefs.current.get(card.id) ?? null, 0, false, false);
       playCard(0, card);
     } else {
       setState((s) => ({ ...s, selectedCard: card.id }));
     }
-  }, [phase, isHumanTurn, validIds, selectedCard, togglePassCard, playCard]);
+  }, [phase, isHumanTurn, validIds, selectedCard, togglePassCard, playCard, launchCard]);
 
-  // ── Trick-end pause → clear trick ─────────────────────────────────────────
+  // ── Trick-end pause ────────────────────────────────────────────────────────
 
   useEffect(() => {
     if (phase !== "trick-end") return;
     const t = setTimeout(() => {
-      setState((s) => {
-        if (s.phase !== "trick-end") return s;
-        return { ...s, phase: "playing", currentTrick: [], ledSuit: null };
-      });
+      setState((s) => s.phase !== "trick-end" ? s
+        : { ...s, phase: "playing", currentTrick: [], ledSuit: null });
     }, 900);
     return () => clearTimeout(t);
   }, [phase, tricksThisHand]);
@@ -452,128 +401,71 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   // ── AI turns ───────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (phase !== "playing" && phase !== "trick-end") return;
-    if (currentPlayer === 0) return;
-    if (phase === "trick-end") return;
-
+    if (phase !== "playing" || currentPlayer === 0) return;
     if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
-
     aiTimerRef.current = setTimeout(() => {
       setState((s) => {
-        if (s.phase !== "playing") return s;
-        if (s.currentPlayer === 0) return s;
-
+        if (s.phase !== "playing" || s.currentPlayer === 0) return s;
         const ai = s.currentPlayer;
-        const valid = getValidHeartPlays(
-          s.hands[ai],
-          s.ledSuit,
-          s.heartsAreBroken,
-          s.isFirstTrick
-        );
+        const valid = getValidHeartPlays(s.hands[ai], s.ledSuit, s.heartsAreBroken, s.isFirstTrick);
         if (valid.length === 0) return s;
-
         const chosen = aiChooseCard(valid, s.currentTrick, s.ledSuit);
-
         const newTrick: TrickPlay[] = [...s.currentTrick, { playerIndex: ai, card: chosen }];
-        const newHands = s.hands.map((hand, i) =>
-          i === ai ? hand.filter((c) => c.id !== chosen.id) : hand
-        );
-        const newLedSuit: Suit | null =
-          s.currentTrick.length === 0 ? (chosen.suit as Suit) : s.ledSuit;
-        const newHeartsAreBroken =
-          s.heartsAreBroken || chosen.suit === "hearts";
-
-        if (newTrick.length < 4) {
-          const nextPlayer = (ai + 1) % 4;
-          return {
-            ...s,
-            hands: newHands,
-            currentTrick: newTrick,
-            ledSuit: newLedSuit,
-            currentPlayer: nextPlayer,
-            heartsAreBroken: newHeartsAreBroken,
-          };
-        }
-
-        const winner = resolveTrick(newTrick, newLedSuit!);
+        const newHands = s.hands.map((h, i) => i === ai ? h.filter((c) => c.id !== chosen.id) : h);
+        const newLed: Suit | null = s.currentTrick.length === 0 ? (chosen.suit as Suit) : s.ledSuit;
+        const newBroken = s.heartsAreBroken || chosen.suit === "hearts";
+        if (newTrick.length < 4)
+          return { ...s, hands: newHands, currentTrick: newTrick, ledSuit: newLed,
+            currentPlayer: (ai + 1) % 4, heartsAreBroken: newBroken };
+        const winner = resolveTrick(newTrick, newLed!);
         const pts = trickPoints(newTrick.map((p) => p.card));
-        const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
-        const newTricksThisHand = s.tricksThisHand + 1;
-
-        if (newTricksThisHand === 13) {
-          const newCumulative = applyHandScores(newHandScores, s.scores);
-          const gameOver = newCumulative.some((sc) => sc >= 100);
-          return {
-            ...s,
-            hands: newHands,
-            handScores: newHandScores,
-            scores: newCumulative,
-            currentTrick: newTrick,
-            ledSuit: newLedSuit,
-            heartsAreBroken: newHeartsAreBroken,
-            isFirstTrick: false,
-            tricksThisHand: newTricksThisHand,
-            currentPlayer: winner,
-            trickLeader: winner,
-            phase: gameOver ? "game-over" : "hand-end",
-          };
+        const newHS = s.handScores.map((hs, i) => i === winner ? hs + pts : hs);
+        const newT = s.tricksThisHand + 1;
+        if (newT === 13) {
+          const newCum = applyHandScores(newHS, s.scores);
+          return { ...s, hands: newHands, handScores: newHS, scores: newCum,
+            currentTrick: newTrick, ledSuit: newLed, heartsAreBroken: newBroken,
+            isFirstTrick: false, tricksThisHand: newT, currentPlayer: winner, trickLeader: winner,
+            phase: newCum.some((sc) => sc >= 100) ? "game-over" : "hand-end" };
         }
-
-        return {
-          ...s,
-          hands: newHands,
-          handScores: newHandScores,
-          currentTrick: newTrick,
-          ledSuit: newLedSuit,
-          heartsAreBroken: newHeartsAreBroken,
-          isFirstTrick: false,
-          tricksThisHand: newTricksThisHand,
-          currentPlayer: winner,
-          trickLeader: winner,
-          phase: "trick-end",
-        };
+        return { ...s, hands: newHands, handScores: newHS, currentTrick: newTrick,
+          ledSuit: newLed, heartsAreBroken: newBroken, isFirstTrick: false,
+          tricksThisHand: newT, currentPlayer: winner, trickLeader: winner, phase: "trick-end" };
       });
     }, 600);
-
-    return () => {
-      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
-    };
+    return () => { if (aiTimerRef.current) clearTimeout(aiTimerRef.current); };
   }, [phase, currentPlayer, tricksThisHand]);
 
-  // ── Between-hand: start next hand ─────────────────────────────────────────
+  // ── Between-hand ───────────────────────────────────────────────────────────
 
   const startNextHand = useCallback(() => {
     setState((s) => makeInitialState(s.handNumber + 1, s.scores));
   }, []);
 
-  const startNewGame = useCallback(() => {
-    setState(freshGame());
-  }, []);
+  const startNewGame = useCallback(() => { setState(freshGame()); }, []);
 
   // ── Menus ──────────────────────────────────────────────────────────────────
 
-  const heartsMenus = useMemo<MenuBarMenu[]>(() => {
-    const gameItems: MenuBarMenu["items"] = [
+  const heartsMenus = useMemo<MenuBarMenu[]>(() => ([
+    { label: "Game", items: [
       { label: "New Hand", onClick: startNextHand },
       { label: "Show Scores", onClick: () => setShowScores(true) },
       { separator: true },
       ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
-      ...(onQuit ? [{ label: "Exit", onClick: onQuit }] : []),
-    ];
-    return [
-      { label: "Game", items: gameItems },
-      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
-    ];
-  }, [startNextHand, onNewGame, onQuit]);
+      ...(onQuit    ? [{ label: "Exit",     onClick: onQuit    }] : []),
+    ]},
+    { label: "Options", items: [
+      { label: "Card Appearance…", onClick: () => setShowDeckModal(true) },
+    ]},
+  ]), [startNextHand, onNewGame, onQuit]);
 
   useWindowMenus(heartsMenus);
 
   // ── Render helpers ─────────────────────────────────────────────────────────
 
-  function trickCardFor(playerIdx: number): Card | null {
-    return currentTrick.find((p) => p.playerIndex === playerIdx)?.card ?? null;
+  function trickCardFor(pi: number): Card | null {
+    return currentTrick.find((p) => p.playerIndex === pi)?.card ?? null;
   }
-
   function passLabel(): string {
     if (passDir === "left")   return "→ Pass Left";
     if (passDir === "right")  return "← Pass Right";
@@ -581,45 +473,27 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     return "";
   }
 
-  const passTargetName = passDir !== "none" ? PLAYER_NAMES[passTarget(0, passDir)] : "";
-  const gameOverWinnerIdx = state.scores.indexOf(Math.min(...state.scores));
-
-  // Human hand overlap: fit 13 cards into ~300px max
-  const hOverlap = handOverlap(humanHand.length, 72, 300);
-  // North AI overlap: fit 13 sm cards into ~280px max
-  const nOverlap = handOverlap(hands[2].length, 52, 280);
+  const passTargetName     = passDir !== "none" ? PLAYER_NAMES[passTarget(0, passDir)] : "";
+  const gameOverWinnerIdx  = state.scores.indexOf(Math.min(...state.scores));
+  const hOverlap           = handOverlap(humanHand.length, 72, 300);
+  const nOverlap           = handOverlap(hands[2].length, 52, 280);
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
     <div className="hearts">
       {showDeckModal && (
-        <DeckModal
-          appearance={appearance}
-          onUpdate={setAppearance}
-          onClose={() => setShowDeckModal(false)}
-        />
+        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
 
-      {/* Hand-end / Game-over / Scores modal */}
+      {/* Score / hand-end modal */}
       {(phase === "hand-end" || phase === "game-over" || showScores) && (
-        <div
-          className="hearts-modal-overlay"
-          onClick={showScores ? () => setShowScores(false) : undefined}
-        >
+        <div className="hearts-modal-overlay" onClick={showScores ? () => setShowScores(false) : undefined}>
           <div className="hearts-modal" onClick={(e) => e.stopPropagation()}>
             <div className="hearts-modal__titlebar">
-              <span>
-                {phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}
-              </span>
+              <span>{phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}</span>
               {showScores && (
-                <button
-                  className="hearts-modal__close"
-                  onClick={() => setShowScores(false)}
-                  aria-label="Close"
-                >
-                  ✕
-                </button>
+                <button className="hearts-modal__close" onClick={() => setShowScores(false)} aria-label="Close">✕</button>
               )}
             </div>
             <div className="hearts-modal__body">
@@ -633,14 +507,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
                 </thead>
                 <tbody>
                   {PLAYER_NAMES.map((name, i) => (
-                    <tr
-                      key={i}
-                      className={
-                        phase === "game-over" && i === gameOverWinnerIdx
-                          ? "hearts-modal__winner-row"
-                          : ""
-                      }
-                    >
+                    <tr key={i} className={phase === "game-over" && i === gameOverWinnerIdx ? "hearts-modal__winner-row" : ""}>
                       <td>{name}</td>
                       {(phase === "hand-end" || phase === "game-over") && (
                         <td className={handScores[i] === 26 ? "hearts-modal__moon" : ""}>
@@ -659,90 +526,102 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
             <div className="hearts-modal__footer">
               {phase === "game-over" ? (
                 <>
-                  {onNewGame && (
-                    <button className="hearts-btn hearts-btn--primary" onClick={onNewGame}>
-                      Choose Game
-                    </button>
-                  )}
-                  <button className="hearts-btn hearts-btn--primary" onClick={startNewGame}>
-                    Play Again
-                  </button>
+                  {onNewGame && <button className="hearts-btn hearts-btn--primary" onClick={onNewGame}>Choose Game</button>}
+                  <button className="hearts-btn hearts-btn--primary" onClick={startNewGame}>Play Again</button>
                 </>
               ) : !showScores ? (
-                <button className="hearts-btn hearts-btn--primary" onClick={startNextHand}>
-                  Continue →
-                </button>
+                <button className="hearts-btn hearts-btn--primary" onClick={startNextHand}>Continue →</button>
               ) : null}
             </div>
           </div>
         </div>
       )}
 
-      {/* ── Table (felt) ── */}
-      <div className="hearts__table">
+      {/* ── Table ── */}
+      <div className="hearts__table" ref={tableRef}>
+
+        {/* Flying card overlays */}
+        {flyingCards.map((fc) => {
+          const cw = fc.sm ? 52 : 72;
+          const ch = fc.sm ? 72 : 100;
+          return (
+            <div
+              key={fc.id}
+              className="hearts__flying-card"
+              style={{
+                width: cw,
+                height: ch,
+                "--from-tx": `${fc.fromX - cw / 2}px`,
+                "--from-ty": `${fc.fromY - ch / 2}px`,
+                "--to-tx":   `${fc.toX   - cw / 2}px`,
+                "--to-ty":   `${fc.toY   - ch / 2}px`,
+                "--land-angle": `${fc.landAngle}deg`,
+              } as React.CSSProperties}
+              onAnimationEnd={(e: React.AnimationEvent<HTMLDivElement>) => {
+                if (e.animationName === "hearts-fly-card")
+                  setFlyingCards((prev) => prev.filter((f) => f.id !== fc.id));
+              }}
+            >
+              {fc.doFlip ? (
+                <div className="hearts__fcard-flipper">
+                  <div className="hearts__fcard-back">
+                    <PlayingCard card={fc.card} faceDown appearance={appearance} size={fc.sm ? "sm" : undefined} />
+                  </div>
+                  <div className="hearts__fcard-front">
+                    <PlayingCard card={fc.card} appearance={appearance} size={fc.sm ? "sm" : undefined} />
+                  </div>
+                </div>
+              ) : (
+                <PlayingCard card={fc.card} appearance={appearance} size={fc.sm ? "sm" : undefined} />
+              )}
+            </div>
+          );
+        })}
 
         {/* North AI */}
-        <div className="hearts__zone hearts__zone--north">
+        <div className="hearts__zone hearts__zone--north" ref={northZoneRef}>
           <div className="hearts__player-label hearts__player-label--ai">
             {PLAYER_NAMES[2]}
             {currentPlayer === 2 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[2] > 0 && (
-              <span className="hearts__hand-score-badge">{handScores[2]}pt</span>
-            )}
+            {handScores[2] > 0 && <span className="hearts__hand-score-badge">{handScores[2]}pt</span>}
           </div>
-          <div
-            className="hearts__ai-fan hearts__ai-fan--horiz"
-            style={{ "--ai-overlap": `${nOverlap}px` } as React.CSSProperties}
-          >
+          <div className="hearts__ai-fan hearts__ai-fan--horiz"
+            style={{ "--ai-overlap": `${nOverlap}px` } as React.CSSProperties}>
             {hands[2].map((card, idx) => (
-              <PlayingCard
-                key={`n-${dealKey}-${card.id}`}
-                card={card}
-                faceDown
-                appearance={appearance}
-                size="sm"
-                dealIndex={idx}
-              />
+              <PlayingCard key={`n-${dealKey}-${card.id}`} card={card} faceDown
+                appearance={appearance} size="sm" dealIndex={idx} />
             ))}
           </div>
         </div>
 
         {/* West AI */}
-        <div className="hearts__zone hearts__zone--west">
+        <div className="hearts__zone hearts__zone--west" ref={westZoneRef}>
           <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
             {PLAYER_NAMES[1]}
             {currentPlayer === 1 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[1] > 0 && (
-              <span className="hearts__hand-score-badge">{handScores[1]}pt</span>
-            )}
+            {handScores[1] > 0 && <span className="hearts__hand-score-badge">{handScores[1]}pt</span>}
           </div>
           <div className="hearts__ai-fan hearts__ai-fan--vert">
             {hands[1].slice(0, 8).map((card, idx) => (
-              <PlayingCard
-                key={`w-${dealKey}-${card.id}`}
-                card={card}
-                faceDown
-                appearance={appearance}
-                size="sm"
-                dealIndex={idx}
-              />
+              <PlayingCard key={`w-${dealKey}-${card.id}`} card={card} faceDown
+                appearance={appearance} size="sm" dealIndex={idx} />
             ))}
-            {hands[1].length > 8 && (
-              <div className="hearts__ai-extra">+{hands[1].length - 8}</div>
-            )}
+            {hands[1].length > 8 && <div className="hearts__ai-extra">+{hands[1].length - 8}</div>}
           </div>
         </div>
 
         {/* Trick area */}
         <div className="hearts__trick-area">
-          <div className="hearts__trick-slot hearts__trick-slot--n">
+          <div className="hearts__trick-slot hearts__trick-slot--n"
+            ref={(el) => { if (el) trickSlotRefs.current.set(2, el); }}>
             {trickCardFor(2) && (
               <div key={trickCardFor(2)!.id} className="hearts__trick-card">
                 <PlayingCard card={trickCardFor(2)!} appearance={appearance} size="sm" />
               </div>
             )}
           </div>
-          <div className="hearts__trick-slot hearts__trick-slot--w">
+          <div className="hearts__trick-slot hearts__trick-slot--w"
+            ref={(el) => { if (el) trickSlotRefs.current.set(1, el); }}>
             {trickCardFor(1) && (
               <div key={trickCardFor(1)!.id} className="hearts__trick-card">
                 <PlayingCard card={trickCardFor(1)!} appearance={appearance} size="sm" />
@@ -755,14 +634,16 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
             )}
             {heartsAreBroken && <span className="hearts__broken">♥</span>}
           </div>
-          <div className="hearts__trick-slot hearts__trick-slot--e">
+          <div className="hearts__trick-slot hearts__trick-slot--e"
+            ref={(el) => { if (el) trickSlotRefs.current.set(3, el); }}>
             {trickCardFor(3) && (
               <div key={trickCardFor(3)!.id} className="hearts__trick-card">
                 <PlayingCard card={trickCardFor(3)!} appearance={appearance} size="sm" />
               </div>
             )}
           </div>
-          <div className="hearts__trick-slot hearts__trick-slot--s">
+          <div className="hearts__trick-slot hearts__trick-slot--s"
+            ref={(el) => { if (el) trickSlotRefs.current.set(0, el); }}>
             {trickCardFor(0) && (
               <div key={trickCardFor(0)!.id} className="hearts__trick-card">
                 <PlayingCard card={trickCardFor(0)!} appearance={appearance} size="sm" />
@@ -772,38 +653,26 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         </div>
 
         {/* East AI */}
-        <div className="hearts__zone hearts__zone--east">
+        <div className="hearts__zone hearts__zone--east" ref={eastZoneRef}>
           <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
             {PLAYER_NAMES[3]}
             {currentPlayer === 3 && phase === "playing" && <span className="hearts__turn-dot" />}
-            {handScores[3] > 0 && (
-              <span className="hearts__hand-score-badge">{handScores[3]}pt</span>
-            )}
+            {handScores[3] > 0 && <span className="hearts__hand-score-badge">{handScores[3]}pt</span>}
           </div>
           <div className="hearts__ai-fan hearts__ai-fan--vert">
             {hands[3].slice(0, 8).map((card, idx) => (
-              <PlayingCard
-                key={`e-${dealKey}-${card.id}`}
-                card={card}
-                faceDown
-                appearance={appearance}
-                size="sm"
-                dealIndex={idx}
-              />
+              <PlayingCard key={`e-${dealKey}-${card.id}`} card={card} faceDown
+                appearance={appearance} size="sm" dealIndex={idx} />
             ))}
-            {hands[3].length > 8 && (
-              <div className="hearts__ai-extra">+{hands[3].length - 8}</div>
-            )}
+            {hands[3].length > 8 && <div className="hearts__ai-extra">+{hands[3].length - 8}</div>}
           </div>
         </div>
 
-        {/* South — human player */}
+        {/* South — human */}
         <div className="hearts__zone hearts__zone--south">
           <div className="hearts__player-label">
             {PLAYER_NAMES[0]}
-            {isHumanTurn && phase === "playing" && (
-              <span className="hearts__turn-dot hearts__turn-dot--human" />
-            )}
+            {isHumanTurn && phase === "playing" && <span className="hearts__turn-dot hearts__turn-dot--human" />}
             <span className="hearts__score-inline">{scores[0]}pts</span>
           </div>
 
@@ -823,19 +692,19 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
               const isSelected = phase === "passing"
                 ? passedCards.some((c) => c.id === card.id)
                 : selectedCard === card.id;
-              const isValid = phase === "playing" && isHumanTurn && validIds.has(card.id);
+              const isValid    = phase === "playing" && isHumanTurn && validIds.has(card.id);
               const isPlayable = phase === "passing" || isValid;
               const hasReceived = receivedCards.some((c) => c.id === card.id);
-
               return (
                 <div
                   key={`h-${dealKey}-${card.id}`}
+                  ref={(el) => { if (el) humanCardRefs.current.set(card.id, el); else humanCardRefs.current.delete(card.id); }}
                   className={[
                     "hearts__fan-item",
-                    isSelected ? "hearts__fan-item--selected" : "",
+                    isSelected  ? "hearts__fan-item--selected"  : "",
                     isValid && !isSelected ? "hearts__fan-item--valid" : "",
-                    isPlayable ? "hearts__fan-item--clickable" : "",
-                    hasReceived ? "hearts__fan-item--received" : "",
+                    isPlayable  ? "hearts__fan-item--clickable" : "",
+                    hasReceived ? "hearts__fan-item--received"  : "",
                   ].filter(Boolean).join(" ")}
                   style={{
                     "--fan-angle": `${angle}deg`,
@@ -852,39 +721,28 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
           {phase === "passing" && passedCards.length === 3 && (
             <div className="hearts__pass-actions">
-              <button className="hearts-btn hearts-btn--primary" onClick={confirmPass}>
-                {passLabel()} →
-              </button>
+              <button className="hearts-btn hearts-btn--primary" onClick={confirmPass}>{passLabel()} →</button>
             </div>
           )}
-
           {phase === "playing" && isHumanTurn && selectedCard && (
             <div className="hearts__play-hint">Click again to play</div>
           )}
           {phase === "playing" && !isHumanTurn && currentPlayer !== 0 && (
-            <div className="hearts__play-hint">
-              {PLAYER_NAMES[currentPlayer]}{"'s turn..."}
-            </div>
+            <div className="hearts__play-hint">{PLAYER_NAMES[currentPlayer]}{"'s turn..."}</div>
           )}
         </div>
+
       </div>
 
       {/* Status bar */}
       <div className="hearts__status-bar">
-        <span>
-          Hand {handNumber + 1} &nbsp;·&nbsp; Trick {Math.min(tricksThisHand + 1, 13)}/13
-          &nbsp;·&nbsp; Pass: {passDir === "none" ? "None" : passDir}
-        </span>
+        <span>Hand {handNumber + 1} · Trick {Math.min(tricksThisHand + 1, 13)}/13 · Pass: {passDir === "none" ? "None" : passDir}</span>
         <span className="hearts__scores-row">
           {PLAYER_NAMES.map((name, i) => (
-            <span key={i} className="hearts__score-item">
-              {name}: {scores[i]}
-            </span>
+            <span key={i} className="hearts__score-item">{name}: {scores[i]}</span>
           ))}
         </span>
-        <button className="hearts-btn hearts-btn--sm" onClick={() => setShowScores(true)}>
-          Scores
-        </button>
+        <button className="hearts-btn hearts-btn--sm" onClick={() => setShowScores(true)}>Scores</button>
       </div>
     </div>
   );

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -180,6 +180,18 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
 
 function freshGame(): HeartsState { return makeInitialState(0, [0,0,0,0]); }
 
+const HEARTS_SAVE_KEY = "cards-hearts-save";
+
+function loadHeartsData(): { state: HeartsState; wonBy: Record<string, number> } | null {
+  try {
+    const raw = localStorage.getItem(HEARTS_SAVE_KEY);
+    if (!raw) return null;
+    const saved = JSON.parse(raw) as { version: number; state: HeartsState; wonBy: Record<string, number> };
+    if (saved?.version === 1 && saved.state?.hands) return { state: saved.state, wonBy: saved.wonBy ?? {} };
+  } catch {}
+  return null;
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface HeartsProps {
@@ -189,7 +201,11 @@ interface HeartsProps {
 }
 
 export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
-  const [state,         setState]        = useState<HeartsState>(freshGame);
+  // Try to restore in-progress game from localStorage (runs on every render but
+  // React only uses the initial value for useRef/useState lazy init)
+  const savedData = useRef(loadHeartsData());
+
+  const [state,         setState]        = useState<HeartsState>(() => savedData.current?.state ?? freshGame());
   const [cardStates,    setCardStates]   = useState<Record<string, CardVisualState>>({});
   const [appearance,    setAppearance]   = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
@@ -198,8 +214,9 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
   const containerRef  = useRef<HTMLDivElement>(null);
   const aiTimerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevHandNum   = useRef(-1);
-  const wonByRef      = useRef<Record<string, number>>({});  // cardId → winning playerIndex
+  // Initialize from saved data so deal animation doesn't replay on restore
+  const prevHandNum   = useRef(savedData.current?.state.handNumber ?? -1);
+  const wonByRef      = useRef<Record<string, number>>(savedData.current?.wonBy ?? {});
 
   // ── CardStack refs for the 4 hands ────────────────────────────────────────
   // Player 0 (human): horizontal fan, centered, with arc
@@ -324,6 +341,22 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
     return cleanup;
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  // ── Persist game state ────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (state.phase === "game-over") {
+      try { localStorage.removeItem(HEARTS_SAVE_KEY); } catch {}
+      return;
+    }
+    try {
+      localStorage.setItem(HEARTS_SAVE_KEY, JSON.stringify({
+        version: 1,
+        state,
+        wonBy: wonByRef.current,
+      }));
+    } catch {}
   }, [state]);
 
   // ── Pass phase ─────────────────────────────────────────────────────────────
@@ -492,7 +525,10 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     setState(s => makeInitialState(s.handNumber + 1, s.scores));
   }, []);
 
-  const startNewGame = useCallback(() => { setState(freshGame()); }, []);
+  const startNewGame = useCallback(() => {
+    try { localStorage.removeItem(HEARTS_SAVE_KEY); } catch {}
+    setState(freshGame());
+  }, []);
 
   // ── Pass label ─────────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -30,9 +30,9 @@ const HAND_CY = [460,  52, 258, 258] as const;
 const TRICK_X = [240, 152, 240, 328] as const;  // indexed by playerIndex
 const TRICK_Y = [352, 258, 168, 258] as const;
 
-// Off-screen pile per player (won tricks fly here)
-const PILE_X = [240,  -80, 240, 560] as const;
-const PILE_Y = [620,  258,  -80, 258] as const;
+// Off-screen pile per player (won tricks fly here — far outside stage bounds)
+const PILE_X = [240, -500, 240, 900] as const;
+const PILE_Y = [900,  258, -500, 258] as const;
 
 // ── Deck helpers ──────────────────────────────────────────────────────────────
 
@@ -235,8 +235,8 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   useEffect(() => {
     const el = containerRef.current; if (!el) return;
     const obs = new ResizeObserver(e => {
-      const { width, height } = e[0].contentRect;
-      setScale(Math.min(1, width / STAGE_W, height / STAGE_H));
+      const w = e[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
     });
     obs.observe(el);
     return () => obs.disconnect();
@@ -450,7 +450,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   // ── Human card click ───────────────────────────────────────────────────────
 
   const { phase, currentPlayer, hands, scores, handScores, passDir, passedCards,
-    receivedCards, ledSuit, heartsAreBroken, isFirstTrick,
+    ledSuit, heartsAreBroken, isFirstTrick,
     tricksThisHand, handNumber, selectedCard } = state;
 
   const isHumanTurn = phase === "playing" && currentPlayer === 0;
@@ -458,7 +458,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     ? getValidHeartPlays(hands[0], ledSuit, heartsAreBroken, isFirstTrick)
     : [];
   const validIds    = useMemo(() => new Set(validPlays.map(c => c.id)), [validPlays]);
-  const receivedIds = useMemo(() => new Set(receivedCards.map(c => c.id)), [receivedCards]);
 
   const handleCardClick = useCallback((card: Card) => {
     if (phase === "passing") { togglePassCard(card.id); return; }
@@ -619,10 +618,10 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       )}
 
       {/* Stage */}
-      <div ref={containerRef} className="hearts__stage-container">
+      <div ref={containerRef} className="hearts__stage-container" style={{ height: Math.round(STAGE_H * scale) }}>
         <div
           className="hearts__stage"
-          style={{ width: STAGE_W, height: STAGE_H, transform: `scale(${scale})`, transformOrigin: "top left" }}
+          style={{ width: STAGE_W, height: STAGE_H, transform: scale < 1 ? `scale(${scale})` : undefined, transformOrigin: "top left" }}
         >
           {/* Player labels — absolutely positioned within stage */}
           <div className="hearts__label hearts__label--north">
@@ -685,11 +684,9 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
             const isPassSel   = passedCards.some(c => c.id === card.id);
             const isPlaySel   = selectedCard === card.id;
             const isValid     = validIds.has(card.id);
-            const isReceived  = receivedIds.has(card.id);
             let highlightColor: string | undefined;
-            if (isPassSel || isPlaySel)                          highlightColor = "#cc4400";
-            else if (isValid && isHumanTurn)                     highlightColor = "#228833";
-            else if (isReceived)                                  highlightColor = "#5b2d8e";
+            if (isPassSel || isPlaySel)       highlightColor = "#cc4400";
+            else if (isValid && isHumanTurn)  highlightColor = "#228833";
             return (
               <PermCard
                 key={card.id}

--- a/src/experiences/Cards/Hearts.tsx
+++ b/src/experiences/Cards/Hearts.tsx
@@ -84,7 +84,6 @@ function passTarget(from: number, dir: PassDir): number {
 
 // ── AI Helpers ────────────────────────────────────────────────────────────────
 
-/** Score a card for "how bad is it to keep" — higher = pass first */
 function problemScore(card: Card): number {
   if (card.suit === "spades") {
     if (card.rank === "A") return 200;
@@ -92,7 +91,6 @@ function problemScore(card: Card): number {
     if (card.rank === "Q") return 160;
   }
   if (card.suit === "hearts") return 100 + rankValue(card.rank as string);
-  // high spades (J, 10, 9, 8 = bad supports)
   if (card.suit === "spades") return rankValue(card.rank as string);
   return 0;
 }
@@ -107,9 +105,7 @@ function aiChooseCard(
   trick: TrickPlay[],
   ledSuit: Suit | null,
 ): Card {
-  // Leading
   if (trick.length === 0 || ledSuit === null) {
-    // Lead lowest non-heart if possible
     const nonHearts = valid.filter((c) => c.suit !== "hearts");
     const pool = nonHearts.length > 0 ? nonHearts : valid;
     return pool.reduce((best, c) =>
@@ -117,11 +113,9 @@ function aiChooseCard(
     );
   }
 
-  // Following suit
   const canFollowSuit = valid.some((c) => c.suit === ledSuit);
   if (canFollowSuit) {
     const suitCards = valid.filter((c) => c.suit === ledSuit);
-    // Find current winner value
     let winnerVal = -1;
     for (const play of trick) {
       if (play.card.suit === ledSuit) {
@@ -129,31 +123,25 @@ function aiChooseCard(
         if (v > winnerVal) winnerVal = v;
       }
     }
-    // Try to play highest card that won't win, or lowest if all would win
     const losers = suitCards.filter((c) => rankValue(c.rank as string) < winnerVal);
     if (losers.length > 0) {
       return losers.reduce((best, c) =>
         rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
       );
     }
-    // All cards win or no hearts broken — play lowest
     return suitCards.reduce((best, c) =>
       rankValue(c.rank as string) < rankValue(best.rank as string) ? c : best
     );
   }
 
-  // Can't follow suit — discard
-  // Dump Q♠ first
   const qs = valid.find((c) => c.suit === "spades" && c.rank === "Q");
   if (qs) return qs;
-  // Highest heart
   const hearts = valid.filter((c) => c.suit === "hearts");
   if (hearts.length > 0) {
     return hearts.reduce((best, c) =>
       rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
     );
   }
-  // Highest remaining
   return valid.reduce((best, c) =>
     rankValue(c.rank as string) > rankValue(best.rank as string) ? c : best
   );
@@ -165,7 +153,6 @@ function applyHandScores(
   handScores: number[],
   cumulativeScores: number[],
 ): number[] {
-  // Check shoot the moon: did any player score all 26?
   const moonShooterIdx = handScores.findIndex((s) => s === 26);
   if (moonShooterIdx !== -1) {
     return cumulativeScores.map((s, i) => (i === moonShooterIdx ? s : s + 26));
@@ -178,7 +165,6 @@ function applyHandScores(
 function makeInitialState(handNumber: number, prevScores: number[]): HeartsState {
   const deck = buildDeck();
   const hands = dealHands(deck, 4);
-  // Sort hands for display: by suit then rank
   const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
   const sortHand = (hand: Card[]) =>
     [...hand].sort((a, b) => {
@@ -189,7 +175,6 @@ function makeInitialState(handNumber: number, prevScores: number[]): HeartsState
 
   const dir = passDirection(handNumber);
 
-  // Find who has 2♣
   let trickLeader = 0;
   for (let i = 0; i < 4; i++) {
     if (hands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
@@ -222,6 +207,21 @@ function freshGame(): HeartsState {
   return makeInitialState(0, [0, 0, 0, 0]);
 }
 
+// ── Fan helpers ───────────────────────────────────────────────────────────────
+
+// Returns rotation angle in degrees for a card at position idx in a hand of total
+function fanAngle(idx: number, total: number): number {
+  if (total <= 1) return 0;
+  const mid = (total - 1) / 2;
+  return ((idx - mid) / mid) * 11;
+}
+
+// Overlap in px to keep a horizontal hand within maxWidth
+function handOverlap(count: number, cardW: number, maxW: number): number {
+  if (count <= 1) return 0;
+  return Math.max(0, Math.round((count * cardW - maxW) / (count - 1)));
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface HeartsProps {
@@ -235,8 +235,17 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [showScores, setShowScores] = useState(false);
-  // Ref to track if an AI step is currently scheduled (prevents double-firing)
+  const [dealKey, setDealKey] = useState(0);
   const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevHandNumRef = useRef(state.handNumber);
+
+  // Increment dealKey on each new hand so cards remount and re-animate
+  useEffect(() => {
+    if (state.handNumber !== prevHandNumRef.current) {
+      prevHandNumRef.current = state.handNumber;
+      setDealKey((k) => k + 1);
+    }
+  }, [state.handNumber]);
 
   // ── Derived ────────────────────────────────────────────────────────────────
 
@@ -271,28 +280,23 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     setState((s) => {
       if (s.passedCards.length !== 3) return s;
 
-      // AI passes
       const aiPasses: Card[][] = [[], [], [], []];
       aiPasses[0] = s.passedCards;
       for (let i = 1; i < 4; i++) {
         aiPasses[i] = aiSelectCardsToPass(s.hands[i]);
       }
 
-      // Exchange cards
       const newHands = s.hands.map((hand) => [...hand]);
       for (let from = 0; from < 4; from++) {
         const to = passTarget(from, s.passDir);
         if (to === from) continue;
         const passing = aiPasses[from];
-        // Remove from sender
         newHands[from] = newHands[from].filter(
           (c) => !passing.some((p) => p.id === c.id)
         );
-        // Add to receiver
         newHands[to] = [...newHands[to], ...passing];
       }
 
-      // Re-sort hands
       const suitOrder: Record<string, number> = { spades: 0, hearts: 1, diamonds: 2, clubs: 3 };
       const sortHand = (hand: Card[]) =>
         [...hand].sort((a, b) => {
@@ -303,7 +307,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
       const sortedHands = newHands.map(sortHand);
 
-      // Find who has 2♣ after passing
       let trickLeader = 0;
       for (let i = 0; i < 4; i++) {
         if (sortedHands[i].some((c) => c.suit === "clubs" && c.rank === "2")) {
@@ -312,7 +315,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         }
       }
 
-      // Determine what human received: find who passes TO player 0
       const humanReceivedFrom: number[] = [];
       for (let from = 0; from < 4; from++) {
         if (passTarget(from, s.passDir) === 0 && from !== 0) {
@@ -342,7 +344,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       if (s.phase !== "playing") return s;
       if (s.currentPlayer !== playerIndex) return s;
 
-      // Validate
       const valid = getValidHeartPlays(
         s.hands[playerIndex],
         s.ledSuit,
@@ -362,7 +363,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       const newHeartsAreBroken =
         s.heartsAreBroken || card.suit === "hearts";
 
-      // Not all 4 played yet
       if (newTrick.length < 4) {
         const nextPlayer = (playerIndex + 1) % 4;
         return {
@@ -376,7 +376,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         };
       }
 
-      // Trick complete — resolve
       const winner = resolveTrick(newTrick, newLedSuit!);
       const pts = trickPoints(newTrick.map((p) => p.card));
       const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
@@ -384,7 +383,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
       const newIsFirstTrick = false;
 
       if (newTricksThisHand === 13) {
-        // Hand over
         const newCumulative = applyHandScores(newHandScores, s.scores);
         const gameOver = newCumulative.some((sc) => sc >= 100);
         return {
@@ -404,7 +402,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         };
       }
 
-      // Brief pause to show trick before clearing
       return {
         ...s,
         hands: newHands,
@@ -433,7 +430,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     if (!validIds.has(card.id)) return;
 
     if (selectedCard === card.id) {
-      // Second click = confirm play
       playCard(0, card);
     } else {
       setState((s) => ({ ...s, selectedCard: card.id }));
@@ -447,12 +443,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     const t = setTimeout(() => {
       setState((s) => {
         if (s.phase !== "trick-end") return s;
-        return {
-          ...s,
-          phase: "playing",
-          currentTrick: [],
-          ledSuit: null,
-        };
+        return { ...s, phase: "playing", currentTrick: [], ledSuit: null };
       });
     }, 900);
     return () => clearTimeout(t);
@@ -465,7 +456,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     if (currentPlayer === 0) return;
     if (phase === "trick-end") return;
 
-    // Cancel any stale timer
     if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
 
     aiTimerRef.current = setTimeout(() => {
@@ -505,7 +495,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
           };
         }
 
-        // Trick complete
         const winner = resolveTrick(newTrick, newLedSuit!);
         const pts = trickPoints(newTrick.map((p) => p.card));
         const newHandScores = s.handScores.map((hs, i) => (i === winner ? hs + pts : hs));
@@ -554,11 +543,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
   // ── Between-hand: start next hand ─────────────────────────────────────────
 
   const startNextHand = useCallback(() => {
-    setState((s) => {
-      const nextHandNum = s.handNumber + 1;
-      const next = makeInitialState(nextHandNum, s.scores);
-      return next;
-    });
+    setState((s) => makeInitialState(s.handNumber + 1, s.scores));
   }, []);
 
   const startNewGame = useCallback(() => {
@@ -585,11 +570,6 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
   // ── Render helpers ─────────────────────────────────────────────────────────
 
-  const passTargetName = passDir !== "none"
-    ? PLAYER_NAMES[passTarget(0, passDir)]
-    : "";
-
-  /** Card played by a given player in current trick */
   function trickCardFor(playerIdx: number): Card | null {
     return currentTrick.find((p) => p.playerIndex === playerIdx)?.card ?? null;
   }
@@ -601,7 +581,13 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
     return "";
   }
 
+  const passTargetName = passDir !== "none" ? PLAYER_NAMES[passTarget(0, passDir)] : "";
   const gameOverWinnerIdx = state.scores.indexOf(Math.min(...state.scores));
+
+  // Human hand overlap: fit 13 cards into ~300px max
+  const hOverlap = handOverlap(humanHand.length, 72, 300);
+  // North AI overlap: fit 13 sm cards into ~280px max
+  const nOverlap = handOverlap(hands[2].length, 52, 280);
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -615,14 +601,25 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         />
       )}
 
-      {/* Hand-end / Game-over scorecard modal */}
+      {/* Hand-end / Game-over / Scores modal */}
       {(phase === "hand-end" || phase === "game-over" || showScores) && (
-        <div className="hearts-modal-overlay" onClick={showScores ? () => setShowScores(false) : undefined}>
+        <div
+          className="hearts-modal-overlay"
+          onClick={showScores ? () => setShowScores(false) : undefined}
+        >
           <div className="hearts-modal" onClick={(e) => e.stopPropagation()}>
             <div className="hearts-modal__titlebar">
-              <span>{phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}</span>
+              <span>
+                {phase === "game-over" ? "Game Over" : showScores ? "Scores" : "Hand Results"}
+              </span>
               {showScores && (
-                <button className="hearts-modal__close" onClick={() => setShowScores(false)} aria-label="Close">✕</button>
+                <button
+                  className="hearts-modal__close"
+                  onClick={() => setShowScores(false)}
+                  aria-label="Close"
+                >
+                  ✕
+                </button>
               )}
             </div>
             <div className="hearts-modal__body">
@@ -636,7 +633,14 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
                 </thead>
                 <tbody>
                   {PLAYER_NAMES.map((name, i) => (
-                    <tr key={i} className={phase === "game-over" && i === gameOverWinnerIdx ? "hearts-modal__winner-row" : ""}>
+                    <tr
+                      key={i}
+                      className={
+                        phase === "game-over" && i === gameOverWinnerIdx
+                          ? "hearts-modal__winner-row"
+                          : ""
+                      }
+                    >
                       <td>{name}</td>
                       {(phase === "hand-end" || phase === "game-over") && (
                         <td className={handScores[i] === 26 ? "hearts-modal__moon" : ""}>
@@ -674,139 +678,148 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
         </div>
       )}
 
-      {/* Table */}
+      {/* ── Table (felt) ── */}
       <div className="hearts__table">
 
-        {/* North AI (top) */}
-        <div className="hearts__north">
+        {/* North AI */}
+        <div className="hearts__zone hearts__zone--north">
           <div className="hearts__player-label hearts__player-label--ai">
             {PLAYER_NAMES[2]}
-            {currentPlayer === 2 && phase === "playing" && (
-              <span className="hearts__turn-dot" />
+            {currentPlayer === 2 && phase === "playing" && <span className="hearts__turn-dot" />}
+            {handScores[2] > 0 && (
+              <span className="hearts__hand-score-badge">{handScores[2]}pt</span>
             )}
           </div>
-          <div className="hearts__ai-hand hearts__ai-hand--horiz">
-            {hands[2].map((card) => (
+          <div
+            className="hearts__ai-fan hearts__ai-fan--horiz"
+            style={{ "--ai-overlap": `${nOverlap}px` } as React.CSSProperties}
+          >
+            {hands[2].map((card, idx) => (
               <PlayingCard
-                key={card.id}
+                key={`n-${dealKey}-${card.id}`}
                 card={card}
                 faceDown
                 appearance={appearance}
                 size="sm"
+                dealIndex={idx}
               />
             ))}
           </div>
-          <div className="hearts__hand-score">
-            {handScores[2] > 0 && `${handScores[2]}pt`}
+        </div>
+
+        {/* West AI */}
+        <div className="hearts__zone hearts__zone--west">
+          <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
+            {PLAYER_NAMES[1]}
+            {currentPlayer === 1 && phase === "playing" && <span className="hearts__turn-dot" />}
+            {handScores[1] > 0 && (
+              <span className="hearts__hand-score-badge">{handScores[1]}pt</span>
+            )}
+          </div>
+          <div className="hearts__ai-fan hearts__ai-fan--vert">
+            {hands[1].slice(0, 8).map((card, idx) => (
+              <PlayingCard
+                key={`w-${dealKey}-${card.id}`}
+                card={card}
+                faceDown
+                appearance={appearance}
+                size="sm"
+                dealIndex={idx}
+              />
+            ))}
+            {hands[1].length > 8 && (
+              <div className="hearts__ai-extra">+{hands[1].length - 8}</div>
+            )}
           </div>
         </div>
 
-        {/* Middle row: West, Center, East */}
-        <div className="hearts__middle">
-          {/* West AI */}
-          <div className="hearts__west">
-            <div className="hearts__player-label hearts__player-label--ai">
-              {PLAYER_NAMES[1]}
-              {currentPlayer === 1 && phase === "playing" && (
-                <span className="hearts__turn-dot" />
-              )}
-            </div>
-            <div className="hearts__ai-hand hearts__ai-hand--vert">
-              {hands[1].map((card) => (
-                <PlayingCard
-                  key={card.id}
-                  card={card}
-                  faceDown
-                  appearance={appearance}
-                  size="sm"
-                />
-              ))}
-            </div>
-            <div className="hearts__hand-score">
-              {handScores[1] > 0 && `${handScores[1]}pt`}
-            </div>
+        {/* Trick area */}
+        <div className="hearts__trick-area">
+          <div className="hearts__trick-slot hearts__trick-slot--n">
+            {trickCardFor(2) && (
+              <div key={trickCardFor(2)!.id} className="hearts__trick-card">
+                <PlayingCard card={trickCardFor(2)!} appearance={appearance} size="sm" />
+              </div>
+            )}
           </div>
-
-          {/* Center trick area */}
-          <div className="hearts__center">
-            {/* North slot */}
-            <div className="hearts__trick-slot hearts__trick-slot--north">
-              {trickCardFor(2) && (
-                <PlayingCard card={trickCardFor(2)!} appearance={appearance} />
-              )}
-            </div>
-            {/* West slot */}
-            <div className="hearts__trick-slot hearts__trick-slot--west">
-              {trickCardFor(1) && (
-                <PlayingCard card={trickCardFor(1)!} appearance={appearance} />
-              )}
-            </div>
-            {/* Center indicator */}
-            <div className="hearts__trick-center">
-              {phase === "playing" || phase === "trick-end" ? (
-                <span className="hearts__trick-count">{tricksThisHand}/13</span>
-              ) : null}
-              {heartsAreBroken && <span className="hearts__broken">♥</span>}
-            </div>
-            {/* East slot */}
-            <div className="hearts__trick-slot hearts__trick-slot--east">
-              {trickCardFor(3) && (
-                <PlayingCard card={trickCardFor(3)!} appearance={appearance} />
-              )}
-            </div>
-            {/* South (human) slot */}
-            <div className="hearts__trick-slot hearts__trick-slot--south">
-              {trickCardFor(0) && (
-                <PlayingCard card={trickCardFor(0)!} appearance={appearance} />
-              )}
-            </div>
+          <div className="hearts__trick-slot hearts__trick-slot--w">
+            {trickCardFor(1) && (
+              <div key={trickCardFor(1)!.id} className="hearts__trick-card">
+                <PlayingCard card={trickCardFor(1)!} appearance={appearance} size="sm" />
+              </div>
+            )}
           </div>
-
-          {/* East AI */}
-          <div className="hearts__east">
-            <div className="hearts__player-label hearts__player-label--ai">
-              {PLAYER_NAMES[3]}
-              {currentPlayer === 3 && phase === "playing" && (
-                <span className="hearts__turn-dot" />
-              )}
-            </div>
-            <div className="hearts__ai-hand hearts__ai-hand--vert">
-              {hands[3].map((card) => (
-                <PlayingCard
-                  key={card.id}
-                  card={card}
-                  faceDown
-                  appearance={appearance}
-                  size="sm"
-                />
-              ))}
-            </div>
-            <div className="hearts__hand-score">
-              {handScores[3] > 0 && `${handScores[3]}pt`}
-            </div>
+          <div className="hearts__trick-center-info">
+            {(phase === "playing" || phase === "trick-end") && (
+              <span className="hearts__trick-count">{tricksThisHand}/13</span>
+            )}
+            {heartsAreBroken && <span className="hearts__broken">♥</span>}
+          </div>
+          <div className="hearts__trick-slot hearts__trick-slot--e">
+            {trickCardFor(3) && (
+              <div key={trickCardFor(3)!.id} className="hearts__trick-card">
+                <PlayingCard card={trickCardFor(3)!} appearance={appearance} size="sm" />
+              </div>
+            )}
+          </div>
+          <div className="hearts__trick-slot hearts__trick-slot--s">
+            {trickCardFor(0) && (
+              <div key={trickCardFor(0)!.id} className="hearts__trick-card">
+                <PlayingCard card={trickCardFor(0)!} appearance={appearance} size="sm" />
+              </div>
+            )}
           </div>
         </div>
 
-        {/* Human (South) */}
-        <div className="hearts__south">
+        {/* East AI */}
+        <div className="hearts__zone hearts__zone--east">
+          <div className="hearts__player-label hearts__player-label--ai hearts__player-label--side">
+            {PLAYER_NAMES[3]}
+            {currentPlayer === 3 && phase === "playing" && <span className="hearts__turn-dot" />}
+            {handScores[3] > 0 && (
+              <span className="hearts__hand-score-badge">{handScores[3]}pt</span>
+            )}
+          </div>
+          <div className="hearts__ai-fan hearts__ai-fan--vert">
+            {hands[3].slice(0, 8).map((card, idx) => (
+              <PlayingCard
+                key={`e-${dealKey}-${card.id}`}
+                card={card}
+                faceDown
+                appearance={appearance}
+                size="sm"
+                dealIndex={idx}
+              />
+            ))}
+            {hands[3].length > 8 && (
+              <div className="hearts__ai-extra">+{hands[3].length - 8}</div>
+            )}
+          </div>
+        </div>
+
+        {/* South — human player */}
+        <div className="hearts__zone hearts__zone--south">
           <div className="hearts__player-label">
             {PLAYER_NAMES[0]}
             {isHumanTurn && phase === "playing" && (
               <span className="hearts__turn-dot hearts__turn-dot--human" />
             )}
-            <span className="hearts__score-inline">{scores[0]}pts total</span>
+            <span className="hearts__score-inline">{scores[0]}pts</span>
           </div>
 
-          {/* Passing phase instruction */}
           {phase === "passing" && (
             <div className="hearts__pass-hint">
-              Select 3 cards to pass to {passTargetName}
-              {passedCards.length > 0 && ` (${passedCards.length}/3 selected)`}
+              Select 3 to pass to {passTargetName}
+              {passedCards.length > 0 && ` (${passedCards.length}/3)`}
             </div>
           )}
 
-          <div className={`hearts__human-hand${phase === "passing" ? " hearts__human-hand--passing" : ""}`}>
-            {humanHand.map((card) => {
+          <div
+            className={`hearts__human-hand${phase === "passing" ? " hearts__human-hand--passing" : ""}`}
+            style={{ "--hand-overlap": `${hOverlap}px` } as React.CSSProperties}
+          >
+            {humanHand.map((card, idx) => {
+              const angle = fanAngle(idx, humanHand.length);
               const isSelected = phase === "passing"
                 ? passedCards.some((c) => c.id === card.id)
                 : selectedCard === card.id;
@@ -816,14 +829,19 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
               return (
                 <div
-                  key={card.id}
+                  key={`h-${dealKey}-${card.id}`}
                   className={[
-                    "hearts__card-wrap",
-                    isSelected ? "hearts__card-wrap--selected" : "",
-                    isValid && !isSelected ? "hearts__card-wrap--valid" : "",
-                    isPlayable ? "hearts__card-wrap--clickable" : "",
-                    hasReceived ? "hearts__card-wrap--received" : "",
+                    "hearts__fan-item",
+                    isSelected ? "hearts__fan-item--selected" : "",
+                    isValid && !isSelected ? "hearts__fan-item--valid" : "",
+                    isPlayable ? "hearts__fan-item--clickable" : "",
+                    hasReceived ? "hearts__fan-item--received" : "",
                   ].filter(Boolean).join(" ")}
+                  style={{
+                    "--fan-angle": `${angle}deg`,
+                    "--fan-i": idx,
+                    zIndex: isSelected ? 20 : idx + 1,
+                  } as React.CSSProperties}
                   onClick={() => handleCardClick(card)}
                 >
                   <PlayingCard card={card} appearance={appearance} />
@@ -834,19 +852,14 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
 
           {phase === "passing" && passedCards.length === 3 && (
             <div className="hearts__pass-actions">
-              <button
-                className="hearts-btn hearts-btn--primary"
-                onClick={confirmPass}
-              >
+              <button className="hearts-btn hearts-btn--primary" onClick={confirmPass}>
                 {passLabel()} →
               </button>
             </div>
           )}
 
           {phase === "playing" && isHumanTurn && selectedCard && (
-            <div className="hearts__play-hint">
-              Click again to play
-            </div>
+            <div className="hearts__play-hint">Click again to play</div>
           )}
           {phase === "playing" && !isHumanTurn && currentPlayer !== 0 && (
             <div className="hearts__play-hint">
@@ -869,10 +882,7 @@ export default function Hearts({ settings, onNewGame, onQuit }: HeartsProps) {
             </span>
           ))}
         </span>
-        <button
-          className="hearts-btn hearts-btn--sm"
-          onClick={() => setShowScores(true)}
-        >
+        <button className="hearts-btn hearts-btn--sm" onClick={() => setShowScores(true)}>
           Scores
         </button>
       </div>

--- a/src/experiences/Cards/Klondike.css
+++ b/src/experiences/Cards/Klondike.css
@@ -1,0 +1,315 @@
+/* ─── Klondike Solitaire ─────────────────────────────────────────────── */
+
+.klondike {
+  display: flex;
+  flex-direction: column;
+  background: #1a4a1a; /* green felt */
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+  min-width: 420px;
+  min-height: 500px;
+  position: relative;
+  padding: 8px;
+  gap: 8px;
+}
+
+/* ─── Top row (foundations + stock/waste) ────────────────────────────── */
+
+.klondike__top-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.klondike__foundations {
+  display: flex;
+  gap: 4px;
+}
+
+.klondike__top-spacer {
+  flex: 1;
+}
+
+.klondike__stock-area {
+  display: flex;
+  flex-direction: row-reverse; /* stock on right, waste on left */
+  gap: 4px;
+  align-items: flex-start;
+}
+
+/* Foundation slots */
+.klondike__foundation-slot {
+  width: 52px;
+  height: 72px;
+  cursor: pointer;
+  position: relative;
+  border-radius: 4px;
+}
+
+.klondike__foundation-slot--selected > .playing-card {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+}
+
+/* Stock slot */
+.klondike__stock-slot {
+  width: 52px;
+  height: 72px;
+  cursor: pointer;
+  position: relative;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+/* Waste slot — needs to accommodate fanout of up to 3 cards */
+.klondike__waste-slot {
+  width: 52px;
+  height: 72px;
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.klondike__waste-slot--selected .klondike__waste-top > .playing-card {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+}
+
+.klondike__waste-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+}
+
+.klondike__waste-peek {
+  position: absolute;
+  top: 0;
+  z-index: 1;
+}
+
+.klondike__waste-peek--back {
+  left: -20px;
+  z-index: 1;
+}
+
+.klondike__waste-peek--mid {
+  left: -10px;
+  z-index: 2;
+}
+
+/* Empty slot generic */
+.klondike__empty-slot {
+  width: 52px;
+  height: 72px;
+  border-radius: 4px;
+  border: 2px dashed rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.15);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.klondike__empty-slot--suit {
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.klondike__suit-hint {
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.25);
+  line-height: 1;
+  font-family: serif;
+}
+
+/* Stock reset indicator */
+.klondike__stock-reset {
+  cursor: pointer;
+}
+
+.klondike__reset-icon {
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.4);
+  font-family: sans-serif;
+  line-height: 1;
+}
+
+/* ─── Tableau ─────────────────────────────────────────────────────────── */
+
+.klondike__tableau {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  align-items: flex-start;
+}
+
+.klondike__column {
+  flex: 1;
+  position: relative;
+  min-height: 72px;
+  /* Height grows with cards; JS positions cards via inline style top */
+}
+
+/* Valid destination highlight */
+.klondike__column--valid-dest > .klondike__empty-slot {
+  border-color: rgba(80, 220, 80, 0.7);
+  background: rgba(80, 220, 80, 0.08);
+}
+
+/* Face-down cards — absolute positioned, show as thin slivers */
+.klondike__facedown-card {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 18px;
+  overflow: hidden;
+  cursor: default;
+}
+
+.klondike__facedown-card .playing-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* Face-up cards — absolute positioned, overlapping */
+.klondike__faceup-card {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 26px;
+  cursor: pointer;
+}
+
+/* The last face-up card in a column should show full height */
+.klondike__faceup-card:last-child {
+  height: 72px;
+}
+
+.klondike__faceup-card .playing-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* Selected card and cards below it in the sequence */
+.klondike__faceup-card--selected .playing-card {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+}
+
+/* Make the valid-dest column style apply to face-up top card too */
+.klondike__column--valid-dest .klondike__faceup-card:last-child .playing-card {
+  box-shadow: 0 0 0 2px rgba(80, 220, 80, 0.5);
+}
+
+/* The empty-slot placeholder inside a column */
+.klondike__column > .klondike__empty-slot {
+  position: relative;
+}
+
+/* ─── Status bar ──────────────────────────────────────────────────────── */
+
+.klondike__statusbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 2px 2px;
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.6);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-top: 2px;
+  flex-wrap: wrap;
+}
+
+/* Auto-complete button */
+.klondike__autocomplete-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  background: #228833;
+  color: #fff;
+  border: 2px solid;
+  border-color: #66cc77 #115522 #115522 #66cc77;
+  padding: 4px 8px;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.klondike__autocomplete-btn:hover {
+  background: #33aa44;
+}
+
+.klondike__autocomplete-btn:active {
+  border-color: #115522 #66cc77 #66cc77 #115522;
+}
+
+/* ─── Win overlay ─────────────────────────────────────────────────────── */
+
+.klondike__win-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.klondike__win-banner {
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  padding: 20px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.klondike__win-title {
+  font-size: 16px;
+  color: #228833;
+  letter-spacing: 2px;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.klondike__win-stats {
+  font-size: 8px;
+  color: #444;
+}
+
+.klondike__win-btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  background: #cc4400;
+  color: #fff;
+  border: 2px solid;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+  padding: 7px 16px;
+  cursor: pointer;
+  width: 100%;
+}
+
+.klondike__win-btn:hover {
+  background: #ee5500;
+}
+
+.klondike__win-btn:active {
+  border-color: #664400 #ffcc88 #ffcc88 #664400;
+}
+
+.klondike__win-btn--secondary {
+  background: #5b2d8e;
+  border-color: #9966cc #331155 #331155 #9966cc;
+  margin-top: -4px;
+}
+
+.klondike__win-btn--secondary:hover {
+  background: #7b3dbe;
+}
+
+.klondike__win-btn--secondary:active {
+  border-color: #331155 #9966cc #9966cc #331155;
+}

--- a/src/experiences/Cards/Klondike.css
+++ b/src/experiences/Cards/Klondike.css
@@ -11,14 +11,36 @@
 
 /* ─── Stage ──────────────────────────────────────────────────────────── */
 
+/* Container measures available width so we can scale the stage to fit */
+.klondike__stage-container {
+  margin: 8px 8px 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+  /* height is set inline via JS (scale * STAGE_H) */
+}
+
 .klondike__stage {
   background: #1a4a1a;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
-  margin: 8px 8px 4px;
   position: relative;
   overflow: hidden;
-  flex-shrink: 0;
+  /* isolation:isolate creates a stacking context so high z-index cards
+     don't bleed above the menu bar or deck modal */
+  isolation: isolate;
+}
+
+/* Transparent hit area over the stock pile — always on top of stock cards */
+.klondike__stock-hit {
+  position: absolute;
+  width: 72px;
+  height: 100px;
+  border-radius: 4px;
+  z-index: 8000;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Empty card slot — dashed outline */

--- a/src/experiences/Cards/Klondike.css
+++ b/src/experiences/Cards/Klondike.css
@@ -1,21 +1,137 @@
-/* ─── Klondike Solitaire ─────────────────────────────────────────────── */
+/* ─── Klondike Solitaire ──────────────────────────────────────────────── */
 
 .klondike {
   display: flex;
   flex-direction: column;
-  background: #1a4a1a; /* green felt */
+  background: #c0c0c0;
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
   user-select: none;
-  min-width: 420px;
-  min-height: 500px;
-  position: relative;
-  padding: 8px;
-  gap: 8px;
 }
 
-/* ─── Top row (foundations + stock/waste) ────────────────────────────── */
+/* ─── Stage ──────────────────────────────────────────────────────────── */
 
+.klondike__stage {
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 8px 8px 4px;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+/* Empty card slot — dashed outline */
+.klondike__slot {
+  position: absolute;
+  width: 72px;
+  height: 100px;
+  border: 2px dashed rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.klondike__slot--foundation { border-color: rgba(255, 255, 255, 0.35); }
+
+.klondike__slot-suit {
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.28);
+  font-family: Georgia, serif;
+  line-height: 1;
+}
+
+.klondike__slot-icon {
+  font-size: 26px;
+  color: rgba(255, 255, 255, 0.4);
+  font-family: sans-serif;
+}
+
+/* ─── Status bar ──────────────────────────────────────────────────────── */
+
+.klondike__statusbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 10px;
+  font-size: 7px;
+  color: #333;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  background: #c0c0c0;
+}
+
+/* ─── Controls ────────────────────────────────────────────────────────── */
+
+.klondike__controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 10px;
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────────────── */
+
+.klondike__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 6px 12px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.klondike__btn--sm { padding: 3px 8px; font-size: 7px; }
+
+.klondike__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+.klondike__btn--primary:hover  { background: #ee5500; }
+.klondike__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+
+.klondike__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.klondike__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }
+
+/* ─── Win overlay ─────────────────────────────────────────────────────── */
+
+.klondike__win-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.klondike__win-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 28px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.klondike__win-title {
+  font-size: 14px;
+  color: #228833;
+  letter-spacing: 2px;
+}
+
+.klondike__win-stats { font-size: 8px; color: #333; }
+
+/* Remove old layout classes that no longer exist */
 .klondike__top-row {
   display: flex;
   align-items: flex-start;

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -1,142 +1,68 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./Klondike.css";
-import { PlayingCard } from "./PlayingCard";
-import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
+import { PermCard } from "./PermCard";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
+import type { Card, CardAppearance, DeckSettings } from "./types";
+import type { Rank, Suit } from "./types";
+import { buildDeck, shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
-// ── Constants ─────────────────────────────────────────────────────────────────
+// ── Stage layout ──────────────────────────────────────────────────────────────
 
-const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"] as const;
-const SUITS_ALL: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
-const FOUNDATION_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+const STAGE_W  = 596;
+const STAGE_H  = 520;
+const CARD_W   = 72;
+const CARD_H   = 100;
+const TOP_Y    = 66;
+const TAB_Y    = 196;
 
-const RANK_VAL: Record<string, number> = {
-  A: 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7,
-  "8": 8, "9": 9, "10": 10, J: 11, Q: 12, K: 13,
+// 7 column x-centers, evenly spaced
+const COL_X: number[] = (() => {
+  const gridW = 7 * CARD_W + 6 * 8;
+  const startX = (STAGE_W - gridW) / 2 + CARD_W / 2;
+  return Array.from({ length: 7 }, (_, i) => startX + i * (CARD_W + 8));
+})();
+
+const Z_DRAG = 9000;
+
+// ── Game logic helpers ────────────────────────────────────────────────────────
+
+const RANK_VALUE: Partial<Record<Rank, number>> = {
+  "A":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"J":11,"Q":12,"K":13,
 };
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+function rv(card: Card): number { return RANK_VALUE[card.rank as Rank] ?? 0; }
 
-function buildStandardDeck(): Card[] {
-  const cards: Card[] = [];
-  for (const suit of SUITS_ALL) {
-    for (const rank of RANKS) {
-      cards.push({ suit, rank, id: `${suit}-${rank}` });
-    }
-  }
-  // Fisher-Yates shuffle
-  for (let i = cards.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = cards[i];
-    cards[i] = cards[j];
-    cards[j] = tmp;
-  }
-  return cards;
+function cardColor(card: Card): "red" | "black" {
+  return card.suit === "hearts" || card.suit === "diamonds" ? "red" : "black";
 }
 
-function isRed(suit: Suit): boolean {
-  return suit === "hearts" || suit === "diamonds";
+function canPlaceOnTableau(card: Card, top: Card | null, relaxed: boolean): boolean {
+  if (top === null) return card.rank === "K" || relaxed;
+  return rv(card) === rv(top) - 1 && cardColor(card) !== cardColor(top);
 }
 
-function canPlaceOnTableau(card: Card, topCard: Card | null, relaxed = false): boolean {
-  if (card.suit === "joker") return false;
-  if (topCard === null) {
-    return relaxed || RANK_VAL[card.rank as string] === 13;
-  }
-  if (topCard.suit === "joker") return false;
-  const oppColor = isRed(card.suit as Suit) !== isRed(topCard.suit as Suit);
-  const oneBelow = RANK_VAL[card.rank as string] === RANK_VAL[topCard.rank as string] - 1;
-  return oppColor && oneBelow;
-}
-
-function canPlaceOnFoundation(card: Card, foundation: Card[]): boolean {
-  if (card.suit === "joker") return false;
-  if (foundation.length === 0) {
-    return RANK_VAL[card.rank as string] === 1;
-  }
-  const top = foundation[foundation.length - 1];
-  return (
-    top.suit === card.suit &&
-    RANK_VAL[card.rank as string] === RANK_VAL[top.rank as string] + 1
-  );
+function canPlaceOnFoundation(card: Card, top: Card | null): boolean {
+  if (top === null) return card.rank === "A";
+  return card.suit === top.suit && rv(card) === rv(top) + 1;
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-interface TableauColumn {
-  faceDown: Card[];
-  faceUp: Card[];
-}
+type Phase = "shuffle" | "idle" | "animating" | "game-over";
+type StackId = `tab-${number}` | `found-${number}` | "stock" | "waste";
 
-interface KlondikeSelection {
-  from: "tableau" | "waste" | "foundation";
-  colIndex: number;
-  cardIndex: number;
-}
-
-type GamePhase = "playing" | "won";
-
-interface KlondikeState {
-  tableau: TableauColumn[];
-  foundations: Card[][];
-  stock: Card[];
-  waste: Card[];
-  wasteIndex: number;
-  selected: KlondikeSelection | null;
-  moves: number;
-  startTime: number;
-  phase: GamePhase;
-}
-
-// ── Game setup ────────────────────────────────────────────────────────────────
-
-function makeInitialState(): KlondikeState {
-  const deck = buildStandardDeck();
-  const tableau: TableauColumn[] = [];
-
-  let idx = 0;
-  for (let col = 0; col < 7; col++) {
-    const numCards = col + 1;
-    const colCards = deck.slice(idx, idx + numCards);
-    idx += numCards;
-    tableau.push({
-      faceDown: colCards.slice(0, numCards - 1),
-      faceUp: [colCards[numCards - 1]],
-    });
-  }
-
-  const stock = deck.slice(idx); // remaining 24 cards
-
-  return {
-    tableau,
-    foundations: [[], [], [], []],
-    stock,
-    waste: [],
-    wasteIndex: -1,
-    selected: null,
-    moves: 0,
-    startTime: Date.now(),
-    phase: "playing",
-  };
-}
-
-// ── Move helpers ──────────────────────────────────────────────────────────────
-
-function getVisibleWasteCard(state: KlondikeState): Card | null {
-  if (state.wasteIndex < 0 || state.waste.length === 0) return null;
-  const idx = Math.min(state.wasteIndex, state.waste.length - 1);
-  return state.waste[idx];
-}
-
-function allFaceUp(tableau: TableauColumn[]): boolean {
-  return tableau.every((col) => col.faceDown.length === 0);
-}
-
-function checkWon(foundations: Card[][]): boolean {
-  return foundations.every((f) => f.length === 13);
+interface DragState {
+  ids: string[];
+  fromStack: StackId;
+  originStates: Record<string, CardVisualState>;
+  offsetX: number;
+  offsetY: number;
+  moved: boolean;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -148,750 +74,638 @@ interface KlondikeProps {
 }
 
 export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps) {
-  const [state, setState] = useState<KlondikeState>(() => makeInitialState());
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const drawMode = settings.klondikeDraw;
+  const relaxed  = settings.klondikeRelaxed;
+
+  const [allCards,      setAllCards]      = useState<Card[]>([]);
+  const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
+  const [phase,         setPhase]         = useState<Phase>("shuffle");
+  const [selectedRun,   setSelectedRun]   = useState<string[]>([]);
+  const [moves,         setMoves]         = useState(0);
+  const [elapsed,       setElapsed]       = useState(0);
+  const [stockLeft,     setStockLeft]     = useState(0);
+  const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
-  const [elapsed, setElapsed] = useState(0);
-  const autoCompleteRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [autoComplete,  setAutoComplete]  = useState(false);
 
-  // ── Timer ──────────────────────────────────────────────────────────────────
+  const stageRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (state.phase === "won") return;
-    const id = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - state.startTime) / 1000));
+  // Stacks — face-down/face-up offsets for tableau fanning
+  const tableau     = useRef<CardStack[]>(
+    Array.from({ length: 7 }, (_, i) =>
+      new CardStack({ zTier: 5 + i, baseX: COL_X[i], baseY: TAB_Y, faceDownOffsetY: 15, faceUpOffsetY: 20 })
+    )
+  );
+  const foundations = useRef<CardStack[]>(
+    Array.from({ length: 4 }, (_, i) =>
+      new CardStack({ zTier: 1 + i, baseX: COL_X[3 + i], baseY: TOP_Y })
+    )
+  );
+  const stockStack = useRef(new CardStack({ zTier: 12, baseX: COL_X[0], baseY: TOP_Y }));
+  const wasteStack = useRef(new CardStack({ zTier: 13, baseX: COL_X[1], baseY: TOP_Y }));
+
+  const drag = useRef<DragState | null>(null);
+
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearTimers = useCallback(() => { timers.current.forEach(clearTimeout); timers.current = []; }, []);
+  function after(ms: number, fn: () => void) { timers.current.push(setTimeout(fn, ms)); }
+
+  const timerRef     = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+  }, []);
+  const ensureTimer = useCallback(() => {
+    if (timerRef.current) return;
+    startTimeRef.current = Date.now();
+    timerRef.current = setInterval(() => {
+      if (startTimeRef.current !== null) setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
     }, 1000);
-    return () => clearInterval(id);
-  }, [state.phase, state.startTime]);
-
-  // ── Auto-complete ──────────────────────────────────────────────────────────
-
-  const startAutoComplete = useCallback(() => {
-    if (autoCompleteRef.current) return;
-    autoCompleteRef.current = setInterval(() => {
-      setState((s) => {
-        if (s.phase === "won") {
-          if (autoCompleteRef.current) {
-            clearInterval(autoCompleteRef.current);
-            autoCompleteRef.current = null;
-          }
-          return s;
-        }
-
-        // Try to move any card to a foundation
-        const newFoundations = s.foundations.map((f) => [...f]);
-        const newTableau = s.tableau.map((col) => ({
-          faceDown: [...col.faceDown],
-          faceUp: [...col.faceUp],
-        }));
-        const newWaste = [...s.waste];
-        let moved = false;
-
-        // Try tableau cards
-        for (let ci = 0; ci < 7 && !moved; ci++) {
-          const col = newTableau[ci];
-          if (col.faceUp.length === 0) continue;
-          const card = col.faceUp[col.faceUp.length - 1];
-          for (let fi = 0; fi < 4 && !moved; fi++) {
-            if (canPlaceOnFoundation(card, newFoundations[fi])) {
-              newFoundations[fi] = [...newFoundations[fi], card];
-              col.faceUp = col.faceUp.slice(0, col.faceUp.length - 1);
-              // flip next face-down
-              if (col.faceUp.length === 0 && col.faceDown.length > 0) {
-                col.faceUp = [col.faceDown[col.faceDown.length - 1]];
-                col.faceDown = col.faceDown.slice(0, col.faceDown.length - 1);
-              }
-              moved = true;
-            }
-          }
-        }
-
-        // Try waste top
-        if (!moved && s.wasteIndex >= 0 && newWaste.length > 0) {
-          const wIdx = Math.min(s.wasteIndex, newWaste.length - 1);
-          const card = newWaste[wIdx];
-          for (let fi = 0; fi < 4 && !moved; fi++) {
-            if (canPlaceOnFoundation(card, newFoundations[fi])) {
-              newFoundations[fi] = [...newFoundations[fi], card];
-              newWaste.splice(wIdx, 1);
-              moved = true;
-            }
-          }
-        }
-
-        if (!moved) {
-          if (autoCompleteRef.current) {
-            clearInterval(autoCompleteRef.current);
-            autoCompleteRef.current = null;
-          }
-          return s;
-        }
-
-        const won = checkWon(newFoundations);
-        const newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
-        const newPhase: GamePhase = won ? "won" : s.phase;
-
-        return {
-          ...s,
-          tableau: newTableau,
-          foundations: newFoundations,
-          waste: newWaste,
-          wasteIndex: newWasteIndex,
-          moves: s.moves + 1,
-          phase: newPhase,
-          selected: null,
-        };
-      });
-    }, 150);
   }, []);
 
+  useEffect(() => { if (phase === "game-over") stopTimer(); }, [phase, stopTimer]);
+  useEffect(() => () => { stopTimer(); }, [stopTimer]);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  function applyLayouts(...layouts: Record<string, CardVisualState>[]): void {
+    setCardStates(prev => {
+      const next = { ...prev };
+      for (const l of layouts) Object.assign(next, l);
+      return next;
+    });
+  }
+
+  function stackById(id: StackId): CardStack {
+    if (id === "stock") return stockStack.current;
+    if (id === "waste") return wasteStack.current;
+    if (id.startsWith("found-")) return foundations.current[parseInt(id.slice(6))];
+    return tableau.current[parseInt(id.slice(4))];
+  }
+
+  // Build visual states for all stacks
+  function allLayouts(ms = 250): Record<string, CardVisualState> {
+    const result: Record<string, CardVisualState> = {};
+    for (const t of tableau.current)     Object.assign(result, t.layout(ms));
+    for (const f of foundations.current) Object.assign(result, f.layout(ms));
+    Object.assign(result, stockStack.current.layout(ms));
+    Object.assign(result, computeWasteLayout(ms));
+    return result;
+  }
+
+  // Waste visual: draw-3 fans the top 3 cards left→right so all are visible
+  function computeWasteLayout(ms = 250): Record<string, CardVisualState> {
+    const cards = wasteStack.current.cards;
+    if (cards.length === 0) return {};
+    if (drawMode === 1 || cards.length <= 1) return wasteStack.current.layout(ms);
+    const result: Record<string, CardVisualState> = {};
+    const show = Math.min(3, cards.length);
+    const base = cards.length - show;
+    for (let i = 0; i < base; i++) {
+      result[cards[i].id] = { x: COL_X[1], y: TOP_Y, z: 1300 + i, rotation: 0, faceDown: false, transitionMs: ms };
+    }
+    for (let j = 0; j < show; j++) {
+      result[cards[base + j].id] = {
+        x: COL_X[1] + (j - (show - 1)) * 8 + (show - 1) * 8,
+        y: TOP_Y, z: 1300 + base + j,
+        rotation: 0, faceDown: false, transitionMs: ms,
+      };
+    }
+    return result;
+  }
+
+  // ── startGame ──────────────────────────────────────────────────────────────
+
+  const startGame = useCallback(() => {
+    clearTimers();
+    stopTimer();
+    setElapsed(0);
+    startTimeRef.current = null;
+    setSelectedRun([]);
+    setMoves(0);
+    setAutoComplete(false);
+    setPhase("shuffle");
+
+    const deck = shuffle(buildDeck({
+      ...settings,
+      numDecks: 1,
+      suits: ["spades", "hearts", "diamonds", "clubs"] as Suit[],
+      includeJokers: false,
+    }));
+
+    for (const t of tableau.current)     t.clear();
+    for (const f of foundations.current) f.clear();
+    stockStack.current.clear();
+    wasteStack.current.clear();
+
+    const initStates: Record<string, CardVisualState> = {};
+    for (const c of deck) {
+      initStates[c.id] = { x: COL_X[0], y: TOP_Y, z: 1200, rotation: 0, faceDown: true, transitionMs: 0 };
+    }
+    setAllCards(deck);
+    setCardStates(initStates);
+
+    const SPLIT = 220, PAUSE = 60, MERGE = 160, STAGGER = 6;
+    const DEAL_MS = 280;
+    const MERGE_TOTAL = MERGE + (deck.length - 1) * STAGGER;
+
+    function mergeAnim(c1: Card[], c2: Card[]): Record<string, CardVisualState> {
+      const merged: Card[] = [];
+      const len = Math.max(c1.length, c2.length);
+      for (let i = 0; i < len; i++) {
+        if (i < c1.length) merged.push(c1[i]);
+        if (i < c2.length) merged.push(c2[i]);
+      }
+      const out: Record<string, CardVisualState> = {};
+      merged.forEach((c, i) => {
+        out[c.id] = { x: COL_X[0], y: TOP_Y, z: 10 + i, rotation: 0, faceDown: true, transitionMs: MERGE, transitionDelay: i * STAGGER };
+      });
+      return out;
+    }
+
+    const half = Math.floor(deck.length / 2);
+    const left = deck.slice(0, half), right = deck.slice(half);
+    const lx = COL_X[0] - 60, rx = COL_X[0] + 60;
+
+    let now = 80;
+
+    after(now, () => {
+      const s: Record<string, CardVisualState> = {};
+      left.forEach((c, i)  => { s[c.id] = { x: lx + i*0.4, y: TOP_Y - i*0.4, z: 300+i, rotation: 0, faceDown: true, transitionMs: SPLIT }; });
+      right.forEach((c, i) => { s[c.id] = { x: rx - i*0.4, y: TOP_Y - i*0.4, z: 400+i, rotation: 0, faceDown: true, transitionMs: SPLIT }; });
+      setCardStates(s);
+    });
+    now += SPLIT + PAUSE;
+
+    after(now, () => setCardStates(mergeAnim(left, right)));
+    now += MERGE_TOTAL + PAUSE;
+
+    after(now, () => {
+      const s: Record<string, CardVisualState> = {};
+      left.forEach((c, i)  => { s[c.id] = { x: lx + i*0.3, y: TOP_Y - i*0.3, z: 300+i, rotation: 0, faceDown: true, transitionMs: SPLIT }; });
+      right.forEach((c, i) => { s[c.id] = { x: rx - i*0.3, y: TOP_Y - i*0.3, z: 400+i, rotation: 0, faceDown: true, transitionMs: SPLIT }; });
+      setCardStates(s);
+    });
+    now += SPLIT + PAUSE;
+
+    after(now, () => setCardStates(mergeAnim(left, right)));
+    now += MERGE_TOTAL + PAUSE;
+
+    // Deal: col 0→1 card, col 1→2, ..., col 6→7; rest to stock
+    after(now, () => {
+      let idx = 0;
+      for (let col = 0; col < 7; col++) {
+        for (let row = 0; row <= col; row++) {
+          tableau.current[col].addCard(deck[idx++], { toTop: true, faceDown: row < col });
+        }
+      }
+      for (let i = idx; i < deck.length; i++) {
+        stockStack.current.addCard(deck[i], { toTop: true, faceDown: true });
+      }
+      setStockLeft(stockStack.current.size);
+
+      // Staggered deal states
+      const dealStates: Record<string, CardVisualState> = {};
+      idx = 0;
+      for (let col = 0; col < 7; col++) {
+        for (let row = 0; row <= col; row++) {
+          const c = deck[idx++];
+          let y = TAB_Y;
+          for (let r = 0; r < row; r++) y += 15;
+          dealStates[c.id] = {
+            x: COL_X[col], y,
+            z: 500 + col * 100 + row,
+            rotation: 0, faceDown: row < col,
+            transitionMs: DEAL_MS, transitionDelay: (col + row) * 40,
+          };
+        }
+      }
+      Object.assign(dealStates, stockStack.current.layout(DEAL_MS));
+      setCardStates(dealStates);
+
+      after(DEAL_MS + 12 * 40 + 100, () => {
+        applyLayouts(allLayouts(0));
+        setPhase("idle");
+      });
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings]);
+
   useEffect(() => {
-    return () => {
-      if (autoCompleteRef.current) {
-        clearInterval(autoCompleteRef.current);
-        autoCompleteRef.current = null;
+    startGame();
+    return clearTimers;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Draw card ─────────────────────────────────────────────────────────────
+
+  const drawCard = useCallback(() => {
+    if (phase !== "idle") return;
+    ensureTimer();
+    setSelectedRun([]);
+
+    if (stockStack.current.size === 0) {
+      if (wasteStack.current.size === 0) return;
+      const cards = [...wasteStack.current.cards].reverse();
+      wasteStack.current.clear();
+      for (const c of cards) stockStack.current.addCard(c, { toTop: true, faceDown: true });
+      setStockLeft(stockStack.current.size);
+      applyLayouts(stockStack.current.layout(250), computeWasteLayout(250));
+      setMoves(m => m + 1);
+      return;
+    }
+
+    const n = Math.min(drawMode, stockStack.current.size);
+    for (let i = 0; i < n; i++) {
+      const c = stockStack.current.removeTop();
+      if (c) wasteStack.current.addCard(c, { toTop: true, faceDown: false });
+    }
+    setStockLeft(stockStack.current.size);
+    applyLayouts(stockStack.current.layout(200), computeWasteLayout(200));
+    setMoves(m => m + 1);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, drawMode]);
+
+  // ── Stack lookup ──────────────────────────────────────────────────────────
+
+  function findStack(cardId: string): StackId | null {
+    for (let i = 0; i < 7; i++) {
+      if (tableau.current[i].cards.some(c => c.id === cardId)) return `tab-${i}`;
+    }
+    for (let i = 0; i < 4; i++) {
+      if (foundations.current[i].cards.some(c => c.id === cardId)) return `found-${i}`;
+    }
+    if (stockStack.current.cards.some(c => c.id === cardId)) return "stock";
+    if (wasteStack.current.cards.some(c => c.id === cardId)) return "waste";
+    return null;
+  }
+
+  function getRunFrom(cardId: string, stackId: StackId): Card[] {
+    const cards = stackById(stackId).cards;
+    const idx = cards.findIndex(c => c.id === cardId);
+    return idx === -1 ? [] : cards.slice(idx);
+  }
+
+  // ── Drop target detection ─────────────────────────────────────────────────
+
+  function findDropTarget(px: number, py: number, run: Card[]): StackId | null {
+    const lead = run[0];
+    const THRESH = 55;
+    let best: StackId | null = null;
+    let bestDist = Infinity;
+
+    for (let i = 0; i < 7; i++) {
+      const top = tableau.current[i].top;
+      if (!canPlaceOnTableau(lead, top, relaxed)) continue;
+      const cy = top ? (cardStates[top.id]?.y ?? TAB_Y) : TAB_Y;
+      const dist = Math.hypot(px - COL_X[i], py - cy);
+      if (dist < THRESH && dist < bestDist) { bestDist = dist; best = `tab-${i}`; }
+    }
+
+    if (run.length === 1) {
+      for (let i = 0; i < 4; i++) {
+        const top = foundations.current[i].top;
+        if (!canPlaceOnFoundation(lead, top)) continue;
+        const dist = Math.hypot(px - COL_X[3 + i], py - TOP_Y);
+        if (dist < THRESH && dist < bestDist) { bestDist = dist; best = `found-${i}`; }
+      }
+    }
+
+    return best;
+  }
+
+  // ── Execute move ──────────────────────────────────────────────────────────
+
+  function executeMove(run: Card[], fromId: StackId, toId: StackId): void {
+    const from = stackById(fromId);
+    const to   = stackById(toId);
+
+    for (let i = run.length - 1; i >= 0; i--) from.removeCard(run[i].id);
+    if (fromId.startsWith("tab-") && from.size > 0 && from.topFaceDown) from.flipTop();
+
+    const faceDown = toId === "stock";
+    for (const c of run) to.addCard(c, { toTop: true, faceDown });
+
+    if (toId === "stock" || toId === "waste") setStockLeft(stockStack.current.size);
+    setMoves(m => m + 1);
+
+    const newLayouts = allLayouts(200);
+    run.forEach((c, i) => {
+      if (newLayouts[c.id]) newLayouts[c.id] = { ...newLayouts[c.id], transitionDelay: i * 40 };
+    });
+    applyLayouts(newLayouts);
+    setSelectedRun([]);
+
+    const won = foundations.current.every(f => f.size === 13);
+    if (won) { after(400, () => setPhase("game-over")); return; }
+
+    // Check auto-complete eligibility
+    const allFaceUp = tableau.current.every(t => !t.topFaceDown || t.size === 0);
+    const noStock   = stockStack.current.size === 0 && wasteStack.current.size === 0;
+    setAutoComplete(allFaceUp && noStock);
+  }
+
+  // ── Auto-complete ─────────────────────────────────────────────────────────
+
+  const runAutoComplete = useCallback(() => {
+    if (phase !== "idle") return;
+    setPhase("animating");
+    const step = () => {
+      let moved = false;
+      outer:
+      for (const t of tableau.current) {
+        const top = t.top;
+        if (!top) continue;
+        for (let fi = 0; fi < 4; fi++) {
+          if (canPlaceOnFoundation(top, foundations.current[fi].top)) {
+            t.removeTop();
+            if (t.size > 0 && t.topFaceDown) t.flipTop();
+            foundations.current[fi].addCard(top, { toTop: true, faceDown: false });
+            moved = true;
+            break outer;
+          }
+        }
+      }
+      // Also check waste
+      if (!moved) {
+        const top = wasteStack.current.top;
+        if (top) {
+          for (let fi = 0; fi < 4; fi++) {
+            if (canPlaceOnFoundation(top, foundations.current[fi].top)) {
+              wasteStack.current.removeTop();
+              foundations.current[fi].addCard(top, { toTop: true, faceDown: false });
+              moved = true;
+              break;
+            }
+          }
+        }
+      }
+      if (!moved) { setPhase("idle"); return; }
+      applyLayouts(allLayouts(200));
+      if (foundations.current.every(f => f.size === 13)) {
+        after(400, () => setPhase("game-over"));
+      } else {
+        after(150, step);
       }
     };
-  }, []);
+    step();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
 
-  // ── Restart ────────────────────────────────────────────────────────────────
+  // ── Pointer handlers ──────────────────────────────────────────────────────
 
-  const restart = useCallback(() => {
-    if (autoCompleteRef.current) {
-      clearInterval(autoCompleteRef.current);
-      autoCompleteRef.current = null;
+  const handleCardPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>, cardId: string) => {
+    if (phase !== "idle") return;
+    const cs = cardStates[cardId];
+    if (!cs || cs.faceDown) return;
+
+    const stackId = findStack(cardId);
+    if (!stackId || stackId === "stock") return;
+
+    // Waste: only top card is draggable
+    if (stackId === "waste") {
+      const topCard = wasteStack.current.top;
+      if (!topCard || topCard.id !== cardId) return;
     }
-    setState(makeInitialState());
-    setElapsed(0);
-  }, []);
 
-  // ── Stock click ────────────────────────────────────────────────────────────
+    const run = getRunFrom(cardId, stackId);
+    if (run.length === 0) return;
 
-  const handleStockClick = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "playing") return s;
-      const draw = settings.klondikeDraw;
+    // Validate run is a legal alternating-color descending sequence
+    for (let i = 1; i < run.length; i++) {
+      if (rv(run[i]) !== rv(run[i-1]) - 1 || cardColor(run[i]) === cardColor(run[i-1])) return;
+    }
 
-      if (s.stock.length === 0) {
-        // Reset: flip waste back to stock
-        if (s.waste.length === 0) return s;
-        return {
-          ...s,
-          stock: [...s.waste].reverse(),
-          waste: [],
-          wasteIndex: -1,
-          selected: null,
-          moves: s.moves + 1,
-        };
-      }
+    ensureTimer();
+    e.currentTarget.setPointerCapture(e.pointerId);
 
-      // Draw from stock to waste
-      const toDraw = Math.min(draw, s.stock.length);
-      const drawn = s.stock.slice(0, toDraw);
-      const newStock = s.stock.slice(toDraw);
-      const newWaste = [...s.waste, ...drawn];
-      const newWasteIndex = newWaste.length - 1;
+    const stageEl = stageRef.current;
+    if (!stageEl) return;
+    const rect = stageEl.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
 
-      return {
-        ...s,
-        stock: newStock,
-        waste: newWaste,
-        wasteIndex: newWasteIndex,
-        selected: null,
-        moves: s.moves + 1,
-      };
-    });
-  }, [settings.klondikeDraw]);
+    drag.current = {
+      ids: run.map(c => c.id),
+      fromStack: stackId,
+      originStates: Object.fromEntries(run.map(c => [c.id, cardStates[c.id]])),
+      offsetX: px - cs.x,
+      offsetY: py - cs.y,
+      moved: false,
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, cardStates]);
 
-  // ── Move logic ─────────────────────────────────────────────────────────────
+  const handleStagePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d) return;
+    const stageEl = stageRef.current;
+    if (!stageEl) return;
+    const rect = stageEl.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
 
-  const tryMoveToFoundation = useCallback(
-    (
-      from: KlondikeSelection["from"],
-      colIndex: number,
-      cardIndex: number,
-      s: KlondikeState
-    ): KlondikeState | null => {
-      let card: Card | null = null;
+    if (!d.moved) {
+      const dx = px - (d.originStates[d.ids[0]]?.x ?? 0) + d.offsetX;
+      const dy = py - (d.originStates[d.ids[0]]?.y ?? 0) + d.offsetY;
+      if (Math.hypot(dx, dy) < 4) return;
+      d.moved = true;
+    }
 
-      if (from === "tableau") {
-        const col = s.tableau[colIndex];
-        if (col.faceUp.length === 0) return null;
-        // Only move single card (top of the sequence) to foundation
-        if (cardIndex !== col.faceUp.length - 1) return null;
-        card = col.faceUp[col.faceUp.length - 1];
-      } else if (from === "waste") {
-        card = getVisibleWasteCard(s);
-      } else if (from === "foundation") {
-        if (s.foundations[colIndex].length === 0) return null;
-        card = s.foundations[colIndex][s.foundations[colIndex].length - 1];
-      }
-
-      if (!card) return null;
-
-      // Find a matching foundation (must be a different pile if source is foundation)
-      for (let fi = 0; fi < 4; fi++) {
-        // Can't move a foundation card onto the same foundation pile
-        if (from === "foundation" && fi === colIndex) continue;
-
-        if (canPlaceOnFoundation(card, s.foundations[fi])) {
-          // Build new foundations: add card to fi
-          const newFoundations = s.foundations.map((f, i) =>
-            i === fi ? [...f, card!] : [...f]
-          );
-
-          let newTableau = s.tableau;
-          let newWaste = s.waste;
-          let newWasteIndex = s.wasteIndex;
-
-          if (from === "tableau") {
-            newTableau = s.tableau.map((tCol, ci) => {
-              if (ci !== colIndex) return tCol;
-              const newFaceUp = tCol.faceUp.slice(0, tCol.faceUp.length - 1);
-              const newFaceDown = [...tCol.faceDown];
-              // Flip next card if face-up becomes empty
-              if (newFaceUp.length === 0 && newFaceDown.length > 0) {
-                newFaceUp.push(newFaceDown[newFaceDown.length - 1]);
-                newFaceDown.pop();
-              }
-              return { faceDown: newFaceDown, faceUp: newFaceUp };
-            });
-          } else if (from === "waste") {
-            const wIdx = Math.min(s.wasteIndex, s.waste.length - 1);
-            newWaste = [...s.waste];
-            newWaste.splice(wIdx, 1);
-            newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
-          } else if (from === "foundation") {
-            // Remove card from source foundation pile
-            newFoundations[colIndex] = newFoundations[colIndex].slice(
-              0,
-              newFoundations[colIndex].length - 1
-            );
-          }
-
-          const won = checkWon(newFoundations);
-          const newPhase: GamePhase = won ? "won" : s.phase;
-
-          return {
-            ...s,
-            tableau: newTableau,
-            foundations: newFoundations,
-            waste: newWaste,
-            wasteIndex: newWasteIndex,
-            selected: null,
-            moves: s.moves + 1,
-            phase: newPhase,
-          };
-        }
-      }
-
-      return null;
-    },
-    []
-  );
-
-  const tryMoveToTableau = useCallback(
-    (
-      sel: KlondikeSelection,
-      destCol: number,
-      s: KlondikeState
-    ): KlondikeState | null => {
-      // Get the sequence of cards to move
-      let cards: Card[] = [];
-
-      if (sel.from === "tableau") {
-        const col = s.tableau[sel.colIndex];
-        cards = col.faceUp.slice(sel.cardIndex);
-      } else if (sel.from === "waste") {
-        const wCard = getVisibleWasteCard(s);
-        if (!wCard) return null;
-        cards = [wCard];
-      } else if (sel.from === "foundation") {
-        const f = s.foundations[sel.colIndex];
-        if (f.length === 0) return null;
-        cards = [f[f.length - 1]];
-      }
-
-      if (cards.length === 0) return null;
-
-      // Can't move a column onto itself
-      if (sel.from === "tableau" && sel.colIndex === destCol) return null;
-
-      const destColData = s.tableau[destCol];
-      const topCard =
-        destColData.faceUp.length > 0
-          ? destColData.faceUp[destColData.faceUp.length - 1]
-          : null;
-
-      if (!canPlaceOnTableau(cards[0], topCard, settings.klondikeRelaxed)) return null;
-
-      // Build new state
-      let newTableau = s.tableau.map((col) => ({
-        faceDown: [...col.faceDown],
-        faceUp: [...col.faceUp],
-      }));
-      let newWaste = [...s.waste];
-      let newWasteIndex = s.wasteIndex;
-      let newFoundations = s.foundations.map((f) => [...f]);
-
-      // Remove from source
-      if (sel.from === "tableau") {
-        const srcCol = newTableau[sel.colIndex];
-        srcCol.faceUp = srcCol.faceUp.slice(0, sel.cardIndex);
-        // Flip next face-down if needed
-        if (srcCol.faceUp.length === 0 && srcCol.faceDown.length > 0) {
-          srcCol.faceUp = [srcCol.faceDown[srcCol.faceDown.length - 1]];
-          srcCol.faceDown = srcCol.faceDown.slice(0, srcCol.faceDown.length - 1);
-        }
-      } else if (sel.from === "waste") {
-        const wIdx = Math.min(s.wasteIndex, s.waste.length - 1);
-        newWaste.splice(wIdx, 1);
-        newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
-      } else if (sel.from === "foundation") {
-        newFoundations[sel.colIndex] = newFoundations[sel.colIndex].slice(
-          0,
-          newFoundations[sel.colIndex].length - 1
-        );
-      }
-
-      // Add to destination
-      newTableau[destCol].faceUp = [...newTableau[destCol].faceUp, ...cards];
-
-      return {
-        ...s,
-        tableau: newTableau,
-        foundations: newFoundations,
-        waste: newWaste,
-        wasteIndex: newWasteIndex,
-        selected: null,
-        moves: s.moves + 1,
-      };
-    },
-    [settings.klondikeRelaxed]
-  );
-
-  // ── Click handlers ─────────────────────────────────────────────────────────
-
-  const handleWasteClick = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "playing") return s;
-      const card = getVisibleWasteCard(s);
-      if (!card) return { ...s, selected: null };
-
-      // If already selected from waste → deselect
-      if (s.selected?.from === "waste") {
-        return { ...s, selected: null };
-      }
-
-      // If something is selected, try move to... waste? That's not valid. Change selection.
-      if (s.selected) {
-        // Can't move to waste, so select waste card instead
-        return {
-          ...s,
-          selected: { from: "waste", colIndex: 0, cardIndex: 0 },
-        };
-      }
-
-      // Select the waste top
-      return {
-        ...s,
-        selected: { from: "waste", colIndex: 0, cardIndex: 0 },
-      };
+    setCardStates(prev => {
+      const next = { ...prev };
+      const originLead = d.originStates[d.ids[0]];
+      d.ids.forEach((id, i) => {
+        const origin = d.originStates[id];
+        const offX = origin ? origin.x - originLead.x : 0;
+        const offY = origin ? origin.y - originLead.y : 0;
+        next[id] = { ...prev[id], x: px - d.offsetX + offX, y: py - d.offsetY + offY, z: Z_DRAG + i, transitionMs: 0 };
+      });
+      return next;
     });
   }, []);
 
-  const handleFoundationClick = useCallback(
-    (fi: number) => {
-      setState((s) => {
-        if (s.phase !== "playing") return s;
+  const handleStagePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d) return;
+    drag.current = null;
 
-        // If something is selected, try moving it to foundation
-        if (s.selected) {
-          // Don't move from same foundation to same foundation
-          if (s.selected.from === "foundation" && s.selected.colIndex === fi) {
-            return { ...s, selected: null };
+    if (!d.moved) {
+      // Tap/click — 2-click mode
+      const leadId = d.ids[0];
+      if (selectedRun.length > 0 && selectedRun[0] !== leadId) {
+        const clickedStack = findStack(leadId);
+        const fromStack    = findStack(selectedRun[0]);
+        if (clickedStack && fromStack) {
+          const run = selectedRun.map(id => allCards.find(c => c.id === id)!).filter(Boolean);
+          if (run.length > 0) {
+            executeMove(run, fromStack, clickedStack);
+            return;
           }
-
-          const moved = tryMoveToFoundation(
-            s.selected.from,
-            s.selected.colIndex,
-            s.selected.cardIndex,
-            s
-          );
-          if (moved) return moved;
-
-          // If selection is a foundation card, switch selection
-          const fTop = s.foundations[fi];
-          if (fTop.length > 0) {
-            return { ...s, selected: { from: "foundation", colIndex: fi, cardIndex: 0 } };
-          }
-
-          return { ...s, selected: null };
         }
-
-        // Select top of foundation
-        if (s.foundations[fi].length > 0) {
-          return {
-            ...s,
-            selected: { from: "foundation", colIndex: fi, cardIndex: 0 },
-          };
-        }
-
-        return s;
-      });
-    },
-    [tryMoveToFoundation]
-  );
-
-  const handleTableauCardClick = useCallback(
-    (colIndex: number, cardIndex: number) => {
-      setState((s) => {
-        if (s.phase !== "playing") return s;
-        const col = s.tableau[colIndex];
-        const card = col.faceUp[cardIndex];
-        if (!card) return s;
-
-        // If clicking the same card, deselect
-        if (
-          s.selected?.from === "tableau" &&
-          s.selected.colIndex === colIndex &&
-          s.selected.cardIndex === cardIndex
-        ) {
-          return { ...s, selected: null };
-        }
-
-        // If something is selected, try moving to this column
-        if (s.selected) {
-          const moved = tryMoveToTableau(s.selected, colIndex, s);
-          if (moved) return moved;
-
-          // Try double-click-style: if single card and can go to foundation
-          // But user clicked a tableau card, not a foundation — try to move selection to foundation
-          // first try to move clicked card to foundation if it's the selection target
-          // Actually: if move fails, change selection to the clicked card
-          return {
-            ...s,
-            selected: { from: "tableau", colIndex, cardIndex },
-          };
-        }
-
-        // No selection — select this card
-        return {
-          ...s,
-          selected: { from: "tableau", colIndex, cardIndex },
-        };
-      });
-    },
-    [tryMoveToTableau]
-  );
-
-  const handleTableauEmptyClick = useCallback(
-    (colIndex: number) => {
-      setState((s) => {
-        if (s.phase !== "playing") return s;
-        if (!s.selected) return s;
-
-        const moved = tryMoveToTableau(s.selected, colIndex, s);
-        if (moved) return moved;
-
-        return { ...s, selected: null };
-      });
-    },
-    [tryMoveToTableau]
-  );
-
-  // Double-click: auto-move to foundation
-  const handleTableauCardDblClick = useCallback(
-    (colIndex: number, cardIndex: number) => {
-      setState((s) => {
-        if (s.phase !== "playing") return s;
-        const col = s.tableau[colIndex];
-        if (cardIndex !== col.faceUp.length - 1) return s; // only top card
-        const moved = tryMoveToFoundation("tableau", colIndex, cardIndex, s);
-        return moved ?? s;
-      });
-    },
-    [tryMoveToFoundation]
-  );
-
-  const handleWasteDblClick = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "playing") return s;
-      const moved = tryMoveToFoundation("waste", 0, 0, s);
-      return moved ?? s;
-    });
-  }, [tryMoveToFoundation]);
-
-  // ── Valid destination highlighting ─────────────────────────────────────────
-
-  const validTableauDests = useMemo<boolean[]>(() => {
-    if (!state.selected) return Array(7).fill(false);
-    return state.tableau.map((col, ci) => {
-      // Don't highlight source column
-      if (state.selected!.from === "tableau" && state.selected!.colIndex === ci) return false;
-
-      let cards: Card[] = [];
-      if (state.selected!.from === "tableau") {
-        cards = state.tableau[state.selected!.colIndex].faceUp.slice(state.selected!.cardIndex);
-      } else if (state.selected!.from === "waste") {
-        const wc = getVisibleWasteCard(state);
-        if (wc) cards = [wc];
-      } else if (state.selected!.from === "foundation") {
-        const f = state.foundations[state.selected!.colIndex];
-        if (f.length > 0) cards = [f[f.length - 1]];
       }
+      if (selectedRun[0] === leadId) {
+        setSelectedRun([]);
+        applyLayouts(allLayouts(150));
+      } else {
+        setSelectedRun(d.ids);
+        applyLayouts(allLayouts(150));
+      }
+      return;
+    }
 
-      if (cards.length === 0) return false;
-      const topCard =
-        col.faceUp.length > 0 ? col.faceUp[col.faceUp.length - 1] : null;
-      return canPlaceOnTableau(cards[0], topCard, settings.klondikeRelaxed);
-    });
-  }, [state, settings.klondikeRelaxed]);
+    const stageEl = stageRef.current;
+    if (!stageEl) { applyLayouts(allLayouts(200)); return; }
+    const rect = stageEl.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
 
-  // ── Menus ──────────────────────────────────────────────────────────────────
+    const run = d.ids.map(id => allCards.find(c => c.id === id)!).filter(Boolean);
+    const target = findDropTarget(px - d.offsetX, py - d.offsetY, run);
+
+    if (target && target !== d.fromStack) {
+      executeMove(run, d.fromStack, target);
+    } else {
+      setCardStates(prev => {
+        const next = { ...prev };
+        const origins = d.originStates;
+        for (const id of Object.keys(origins)) {
+          const cs: CardVisualState = origins[id];
+          next[id] = { ...cs, transitionMs: 200 };
+        }
+        return next;
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allCards, cardStates, selectedRun, relaxed]);
+
+  // 2-click: click a foundation slot directly
+  const handleFoundationClick = useCallback((foundIdx: number) => {
+    if (phase !== "idle" || selectedRun.length === 0) return;
+    const run = selectedRun.map(id => allCards.find(c => c.id === id)!).filter(Boolean);
+    if (run.length !== 1) return;
+    const fromId = findStack(selectedRun[0]);
+    if (!fromId) return;
+    if (canPlaceOnFoundation(run[0], foundations.current[foundIdx].top)) {
+      executeMove(run, fromId, `found-${foundIdx}`);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selectedRun, allCards]);
+
+  // 2-click: click an empty tableau column
+  const handleEmptyTabClick = useCallback((col: number) => {
+    if (phase !== "idle" || selectedRun.length === 0) return;
+    const run = selectedRun.map(id => allCards.find(c => c.id === id)!).filter(Boolean);
+    const fromId = findStack(selectedRun[0]);
+    if (!fromId || !canPlaceOnTableau(run[0], null, relaxed)) return;
+    executeMove(run, fromId, `tab-${col}`);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, selectedRun, allCards, relaxed]);
+
+  // ── Menus ─────────────────────────────────────────────────────────────────
 
   const menus = useMemo<MenuBarMenu[]>(() => {
     const gameItems: MenuBarMenu["items"] = [
-      { label: "Restart", onClick: restart },
-      ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
-      ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+      { label: "New Game",    onClick: startGame },
+      ...(onNewGame ? [{ label: "Change Game…", onClick: onNewGame }] : []),
+      ...(onQuit    ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
     ];
     return [
-      { label: "Game", items: gameItems },
-      {
-        label: "Options",
-        items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }],
-      },
+      { label: "Game",    items: gameItems },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
-  }, [restart, onNewGame, onQuit]);
+  }, [startGame, onNewGame, onQuit]);
 
   useWindowMenus(menus);
 
-  // ── Render ─────────────────────────────────────────────────────────────────
-
-  const { tableau, foundations, stock, waste, wasteIndex, selected, moves, phase } = state;
-  const wasteTopCard = getVisibleWasteCard(state);
-  const canAutoComplete = allFaceUp(tableau) && phase === "playing";
-  const autoRunning = autoCompleteRef.current !== null;
-
-  const SUIT_SYMBOLS: Record<Suit, string> = {
-    spades: "♠",
-    hearts: "♥",
-    diamonds: "♦",
-    clubs: "♣",
-  };
+  // ── Render ────────────────────────────────────────────────────────────────
 
   return (
     <div className="klondike">
       {showDeckModal && (
-        <DeckModal
-          appearance={appearance}
-          onUpdate={setAppearance}
-          onClose={() => setShowDeckModal(false)}
-        />
+        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
 
-      {/* Top area: foundations + stock/waste */}
-      <div className="klondike__top-row">
-        {/* Foundations */}
-        <div className="klondike__foundations">
-          {FOUNDATION_SUITS.map((suit, fi) => {
-            const fPile = foundations[fi];
-            const fTop = fPile.length > 0 ? fPile[fPile.length - 1] : null;
-            const isSelected =
-              selected?.from === "foundation" && selected.colIndex === fi;
-            return (
-              <div
-                key={suit}
-                className={
-                  "klondike__foundation-slot" +
-                  (isSelected ? " klondike__foundation-slot--selected" : "")
-                }
-                onClick={() => handleFoundationClick(fi)}
-                title={`${suit} foundation`}
-              >
-                {fTop ? (
-                  <PlayingCard card={fTop} appearance={appearance} size="sm" />
-                ) : (
-                  <div className="klondike__empty-slot klondike__empty-slot--suit">
-                    <span className="klondike__suit-hint">{SUIT_SYMBOLS[suit]}</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+      <div
+        ref={stageRef}
+        className="klondike__stage"
+        style={{ width: STAGE_W, height: STAGE_H }}
+        onPointerMove={handleStagePointerMove}
+        onPointerUp={handleStagePointerUp}
+      >
+        {/* Empty slot outlines */}
+        <div
+          className="klondike__slot"
+          style={{ left: COL_X[0] - CARD_W/2, top: TOP_Y - CARD_H/2 }}
+          onClick={drawCard}
+        >
+          {stockStack.current.size === 0 && <span className="klondike__slot-icon">↺</span>}
         </div>
 
-        {/* Spacer */}
-        <div className="klondike__top-spacer" />
+        <div className="klondike__slot" style={{ left: COL_X[1] - CARD_W/2, top: TOP_Y - CARD_H/2 }} />
 
-        {/* Stock + Waste */}
-        <div className="klondike__stock-area">
-          {/* Waste */}
+        {[0,1,2,3].map(i => (
           <div
-            className={
-              "klondike__waste-slot" +
-              (selected?.from === "waste" ? " klondike__waste-slot--selected" : "")
-            }
-            onClick={handleWasteClick}
-            onDoubleClick={handleWasteDblClick}
+            key={i}
+            className="klondike__slot klondike__slot--foundation"
+            style={{ left: COL_X[3+i] - CARD_W/2, top: TOP_Y - CARD_H/2 }}
+            onClick={() => handleFoundationClick(i)}
           >
-            {wasteTopCard ? (
-              <>
-                {/* Show peeks of cards behind in draw-3 mode (back=furthest left, mid=closer) */}
-                {settings.klondikeDraw === 3 && wasteIndex >= 2 && waste[wasteIndex - 2] && (
-                  <div className="klondike__waste-peek klondike__waste-peek--back">
-                    <PlayingCard
-                      card={waste[wasteIndex - 2]}
-                      appearance={appearance}
-                      size="sm"
-                    />
-                  </div>
-                )}
-                {settings.klondikeDraw === 3 && wasteIndex >= 1 && waste[wasteIndex - 1] && (
-                  <div className="klondike__waste-peek klondike__waste-peek--mid">
-                    <PlayingCard
-                      card={waste[wasteIndex - 1]}
-                      appearance={appearance}
-                      size="sm"
-                    />
-                  </div>
-                )}
-                <div className="klondike__waste-top">
-                  <PlayingCard key={wasteTopCard.id} card={wasteTopCard} appearance={appearance} size="sm" dealIndex={0} />
-                </div>
-              </>
-            ) : (
-              <div className="klondike__empty-slot" />
-            )}
+            <span className="klondike__slot-suit">{["♠","♥","♦","♣"][i]}</span>
           </div>
+        ))}
 
-          {/* Stock */}
+        {tableau.current.map((t, i) => t.size === 0 && (
           <div
-            className="klondike__stock-slot"
-            onClick={handleStockClick}
-            title={stock.length > 0 ? `Stock: ${stock.length} cards` : "Click to reset"}
-          >
-            {stock.length > 0 ? (
-              <PlayingCard
-                card={stock[0]}
-                faceDown
-                appearance={appearance}
-                size="sm"
-              />
-            ) : (
-              <div className="klondike__empty-slot klondike__stock-reset">
-                <span className="klondike__reset-icon">↺</span>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+            key={i}
+            className="klondike__slot"
+            style={{ left: COL_X[i] - CARD_W/2, top: TAB_Y - CARD_H/2 }}
+            onClick={() => handleEmptyTabClick(i)}
+          />
+        ))}
 
-      {/* Tableau */}
-      <div className="klondike__tableau">
-        {tableau.map((col, ci) => {
-          const isValidDest = validTableauDests[ci];
-          const totalCards = col.faceDown.length + col.faceUp.length;
-          // Height: face-down slivers (18px each) + face-up slivers (26px each) + last card full height (72px)
-          const colHeight = totalCards === 0
-            ? 72
-            : col.faceDown.length * 18 +
-              (col.faceUp.length > 1 ? (col.faceUp.length - 1) * 26 : 0) +
-              72;
-
+        {/* All 52 cards — permanently mounted */}
+        {allCards.map(card => {
+          const cs = cardStates[card.id];
+          if (!cs) return null;
+          const isSelected = selectedRun.includes(card.id);
+          const canInteract = !cs.faceDown && phase === "idle";
           return (
-            <div
-              key={ci}
-              className={
-                "klondike__column" +
-                (isValidDest ? " klondike__column--valid-dest" : "")
-              }
-              style={{ height: colHeight }}
-              onClick={totalCards === 0 ? () => handleTableauEmptyClick(ci) : undefined}
-            >
-              {/* Face-down cards */}
-              {col.faceDown.map((card, di) => (
-                <div
-                  key={card.id}
-                  className="klondike__facedown-card"
-                  style={{ top: di * 18 }}
-                >
-                  <PlayingCard card={card} faceDown appearance={appearance} size="sm" />
-                </div>
-              ))}
-
-              {/* Face-up cards */}
-              {col.faceUp.map((card, ui) => {
-                const topOffset = col.faceDown.length * 18;
-                const isSelected =
-                  selected?.from === "tableau" &&
-                  selected.colIndex === ci &&
-                  selected.cardIndex <= ui;
-                const isSelectionStart =
-                  selected?.from === "tableau" &&
-                  selected.colIndex === ci &&
-                  selected.cardIndex === ui;
-                return (
-                  <div
-                    key={card.id}
-                    className={
-                      "klondike__faceup-card" +
-                      (isSelected ? " klondike__faceup-card--selected" : "") +
-                      (isSelectionStart ? " klondike__faceup-card--selection-start" : "")
-                    }
-                    style={{ top: topOffset + ui * 26 }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleTableauCardClick(ci, ui);
-                    }}
-                    onDoubleClick={(e) => {
-                      e.stopPropagation();
-                      handleTableauCardDblClick(ci, ui);
-                    }}
-                  >
-                    <PlayingCard card={card} appearance={appearance} size="sm" />
-                  </div>
-                );
-              })}
-
-              {/* Empty column placeholder */}
-              {totalCards === 0 && (
-                <div className="klondike__empty-slot" />
-              )}
-            </div>
+            <PermCard
+              key={card.id}
+              card={card}
+              cs={cs}
+              appearance={appearance}
+              highlightColor={isSelected ? "#cc4400" : undefined}
+              onPointerDown={canInteract ? (e) => handleCardPointerDown(e, card.id) : undefined}
+            />
           );
         })}
       </div>
 
-      {/* Status bar */}
       <div className="klondike__statusbar">
         <span>Moves: {moves}</span>
+        <span>Stock: {stockLeft}</span>
+        <span>Draw {drawMode}</span>
         <span>Time: {elapsed}s</span>
-        <span>Draw: {settings.klondikeDraw}</span>
-        {canAutoComplete && !autoRunning && (
-          <button className="klondike__autocomplete-btn" onClick={startAutoComplete}>
+        {autoComplete && phase === "idle" && (
+          <button className="klondike__btn klondike__btn--primary klondike__btn--sm" onClick={runAutoComplete}>
             Auto-Complete
           </button>
         )}
       </div>
 
-      {/* Win overlay */}
-      {phase === "won" && (
+      <div className="klondike__controls">
+        <button className="klondike__btn klondike__btn--primary" onClick={startGame}>New Game</button>
+        {onNewGame && <button className="klondike__btn klondike__btn--secondary" onClick={onNewGame}>Change Game</button>}
+      </div>
+
+      {phase === "game-over" && (
         <div className="klondike__win-overlay">
           <div className="klondike__win-banner">
-            <div className="klondike__win-title">YOU WIN!</div>
-            <div className="klondike__win-stats">
-              {moves} moves &bull; {elapsed}s
-            </div>
-            <button className="klondike__win-btn" onClick={restart}>
-              Play Again
-            </button>
-            {onNewGame && (
-              <button className="klondike__win-btn klondike__win-btn--secondary" onClick={onNewGame}>
-                New Game
-              </button>
-            )}
+            <div className="klondike__win-title">You Win!</div>
+            <div className="klondike__win-stats">{moves} moves · {elapsed}s</div>
+            <button className="klondike__btn klondike__btn--primary" onClick={startGame}>Play Again</button>
           </div>
         </div>
       )}

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -63,6 +63,8 @@ interface DragState {
   offsetX: number;
   offsetY: number;
   moved: boolean;
+  startPx: number;
+  startPy: number;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -87,8 +89,10 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
   const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [autoComplete,  setAutoComplete]  = useState(false);
+  const [scale,         setScale]         = useState(1);
 
-  const stageRef = useRef<HTMLDivElement>(null);
+  const stageRef     = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Stacks — face-down/face-up offsets for tableau fanning
   const tableau     = useRef<CardStack[]>(
@@ -125,6 +129,18 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
 
   useEffect(() => { if (phase === "game-over") stopTimer(); }, [phase, stopTimer]);
   useEffect(() => () => { stopTimer(); }, [stopTimer]);
+
+  // Scale stage to fit container on narrow screens
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -482,8 +498,10 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
     const stageEl = stageRef.current;
     if (!stageEl) return;
     const rect = stageEl.getBoundingClientRect();
-    const px = e.clientX - rect.left;
-    const py = e.clientY - rect.top;
+    // Divide by actual rendered size to get stage-native coords (handles CSS scale)
+    const stageScale = rect.width / STAGE_W;
+    const px = (e.clientX - rect.left) / stageScale;
+    const py = (e.clientY - rect.top)  / stageScale;
 
     drag.current = {
       ids: run.map(c => c.id),
@@ -492,6 +510,8 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
       offsetX: px - cs.x,
       offsetY: py - cs.y,
       moved: false,
+      startPx: px,
+      startPy: py,
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase, cardStates]);
@@ -502,13 +522,15 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
     const stageEl = stageRef.current;
     if (!stageEl) return;
     const rect = stageEl.getBoundingClientRect();
-    const px = e.clientX - rect.left;
-    const py = e.clientY - rect.top;
+    const stageScale = rect.width / STAGE_W;
+    const px = (e.clientX - rect.left) / stageScale;
+    const py = (e.clientY - rect.top)  / stageScale;
 
     if (!d.moved) {
-      const dx = px - (d.originStates[d.ids[0]]?.x ?? 0) + d.offsetX;
-      const dy = py - (d.originStates[d.ids[0]]?.y ?? 0) + d.offsetY;
-      if (Math.hypot(dx, dy) < 4) return;
+      // Compare current pointer to WHERE pointer was at pointerDown
+      const dx = px - d.startPx;
+      const dy = py - d.startPy;
+      if (Math.hypot(dx, dy) < 5) return;
       d.moved = true;
     }
 
@@ -557,8 +579,9 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
     const stageEl = stageRef.current;
     if (!stageEl) { applyLayouts(allLayouts(200)); return; }
     const rect = stageEl.getBoundingClientRect();
-    const px = e.clientX - rect.left;
-    const py = e.clientY - rect.top;
+    const stageScale = rect.width / STAGE_W;
+    const px = (e.clientX - rect.left) / stageScale;
+    const py = (e.clientY - rect.top)  / stageScale;
 
     const run = d.ids.map(id => allCards.find(c => c.id === id)!).filter(Boolean);
     const target = findDropTarget(px - d.offsetX, py - d.offsetY, run);
@@ -626,61 +649,93 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
         <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
 
+      {/* Container measures available width; stage scales down to fit */}
       <div
-        ref={stageRef}
-        className="klondike__stage"
-        style={{ width: STAGE_W, height: STAGE_H }}
-        onPointerMove={handleStagePointerMove}
-        onPointerUp={handleStagePointerUp}
+        ref={containerRef}
+        className="klondike__stage-container"
+        style={{ height: Math.round(STAGE_H * scale) + 4 }}
       >
-        {/* Empty slot outlines */}
         <div
-          className="klondike__slot"
-          style={{ left: COL_X[0] - CARD_W/2, top: TOP_Y - CARD_H/2 }}
-          onClick={drawCard}
+          ref={stageRef}
+          className="klondike__stage"
+          style={{
+            width: STAGE_W,
+            height: STAGE_H,
+            transform: scale < 1 ? `scale(${scale})` : undefined,
+            transformOrigin: "top left",
+          }}
+          onPointerMove={handleStagePointerMove}
+          onPointerUp={handleStagePointerUp}
         >
-          {stockStack.current.size === 0 && <span className="klondike__slot-icon">↺</span>}
-        </div>
+          {/* Waste slot outline */}
+          <div className="klondike__slot" style={{ left: COL_X[1] - CARD_W/2, top: TOP_Y - CARD_H/2 }} />
 
-        <div className="klondike__slot" style={{ left: COL_X[1] - CARD_W/2, top: TOP_Y - CARD_H/2 }} />
+          {/* Foundation slots */}
+          {[0,1,2,3].map(i => (
+            <div
+              key={i}
+              className="klondike__slot klondike__slot--foundation"
+              style={{ left: COL_X[3+i] - CARD_W/2, top: TOP_Y - CARD_H/2 }}
+              onClick={() => handleFoundationClick(i)}
+            >
+              <span className="klondike__slot-suit">{["♠","♥","♦","♣"][i]}</span>
+            </div>
+          ))}
 
-        {[0,1,2,3].map(i => (
-          <div
-            key={i}
-            className="klondike__slot klondike__slot--foundation"
-            style={{ left: COL_X[3+i] - CARD_W/2, top: TOP_Y - CARD_H/2 }}
-            onClick={() => handleFoundationClick(i)}
-          >
-            <span className="klondike__slot-suit">{["♠","♥","♦","♣"][i]}</span>
-          </div>
-        ))}
-
-        {tableau.current.map((t, i) => t.size === 0 && (
-          <div
-            key={i}
-            className="klondike__slot"
-            style={{ left: COL_X[i] - CARD_W/2, top: TAB_Y - CARD_H/2 }}
-            onClick={() => handleEmptyTabClick(i)}
-          />
-        ))}
-
-        {/* All 52 cards — permanently mounted */}
-        {allCards.map(card => {
-          const cs = cardStates[card.id];
-          if (!cs) return null;
-          const isSelected = selectedRun.includes(card.id);
-          const canInteract = !cs.faceDown && phase === "idle";
-          return (
-            <PermCard
-              key={card.id}
-              card={card}
-              cs={cs}
-              appearance={appearance}
-              highlightColor={isSelected ? "#cc4400" : undefined}
-              onPointerDown={canInteract ? (e) => handleCardPointerDown(e, card.id) : undefined}
+          {/* Empty tableau column slots */}
+          {tableau.current.map((t, i) => t.size === 0 && (
+            <div
+              key={i}
+              className="klondike__slot"
+              style={{ left: COL_X[i] - CARD_W/2, top: TAB_Y - CARD_H/2 }}
+              onClick={() => handleEmptyTabClick(i)}
             />
-          );
-        })}
+          ))}
+
+          {/* All 52 cards — permanently mounted */}
+          {allCards.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            const isSelected  = selectedRun.includes(card.id);
+            const isTopStock  = stockStack.current.top?.id === card.id;
+            const canInteract = !cs.faceDown && phase === "idle";
+            return (
+              <PermCard
+                key={card.id}
+                card={card}
+                cs={cs}
+                appearance={appearance}
+                highlightColor={isSelected ? "#cc4400" : undefined}
+                onClick={isTopStock ? drawCard : undefined}
+                onPointerDown={canInteract ? (e) => handleCardPointerDown(e, card.id) : undefined}
+              />
+            );
+          })}
+
+          {/* Stock click-catcher: transparent overlay above stock cards so taps work */}
+          <div
+            className="klondike__stock-hit"
+            style={{
+              left: COL_X[0] - CARD_W/2,
+              top: TOP_Y - CARD_H/2,
+              border: stockLeft === 0 ? "2px dashed rgba(255,255,255,0.25)" : "none",
+            }}
+            onClick={drawCard}
+          >
+            {stockLeft === 0 && <span className="klondike__slot-icon">↺</span>}
+          </div>
+
+          {/* Win overlay — inside stage so it's contained by isolation context */}
+          {phase === "game-over" && (
+            <div className="klondike__win-overlay">
+              <div className="klondike__win-banner">
+                <div className="klondike__win-title">You Win!</div>
+                <div className="klondike__win-stats">{moves} moves · {elapsed}s</div>
+                <button className="klondike__btn klondike__btn--primary" onClick={startGame}>Play Again</button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="klondike__statusbar">
@@ -699,16 +754,6 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
         <button className="klondike__btn klondike__btn--primary" onClick={startGame}>New Game</button>
         {onNewGame && <button className="klondike__btn klondike__btn--secondary" onClick={onNewGame}>Change Game</button>}
       </div>
-
-      {phase === "game-over" && (
-        <div className="klondike__win-overlay">
-          <div className="klondike__win-banner">
-            <div className="klondike__win-title">You Win!</div>
-            <div className="klondike__win-stats">{moves} moves · {elapsed}s</div>
-            <button className="klondike__btn klondike__btn--primary" onClick={startGame}>Play Again</button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -1,0 +1,901 @@
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import "./Cards.css";
+import "./Klondike.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, CardAppearance, DeckSettings, Suit } from "./types";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { DeckModal } from "./DeckModal";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"] as const;
+const SUITS_ALL: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+const FOUNDATION_SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+
+const RANK_VAL: Record<string, number> = {
+  A: 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7,
+  "8": 8, "9": 9, "10": 10, J: 11, Q: 12, K: 13,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildStandardDeck(): Card[] {
+  const cards: Card[] = [];
+  for (const suit of SUITS_ALL) {
+    for (const rank of RANKS) {
+      cards.push({ suit, rank, id: `${suit}-${rank}` });
+    }
+  }
+  // Fisher-Yates shuffle
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = cards[i];
+    cards[i] = cards[j];
+    cards[j] = tmp;
+  }
+  return cards;
+}
+
+function isRed(suit: Suit): boolean {
+  return suit === "hearts" || suit === "diamonds";
+}
+
+function canPlaceOnTableau(card: Card, topCard: Card | null): boolean {
+  if (card.suit === "joker") return false;
+  if (topCard === null) {
+    // Empty column: only King
+    return RANK_VAL[card.rank as string] === 13;
+  }
+  if (topCard.suit === "joker") return false;
+  const oppColor = isRed(card.suit as Suit) !== isRed(topCard.suit as Suit);
+  const oneBelow = RANK_VAL[card.rank as string] === RANK_VAL[topCard.rank as string] - 1;
+  return oppColor && oneBelow;
+}
+
+function canPlaceOnFoundation(card: Card, foundation: Card[]): boolean {
+  if (card.suit === "joker") return false;
+  if (foundation.length === 0) {
+    return RANK_VAL[card.rank as string] === 1;
+  }
+  const top = foundation[foundation.length - 1];
+  return (
+    top.suit === card.suit &&
+    RANK_VAL[card.rank as string] === RANK_VAL[top.rank as string] + 1
+  );
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface TableauColumn {
+  faceDown: Card[];
+  faceUp: Card[];
+}
+
+interface KlondikeSelection {
+  from: "tableau" | "waste" | "foundation";
+  colIndex: number;
+  cardIndex: number;
+}
+
+type GamePhase = "playing" | "won";
+
+interface KlondikeState {
+  tableau: TableauColumn[];
+  foundations: Card[][];
+  stock: Card[];
+  waste: Card[];
+  wasteIndex: number;
+  selected: KlondikeSelection | null;
+  moves: number;
+  startTime: number;
+  phase: GamePhase;
+}
+
+// ── Game setup ────────────────────────────────────────────────────────────────
+
+function makeInitialState(): KlondikeState {
+  const deck = buildStandardDeck();
+  const tableau: TableauColumn[] = [];
+
+  let idx = 0;
+  for (let col = 0; col < 7; col++) {
+    const numCards = col + 1;
+    const colCards = deck.slice(idx, idx + numCards);
+    idx += numCards;
+    tableau.push({
+      faceDown: colCards.slice(0, numCards - 1),
+      faceUp: [colCards[numCards - 1]],
+    });
+  }
+
+  const stock = deck.slice(idx); // remaining 24 cards
+
+  return {
+    tableau,
+    foundations: [[], [], [], []],
+    stock,
+    waste: [],
+    wasteIndex: -1,
+    selected: null,
+    moves: 0,
+    startTime: Date.now(),
+    phase: "playing",
+  };
+}
+
+// ── Move helpers ──────────────────────────────────────────────────────────────
+
+function getVisibleWasteCard(state: KlondikeState): Card | null {
+  if (state.wasteIndex < 0 || state.waste.length === 0) return null;
+  const idx = Math.min(state.wasteIndex, state.waste.length - 1);
+  return state.waste[idx];
+}
+
+function allFaceUp(tableau: TableauColumn[]): boolean {
+  return tableau.every((col) => col.faceDown.length === 0);
+}
+
+function checkWon(foundations: Card[][]): boolean {
+  return foundations.every((f) => f.length === 13);
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface KlondikeProps {
+  settings: DeckSettings;
+  onNewGame?: () => void;
+  onQuit?: () => void;
+}
+
+export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps) {
+  const [state, setState] = useState<KlondikeState>(() => makeInitialState());
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [showDeckModal, setShowDeckModal] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const autoCompleteRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ── Timer ──────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (state.phase === "won") return;
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - state.startTime) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [state.phase, state.startTime]);
+
+  // ── Auto-complete ──────────────────────────────────────────────────────────
+
+  const startAutoComplete = useCallback(() => {
+    if (autoCompleteRef.current) return;
+    autoCompleteRef.current = setInterval(() => {
+      setState((s) => {
+        if (s.phase === "won") {
+          if (autoCompleteRef.current) {
+            clearInterval(autoCompleteRef.current);
+            autoCompleteRef.current = null;
+          }
+          return s;
+        }
+
+        // Try to move any card to a foundation
+        const newFoundations = s.foundations.map((f) => [...f]);
+        const newTableau = s.tableau.map((col) => ({
+          faceDown: [...col.faceDown],
+          faceUp: [...col.faceUp],
+        }));
+        const newWaste = [...s.waste];
+        let moved = false;
+
+        // Try tableau cards
+        for (let ci = 0; ci < 7 && !moved; ci++) {
+          const col = newTableau[ci];
+          if (col.faceUp.length === 0) continue;
+          const card = col.faceUp[col.faceUp.length - 1];
+          for (let fi = 0; fi < 4 && !moved; fi++) {
+            if (canPlaceOnFoundation(card, newFoundations[fi])) {
+              newFoundations[fi] = [...newFoundations[fi], card];
+              col.faceUp = col.faceUp.slice(0, col.faceUp.length - 1);
+              // flip next face-down
+              if (col.faceUp.length === 0 && col.faceDown.length > 0) {
+                col.faceUp = [col.faceDown[col.faceDown.length - 1]];
+                col.faceDown = col.faceDown.slice(0, col.faceDown.length - 1);
+              }
+              moved = true;
+            }
+          }
+        }
+
+        // Try waste top
+        if (!moved && s.wasteIndex >= 0 && newWaste.length > 0) {
+          const wIdx = Math.min(s.wasteIndex, newWaste.length - 1);
+          const card = newWaste[wIdx];
+          for (let fi = 0; fi < 4 && !moved; fi++) {
+            if (canPlaceOnFoundation(card, newFoundations[fi])) {
+              newFoundations[fi] = [...newFoundations[fi], card];
+              newWaste.splice(wIdx, 1);
+              moved = true;
+            }
+          }
+        }
+
+        if (!moved) {
+          if (autoCompleteRef.current) {
+            clearInterval(autoCompleteRef.current);
+            autoCompleteRef.current = null;
+          }
+          return s;
+        }
+
+        const won = checkWon(newFoundations);
+        const newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
+        const newPhase: GamePhase = won ? "won" : s.phase;
+
+        return {
+          ...s,
+          tableau: newTableau,
+          foundations: newFoundations,
+          waste: newWaste,
+          wasteIndex: newWasteIndex,
+          moves: s.moves + 1,
+          phase: newPhase,
+          selected: null,
+        };
+      });
+    }, 150);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (autoCompleteRef.current) {
+        clearInterval(autoCompleteRef.current);
+        autoCompleteRef.current = null;
+      }
+    };
+  }, []);
+
+  // ── Restart ────────────────────────────────────────────────────────────────
+
+  const restart = useCallback(() => {
+    if (autoCompleteRef.current) {
+      clearInterval(autoCompleteRef.current);
+      autoCompleteRef.current = null;
+    }
+    setState(makeInitialState());
+    setElapsed(0);
+  }, []);
+
+  // ── Stock click ────────────────────────────────────────────────────────────
+
+  const handleStockClick = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+      const draw = settings.klondikeDraw;
+
+      if (s.stock.length === 0) {
+        // Reset: flip waste back to stock
+        if (s.waste.length === 0) return s;
+        return {
+          ...s,
+          stock: [...s.waste].reverse(),
+          waste: [],
+          wasteIndex: -1,
+          selected: null,
+          moves: s.moves + 1,
+        };
+      }
+
+      // Draw from stock to waste
+      const toDraw = Math.min(draw, s.stock.length);
+      const drawn = s.stock.slice(0, toDraw);
+      const newStock = s.stock.slice(toDraw);
+      const newWaste = [...s.waste, ...drawn];
+      const newWasteIndex = newWaste.length - 1;
+
+      return {
+        ...s,
+        stock: newStock,
+        waste: newWaste,
+        wasteIndex: newWasteIndex,
+        selected: null,
+        moves: s.moves + 1,
+      };
+    });
+  }, [settings.klondikeDraw]);
+
+  // ── Move logic ─────────────────────────────────────────────────────────────
+
+  const tryMoveToFoundation = useCallback(
+    (
+      from: KlondikeSelection["from"],
+      colIndex: number,
+      cardIndex: number,
+      s: KlondikeState
+    ): KlondikeState | null => {
+      let card: Card | null = null;
+
+      if (from === "tableau") {
+        const col = s.tableau[colIndex];
+        if (col.faceUp.length === 0) return null;
+        // Only move single card (top of the sequence) to foundation
+        if (cardIndex !== col.faceUp.length - 1) return null;
+        card = col.faceUp[col.faceUp.length - 1];
+      } else if (from === "waste") {
+        card = getVisibleWasteCard(s);
+      } else if (from === "foundation") {
+        if (s.foundations[colIndex].length === 0) return null;
+        card = s.foundations[colIndex][s.foundations[colIndex].length - 1];
+      }
+
+      if (!card) return null;
+
+      // Find a matching foundation (must be a different pile if source is foundation)
+      for (let fi = 0; fi < 4; fi++) {
+        // Can't move a foundation card onto the same foundation pile
+        if (from === "foundation" && fi === colIndex) continue;
+
+        if (canPlaceOnFoundation(card, s.foundations[fi])) {
+          // Build new foundations: add card to fi
+          const newFoundations = s.foundations.map((f, i) =>
+            i === fi ? [...f, card!] : [...f]
+          );
+
+          let newTableau = s.tableau;
+          let newWaste = s.waste;
+          let newWasteIndex = s.wasteIndex;
+
+          if (from === "tableau") {
+            newTableau = s.tableau.map((tCol, ci) => {
+              if (ci !== colIndex) return tCol;
+              const newFaceUp = tCol.faceUp.slice(0, tCol.faceUp.length - 1);
+              const newFaceDown = [...tCol.faceDown];
+              // Flip next card if face-up becomes empty
+              if (newFaceUp.length === 0 && newFaceDown.length > 0) {
+                newFaceUp.push(newFaceDown[newFaceDown.length - 1]);
+                newFaceDown.pop();
+              }
+              return { faceDown: newFaceDown, faceUp: newFaceUp };
+            });
+          } else if (from === "waste") {
+            const wIdx = Math.min(s.wasteIndex, s.waste.length - 1);
+            newWaste = [...s.waste];
+            newWaste.splice(wIdx, 1);
+            newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
+          } else if (from === "foundation") {
+            // Remove card from source foundation pile
+            newFoundations[colIndex] = newFoundations[colIndex].slice(
+              0,
+              newFoundations[colIndex].length - 1
+            );
+          }
+
+          const won = checkWon(newFoundations);
+          const newPhase: GamePhase = won ? "won" : s.phase;
+
+          return {
+            ...s,
+            tableau: newTableau,
+            foundations: newFoundations,
+            waste: newWaste,
+            wasteIndex: newWasteIndex,
+            selected: null,
+            moves: s.moves + 1,
+            phase: newPhase,
+          };
+        }
+      }
+
+      return null;
+    },
+    []
+  );
+
+  const tryMoveToTableau = useCallback(
+    (
+      sel: KlondikeSelection,
+      destCol: number,
+      s: KlondikeState
+    ): KlondikeState | null => {
+      // Get the sequence of cards to move
+      let cards: Card[] = [];
+
+      if (sel.from === "tableau") {
+        const col = s.tableau[sel.colIndex];
+        cards = col.faceUp.slice(sel.cardIndex);
+      } else if (sel.from === "waste") {
+        const wCard = getVisibleWasteCard(s);
+        if (!wCard) return null;
+        cards = [wCard];
+      } else if (sel.from === "foundation") {
+        const f = s.foundations[sel.colIndex];
+        if (f.length === 0) return null;
+        cards = [f[f.length - 1]];
+      }
+
+      if (cards.length === 0) return null;
+
+      // Can't move a column onto itself
+      if (sel.from === "tableau" && sel.colIndex === destCol) return null;
+
+      const destColData = s.tableau[destCol];
+      const topCard =
+        destColData.faceUp.length > 0
+          ? destColData.faceUp[destColData.faceUp.length - 1]
+          : null;
+
+      if (!canPlaceOnTableau(cards[0], topCard)) return null;
+
+      // Build new state
+      let newTableau = s.tableau.map((col) => ({
+        faceDown: [...col.faceDown],
+        faceUp: [...col.faceUp],
+      }));
+      let newWaste = [...s.waste];
+      let newWasteIndex = s.wasteIndex;
+      let newFoundations = s.foundations.map((f) => [...f]);
+
+      // Remove from source
+      if (sel.from === "tableau") {
+        const srcCol = newTableau[sel.colIndex];
+        srcCol.faceUp = srcCol.faceUp.slice(0, sel.cardIndex);
+        // Flip next face-down if needed
+        if (srcCol.faceUp.length === 0 && srcCol.faceDown.length > 0) {
+          srcCol.faceUp = [srcCol.faceDown[srcCol.faceDown.length - 1]];
+          srcCol.faceDown = srcCol.faceDown.slice(0, srcCol.faceDown.length - 1);
+        }
+      } else if (sel.from === "waste") {
+        const wIdx = Math.min(s.wasteIndex, s.waste.length - 1);
+        newWaste.splice(wIdx, 1);
+        newWasteIndex = Math.min(s.wasteIndex, newWaste.length - 1);
+      } else if (sel.from === "foundation") {
+        newFoundations[sel.colIndex] = newFoundations[sel.colIndex].slice(
+          0,
+          newFoundations[sel.colIndex].length - 1
+        );
+      }
+
+      // Add to destination
+      newTableau[destCol].faceUp = [...newTableau[destCol].faceUp, ...cards];
+
+      return {
+        ...s,
+        tableau: newTableau,
+        foundations: newFoundations,
+        waste: newWaste,
+        wasteIndex: newWasteIndex,
+        selected: null,
+        moves: s.moves + 1,
+      };
+    },
+    []
+  );
+
+  // ── Click handlers ─────────────────────────────────────────────────────────
+
+  const handleWasteClick = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+      const card = getVisibleWasteCard(s);
+      if (!card) return { ...s, selected: null };
+
+      // If already selected from waste → deselect
+      if (s.selected?.from === "waste") {
+        return { ...s, selected: null };
+      }
+
+      // If something is selected, try move to... waste? That's not valid. Change selection.
+      if (s.selected) {
+        // Can't move to waste, so select waste card instead
+        return {
+          ...s,
+          selected: { from: "waste", colIndex: 0, cardIndex: 0 },
+        };
+      }
+
+      // Select the waste top
+      return {
+        ...s,
+        selected: { from: "waste", colIndex: 0, cardIndex: 0 },
+      };
+    });
+  }, []);
+
+  const handleFoundationClick = useCallback(
+    (fi: number) => {
+      setState((s) => {
+        if (s.phase !== "playing") return s;
+
+        // If something is selected, try moving it to foundation
+        if (s.selected) {
+          // Don't move from same foundation to same foundation
+          if (s.selected.from === "foundation" && s.selected.colIndex === fi) {
+            return { ...s, selected: null };
+          }
+
+          const moved = tryMoveToFoundation(
+            s.selected.from,
+            s.selected.colIndex,
+            s.selected.cardIndex,
+            s
+          );
+          if (moved) return moved;
+
+          // If selection is a foundation card, switch selection
+          const fTop = s.foundations[fi];
+          if (fTop.length > 0) {
+            return { ...s, selected: { from: "foundation", colIndex: fi, cardIndex: 0 } };
+          }
+
+          return { ...s, selected: null };
+        }
+
+        // Select top of foundation
+        if (s.foundations[fi].length > 0) {
+          return {
+            ...s,
+            selected: { from: "foundation", colIndex: fi, cardIndex: 0 },
+          };
+        }
+
+        return s;
+      });
+    },
+    [tryMoveToFoundation]
+  );
+
+  const handleTableauCardClick = useCallback(
+    (colIndex: number, cardIndex: number) => {
+      setState((s) => {
+        if (s.phase !== "playing") return s;
+        const col = s.tableau[colIndex];
+        const card = col.faceUp[cardIndex];
+        if (!card) return s;
+
+        // If clicking the same card, deselect
+        if (
+          s.selected?.from === "tableau" &&
+          s.selected.colIndex === colIndex &&
+          s.selected.cardIndex === cardIndex
+        ) {
+          return { ...s, selected: null };
+        }
+
+        // If something is selected, try moving to this column
+        if (s.selected) {
+          const moved = tryMoveToTableau(s.selected, colIndex, s);
+          if (moved) return moved;
+
+          // Try double-click-style: if single card and can go to foundation
+          // But user clicked a tableau card, not a foundation — try to move selection to foundation
+          // first try to move clicked card to foundation if it's the selection target
+          // Actually: if move fails, change selection to the clicked card
+          return {
+            ...s,
+            selected: { from: "tableau", colIndex, cardIndex },
+          };
+        }
+
+        // No selection — select this card
+        return {
+          ...s,
+          selected: { from: "tableau", colIndex, cardIndex },
+        };
+      });
+    },
+    [tryMoveToTableau]
+  );
+
+  const handleTableauEmptyClick = useCallback(
+    (colIndex: number) => {
+      setState((s) => {
+        if (s.phase !== "playing") return s;
+        if (!s.selected) return s;
+
+        const moved = tryMoveToTableau(s.selected, colIndex, s);
+        if (moved) return moved;
+
+        return { ...s, selected: null };
+      });
+    },
+    [tryMoveToTableau]
+  );
+
+  // Double-click: auto-move to foundation
+  const handleTableauCardDblClick = useCallback(
+    (colIndex: number, cardIndex: number) => {
+      setState((s) => {
+        if (s.phase !== "playing") return s;
+        const col = s.tableau[colIndex];
+        if (cardIndex !== col.faceUp.length - 1) return s; // only top card
+        const moved = tryMoveToFoundation("tableau", colIndex, cardIndex, s);
+        return moved ?? s;
+      });
+    },
+    [tryMoveToFoundation]
+  );
+
+  const handleWasteDblClick = useCallback(() => {
+    setState((s) => {
+      if (s.phase !== "playing") return s;
+      const moved = tryMoveToFoundation("waste", 0, 0, s);
+      return moved ?? s;
+    });
+  }, [tryMoveToFoundation]);
+
+  // ── Valid destination highlighting ─────────────────────────────────────────
+
+  const validTableauDests = useMemo<boolean[]>(() => {
+    if (!state.selected) return Array(7).fill(false);
+    return state.tableau.map((col, ci) => {
+      // Don't highlight source column
+      if (state.selected!.from === "tableau" && state.selected!.colIndex === ci) return false;
+
+      let cards: Card[] = [];
+      if (state.selected!.from === "tableau") {
+        cards = state.tableau[state.selected!.colIndex].faceUp.slice(state.selected!.cardIndex);
+      } else if (state.selected!.from === "waste") {
+        const wc = getVisibleWasteCard(state);
+        if (wc) cards = [wc];
+      } else if (state.selected!.from === "foundation") {
+        const f = state.foundations[state.selected!.colIndex];
+        if (f.length > 0) cards = [f[f.length - 1]];
+      }
+
+      if (cards.length === 0) return false;
+      const topCard =
+        col.faceUp.length > 0 ? col.faceUp[col.faceUp.length - 1] : null;
+      return canPlaceOnTableau(cards[0], topCard);
+    });
+  }, [state]);
+
+  // ── Menus ──────────────────────────────────────────────────────────────────
+
+  const menus = useMemo<MenuBarMenu[]>(() => {
+    const gameItems: MenuBarMenu["items"] = [
+      { label: "Restart", onClick: restart },
+      ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
+      ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+    ];
+    return [
+      { label: "Game", items: gameItems },
+      {
+        label: "Options",
+        items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }],
+      },
+    ];
+  }, [restart, onNewGame, onQuit]);
+
+  useWindowMenus(menus);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const { tableau, foundations, stock, waste, wasteIndex, selected, moves, phase } = state;
+  const wasteTopCard = getVisibleWasteCard(state);
+  const canAutoComplete = allFaceUp(tableau) && phase === "playing";
+  const autoRunning = autoCompleteRef.current !== null;
+
+  const SUIT_SYMBOLS: Record<Suit, string> = {
+    spades: "♠",
+    hearts: "♥",
+    diamonds: "♦",
+    clubs: "♣",
+  };
+
+  return (
+    <div className="klondike">
+      {showDeckModal && (
+        <DeckModal
+          appearance={appearance}
+          onUpdate={setAppearance}
+          onClose={() => setShowDeckModal(false)}
+        />
+      )}
+
+      {/* Top area: foundations + stock/waste */}
+      <div className="klondike__top-row">
+        {/* Foundations */}
+        <div className="klondike__foundations">
+          {FOUNDATION_SUITS.map((suit, fi) => {
+            const fPile = foundations[fi];
+            const fTop = fPile.length > 0 ? fPile[fPile.length - 1] : null;
+            const isSelected =
+              selected?.from === "foundation" && selected.colIndex === fi;
+            return (
+              <div
+                key={suit}
+                className={
+                  "klondike__foundation-slot" +
+                  (isSelected ? " klondike__foundation-slot--selected" : "")
+                }
+                onClick={() => handleFoundationClick(fi)}
+                title={`${suit} foundation`}
+              >
+                {fTop ? (
+                  <PlayingCard card={fTop} appearance={appearance} size="sm" />
+                ) : (
+                  <div className="klondike__empty-slot klondike__empty-slot--suit">
+                    <span className="klondike__suit-hint">{SUIT_SYMBOLS[suit]}</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Spacer */}
+        <div className="klondike__top-spacer" />
+
+        {/* Stock + Waste */}
+        <div className="klondike__stock-area">
+          {/* Waste */}
+          <div
+            className={
+              "klondike__waste-slot" +
+              (selected?.from === "waste" ? " klondike__waste-slot--selected" : "")
+            }
+            onClick={handleWasteClick}
+            onDoubleClick={handleWasteDblClick}
+          >
+            {wasteTopCard ? (
+              <>
+                {/* Show peeks of cards behind in draw-3 mode (back=furthest left, mid=closer) */}
+                {settings.klondikeDraw === 3 && wasteIndex >= 2 && waste[wasteIndex - 2] && (
+                  <div className="klondike__waste-peek klondike__waste-peek--back">
+                    <PlayingCard
+                      card={waste[wasteIndex - 2]}
+                      appearance={appearance}
+                      size="sm"
+                    />
+                  </div>
+                )}
+                {settings.klondikeDraw === 3 && wasteIndex >= 1 && waste[wasteIndex - 1] && (
+                  <div className="klondike__waste-peek klondike__waste-peek--mid">
+                    <PlayingCard
+                      card={waste[wasteIndex - 1]}
+                      appearance={appearance}
+                      size="sm"
+                    />
+                  </div>
+                )}
+                <div className="klondike__waste-top">
+                  <PlayingCard card={wasteTopCard} appearance={appearance} size="sm" />
+                </div>
+              </>
+            ) : (
+              <div className="klondike__empty-slot" />
+            )}
+          </div>
+
+          {/* Stock */}
+          <div
+            className="klondike__stock-slot"
+            onClick={handleStockClick}
+            title={stock.length > 0 ? `Stock: ${stock.length} cards` : "Click to reset"}
+          >
+            {stock.length > 0 ? (
+              <PlayingCard
+                card={stock[0]}
+                faceDown
+                appearance={appearance}
+                size="sm"
+              />
+            ) : (
+              <div className="klondike__empty-slot klondike__stock-reset">
+                <span className="klondike__reset-icon">↺</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Tableau */}
+      <div className="klondike__tableau">
+        {tableau.map((col, ci) => {
+          const isValidDest = validTableauDests[ci];
+          const totalCards = col.faceDown.length + col.faceUp.length;
+          // Height: face-down slivers (18px each) + face-up slivers (26px each) + last card full height (72px)
+          const colHeight = totalCards === 0
+            ? 72
+            : col.faceDown.length * 18 +
+              (col.faceUp.length > 1 ? (col.faceUp.length - 1) * 26 : 0) +
+              72;
+
+          return (
+            <div
+              key={ci}
+              className={
+                "klondike__column" +
+                (isValidDest ? " klondike__column--valid-dest" : "")
+              }
+              style={{ height: colHeight }}
+              onClick={totalCards === 0 ? () => handleTableauEmptyClick(ci) : undefined}
+            >
+              {/* Face-down cards */}
+              {col.faceDown.map((card, di) => (
+                <div
+                  key={card.id}
+                  className="klondike__facedown-card"
+                  style={{ top: di * 18 }}
+                >
+                  <PlayingCard card={card} faceDown appearance={appearance} size="sm" />
+                </div>
+              ))}
+
+              {/* Face-up cards */}
+              {col.faceUp.map((card, ui) => {
+                const topOffset = col.faceDown.length * 18;
+                const isSelected =
+                  selected?.from === "tableau" &&
+                  selected.colIndex === ci &&
+                  selected.cardIndex <= ui;
+                const isSelectionStart =
+                  selected?.from === "tableau" &&
+                  selected.colIndex === ci &&
+                  selected.cardIndex === ui;
+                return (
+                  <div
+                    key={card.id}
+                    className={
+                      "klondike__faceup-card" +
+                      (isSelected ? " klondike__faceup-card--selected" : "") +
+                      (isSelectionStart ? " klondike__faceup-card--selection-start" : "")
+                    }
+                    style={{ top: topOffset + ui * 26 }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleTableauCardClick(ci, ui);
+                    }}
+                    onDoubleClick={(e) => {
+                      e.stopPropagation();
+                      handleTableauCardDblClick(ci, ui);
+                    }}
+                  >
+                    <PlayingCard card={card} appearance={appearance} size="sm" />
+                  </div>
+                );
+              })}
+
+              {/* Empty column placeholder */}
+              {totalCards === 0 && (
+                <div className="klondike__empty-slot" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Status bar */}
+      <div className="klondike__statusbar">
+        <span>Moves: {moves}</span>
+        <span>Time: {elapsed}s</span>
+        <span>Draw: {settings.klondikeDraw}</span>
+        {canAutoComplete && !autoRunning && (
+          <button className="klondike__autocomplete-btn" onClick={startAutoComplete}>
+            Auto-Complete
+          </button>
+        )}
+      </div>
+
+      {/* Win overlay */}
+      {phase === "won" && (
+        <div className="klondike__win-overlay">
+          <div className="klondike__win-banner">
+            <div className="klondike__win-title">YOU WIN!</div>
+            <div className="klondike__win-stats">
+              {moves} moves &bull; {elapsed}s
+            </div>
+            <button className="klondike__win-btn" onClick={restart}>
+              Play Again
+            </button>
+            {onNewGame && (
+              <button className="klondike__win-btn klondike__win-btn--secondary" onClick={onNewGame}>
+                New Game
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -41,11 +41,10 @@ function isRed(suit: Suit): boolean {
   return suit === "hearts" || suit === "diamonds";
 }
 
-function canPlaceOnTableau(card: Card, topCard: Card | null): boolean {
+function canPlaceOnTableau(card: Card, topCard: Card | null, relaxed = false): boolean {
   if (card.suit === "joker") return false;
   if (topCard === null) {
-    // Empty column: only King
-    return RANK_VAL[card.rank as string] === 13;
+    return relaxed || RANK_VAL[card.rank as string] === 13;
   }
   if (topCard.suit === "joker") return false;
   const oppColor = isRed(card.suit as Suit) !== isRed(topCard.suit as Suit);
@@ -424,7 +423,7 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
           ? destColData.faceUp[destColData.faceUp.length - 1]
           : null;
 
-      if (!canPlaceOnTableau(cards[0], topCard)) return null;
+      if (!canPlaceOnTableau(cards[0], topCard, settings.klondikeRelaxed)) return null;
 
       // Build new state
       let newTableau = s.tableau.map((col) => ({
@@ -468,7 +467,7 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
         moves: s.moves + 1,
       };
     },
-    []
+    [settings.klondikeRelaxed]
   );
 
   // ── Click handlers ─────────────────────────────────────────────────────────
@@ -645,9 +644,9 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
       if (cards.length === 0) return false;
       const topCard =
         col.faceUp.length > 0 ? col.faceUp[col.faceUp.length - 1] : null;
-      return canPlaceOnTableau(cards[0], topCard);
+      return canPlaceOnTableau(cards[0], topCard, settings.klondikeRelaxed);
     });
-  }, [state]);
+  }, [state, settings.klondikeRelaxed]);
 
   // ── Menus ──────────────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -759,7 +759,7 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
                   </div>
                 )}
                 <div className="klondike__waste-top">
-                  <PlayingCard card={wasteTopCard} appearance={appearance} size="sm" />
+                  <PlayingCard key={wasteTopCard.id} card={wasteTopCard} appearance={appearance} size="sm" dealIndex={0} />
                 </div>
               </>
             ) : (

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -267,8 +267,39 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
 
     setStockLeft(stockStack.current.size);
     setAllCards(allC);
-    setCardStates(allLayouts(0));
-    setPhase("idle");
+
+    // Deal animation: all cards start at stock position, then fan out
+    const initStates: Record<string, CardVisualState> = {};
+    for (const c of allC) {
+      initStates[c.id] = { x: COL_X[0], y: TOP_Y, z: 100, rotation: 0, faceDown: true, transitionMs: 0 };
+    }
+    setCardStates(initStates);
+    setPhase("shuffle");
+
+    const DEAL_MS = 250;
+    const finalLayout = allLayouts(DEAL_MS);
+    let di = 0;
+    for (let col = 0; col < 7; col++) {
+      for (const c of tableau.current[col].cards) {
+        if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: di++ * 28 };
+      }
+    }
+    for (const c of wasteStack.current.cards) {
+      if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: di++ * 14 };
+    }
+    for (let f = 0; f < 4; f++) {
+      for (const c of foundations.current[f].cards) {
+        if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: di++ * 14 };
+      }
+    }
+    for (const c of stockStack.current.cards) {
+      if (finalLayout[c.id]) finalLayout[c.id] = { ...finalLayout[c.id], transitionDelay: di++ * 6 };
+    }
+
+    after(60, () => {
+      setCardStates(finalLayout);
+      after(DEAL_MS + di * 28 + 200, () => { setCardStates(allLayouts(0)); setPhase("idle"); });
+    });
   }
 
   // ── startGame ──────────────────────────────────────────────────────────────

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./Klondike.css";
 import { PermCard } from "./PermCard";
@@ -28,6 +28,27 @@ const COL_X: number[] = (() => {
 })();
 
 const Z_DRAG = 9000;
+const KLONDIKE_SAVE_KEY = "cards-klondike-save";
+
+// ── Persistence helpers ───────────────────────────────────────────────────────
+
+interface SnapshotEntry { id: string; suit: string; rank: string; faceDown: boolean; }
+interface KlondikeSnapshot {
+  version: number;
+  moves: number;
+  tableau: SnapshotEntry[][];
+  foundations: SnapshotEntry[][];
+  stock: SnapshotEntry[];
+  waste: SnapshotEntry[];
+}
+
+function snapshotStack(stack: CardStack): SnapshotEntry[] {
+  const lays = stack.layout(0);
+  return stack.cards.map(c => ({
+    id: c.id, suit: c.suit as string, rank: c.rank as string,
+    faceDown: lays[c.id]?.faceDown ?? false,
+  }));
+}
 
 // ── Game logic helpers ────────────────────────────────────────────────────────
 
@@ -190,6 +211,66 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
     return result;
   }
 
+  // ── restoreKlondike ────────────────────────────────────────────────────────
+
+  function restoreKlondike(snap: KlondikeSnapshot): void {
+    clearTimers();
+    stopTimer();
+    setElapsed(0);
+    startTimeRef.current = null;
+    setSelectedRun([]);
+    setMoves(snap.moves ?? 0);
+    setAutoComplete(false);
+
+    const seen = new Set<string>();
+    const allC: Card[] = [];
+    const collect = (entries: SnapshotEntry[]) => {
+      for (const e of entries) {
+        if (!seen.has(e.id)) {
+          seen.add(e.id);
+          allC.push({ id: e.id, suit: e.suit as Suit, rank: e.rank as Rank });
+        }
+      }
+    };
+    snap.tableau.forEach(col => collect(col));
+    collect(snap.stock);
+    collect(snap.waste);
+    snap.foundations.forEach(f => collect(f));
+
+    const byId = new Map(allC.map(c => [c.id, c]));
+
+    for (const t of tableau.current)     t.clear();
+    for (const f of foundations.current) f.clear();
+    stockStack.current.clear();
+    wasteStack.current.clear();
+
+    snap.tableau.forEach((col, i) => {
+      for (const e of col) {
+        const c = byId.get(e.id); if (!c) continue;
+        tableau.current[i].addCard(c, { toTop: true, faceDown: e.faceDown });
+      }
+    });
+    snap.foundations.forEach((fi, i) => {
+      for (const e of fi) {
+        const c = byId.get(e.id); if (!c) continue;
+        foundations.current[i].addCard(c, { toTop: true, faceDown: false });
+      }
+    });
+    for (const e of snap.stock) {
+      const c = byId.get(e.id); if (!c) continue;
+      stockStack.current.addCard(c, { toTop: true, faceDown: true });
+    }
+    for (const e of snap.waste) {
+      const c = byId.get(e.id); if (!c) continue;
+      wasteStack.current.addCard(c, { toTop: true, faceDown: false });
+    }
+
+    setStockLeft(stockStack.current.size);
+    setAllCards(allC);
+    setCardStates(allLayouts(0));
+    setPhase("idle");
+  }
+
   // ── startGame ──────────────────────────────────────────────────────────────
 
   const startGame = useCallback(() => {
@@ -201,6 +282,7 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
     setMoves(0);
     setAutoComplete(false);
     setPhase("shuffle");
+    try { localStorage.removeItem(KLONDIKE_SAVE_KEY); } catch {}
 
     const deck = shuffle(buildDeck({
       ...settings,
@@ -307,7 +389,32 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings]);
 
+  // Save game state after every move
   useEffect(() => {
+    if (allCards.length === 0 || phase === "shuffle") return;
+    try {
+      const snap: KlondikeSnapshot = {
+        version: 1, moves,
+        tableau: tableau.current.map(snapshotStack),
+        foundations: foundations.current.map(snapshotStack),
+        stock: snapshotStack(stockStack.current),
+        waste: snapshotStack(wasteStack.current),
+      };
+      localStorage.setItem(KLONDIKE_SAVE_KEY, JSON.stringify(snap));
+    } catch {}
+  }, [moves, phase, allCards.length]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(KLONDIKE_SAVE_KEY);
+      if (raw) {
+        const snap = JSON.parse(raw) as KlondikeSnapshot;
+        if (snap.version === 1 && Array.isArray(snap.tableau)) {
+          restoreKlondike(snap);
+          return clearTimers;
+        }
+      }
+    } catch {}
     startGame();
     return clearTimers;
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/experiences/Cards/Klondike.tsx
+++ b/src/experiences/Cards/Klondike.tsx
@@ -740,6 +740,23 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allCards, cardStates, selectedRun, relaxed]);
 
+  // Double-click: auto-send top card to foundation
+  const handleCardDoubleClick = useCallback((cardId: string) => {
+    if (phase !== "idle") return;
+    const stackId = findStack(cardId);
+    if (!stackId) return;
+    if (stackById(stackId).top?.id !== cardId) return;
+    const card = allCards.find(c => c.id === cardId);
+    if (!card) return;
+    for (let fi = 0; fi < 4; fi++) {
+      if (canPlaceOnFoundation(card, foundations.current[fi].top)) {
+        executeMove([card], stackId, `found-${fi}`);
+        return;
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, allCards]);
+
   // 2-click: click a foundation slot directly
   const handleFoundationClick = useCallback((foundIdx: number) => {
     if (phase !== "idle" || selectedRun.length === 0) return;
@@ -845,6 +862,7 @@ export default function Klondike({ settings, onNewGame, onQuit }: KlondikeProps)
                 appearance={appearance}
                 highlightColor={isSelected ? "#cc4400" : undefined}
                 onClick={isTopStock ? drawCard : undefined}
+                onDoubleClick={canInteract && !isTopStock ? () => handleCardDoubleClick(card.id) : undefined}
                 onPointerDown={canInteract ? (e) => handleCardPointerDown(e, card.id) : undefined}
               />
             );

--- a/src/experiences/Cards/Memory.css
+++ b/src/experiences/Cards/Memory.css
@@ -1,0 +1,158 @@
+/* ─── Memory / Concentration ────────────────────────────────────────── */
+
+@keyframes memory-match-flash {
+  0%   { outline-color: #44cc44; box-shadow: 0 0 8px 2px rgba(68, 204, 68, 0.6); }
+  60%  { outline-color: #44cc44; box-shadow: 0 0 14px 4px rgba(68, 204, 68, 0.4); }
+  100% { outline-color: transparent; box-shadow: none; }
+}
+
+.memory {
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  user-select: none;
+}
+
+/* Info bar (difficulty label) */
+.memory__infobar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 10px 3px;
+  font-size: 7px;
+  color: #444;
+  border-bottom: 1px solid #808080;
+}
+
+/* Green felt table */
+.memory__table {
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  margin: 8px 8px 4px;
+  padding: 10px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Card grid */
+.memory__grid {
+  display: grid;
+  gap: 6px;
+  /* gridTemplateColumns set inline via style prop */
+}
+
+/* Individual card slot */
+.memory__card-wrap {
+  cursor: pointer;
+  border-radius: 4px;
+  transition: transform 0.12s ease;
+  position: relative;
+}
+
+.memory__card-wrap:hover.memory__card-wrap--facedown {
+  transform: translateY(-2px);
+}
+
+/* Selected (face-up, not yet matched): orange highlight */
+.memory__card-wrap--selected .playing-card {
+  outline: 2px solid #cc4400;
+  outline-offset: 1px;
+}
+
+/* Matched + flashing: green highlight */
+.memory__card-wrap--matched-flash .playing-card {
+  outline: 2px solid #44cc44;
+  outline-offset: 1px;
+  animation: memory-match-flash 0.9s ease forwards;
+}
+
+/* Matched (flash done): no highlight, slightly dimmed */
+.memory__card-wrap--matched {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.memory__card-wrap--matched .playing-card {
+  outline: none;
+}
+
+/* Face-down card: pointer cursor */
+.memory__card-wrap--facedown {
+  cursor: pointer;
+}
+
+/* Win banner — overlaid inside the table */
+.memory__win-banner {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.memory__win-title {
+  font-size: 14px;
+  color: #44cc44;
+  letter-spacing: 2px;
+  text-shadow: 0 0 8px rgba(68, 204, 68, 0.7);
+}
+
+.memory__win-stats {
+  font-size: 8px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* Status bar */
+.memory__statusbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 7px;
+  color: #333;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  background: #c0c0c0;
+}
+
+/* Controls row */
+.memory__controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 10px;
+}
+
+/* Buttons */
+.memory__btn {
+  font-family: "Press Start 2P", monospace;
+  font-size: 8px;
+  padding: 6px 12px;
+  border: 2px solid;
+  cursor: pointer;
+}
+
+.memory__btn--primary {
+  background: #cc4400;
+  color: #fff;
+  border-color: #ffcc88 #664400 #664400 #ffcc88;
+}
+.memory__btn--primary:hover  { background: #ee5500; }
+.memory__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+
+.memory__btn--secondary {
+  background: #c0c0c0;
+  color: #000;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+.memory__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }

--- a/src/experiences/Cards/Memory.css
+++ b/src/experiences/Cards/Memory.css
@@ -1,11 +1,5 @@
 /* ─── Memory / Concentration ────────────────────────────────────────── */
 
-@keyframes memory-match-flash {
-  0%   { outline-color: #44cc44; box-shadow: 0 0 8px 2px rgba(68, 204, 68, 0.6); }
-  60%  { outline-color: #44cc44; box-shadow: 0 0 14px 4px rgba(68, 204, 68, 0.4); }
-  100% { outline-color: transparent; box-shadow: none; }
-}
-
 .memory {
   display: flex;
   flex-direction: column;
@@ -15,7 +9,6 @@
   user-select: none;
 }
 
-/* Info bar (difficulty label) */
 .memory__infobar {
   display: flex;
   justify-content: center;
@@ -26,71 +19,20 @@
   border-bottom: 1px solid #808080;
 }
 
-/* Green felt table */
-.memory__table {
+.memory__stage {
   background: #1a4a1a;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   margin: 8px 8px 4px;
-  padding: 10px;
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
-/* Card grid */
-.memory__grid {
-  display: grid;
-  gap: 6px;
-  /* gridTemplateColumns set inline via style prop */
-}
-
-/* Individual card slot */
-.memory__card-wrap {
-  cursor: pointer;
-  border-radius: 4px;
-  transition: transform 0.12s ease;
-  position: relative;
-}
-
-.memory__card-wrap:hover.memory__card-wrap--facedown {
-  transform: translateY(-2px);
-}
-
-/* Selected (face-up, not yet matched): orange highlight */
-.memory__card-wrap--selected .playing-card {
-  outline: 2px solid #cc4400;
-  outline-offset: 1px;
-}
-
-/* Matched + flashing: green highlight */
-.memory__card-wrap--matched-flash .playing-card {
-  outline: 2px solid #44cc44;
-  outline-offset: 1px;
-  animation: memory-match-flash 0.9s ease forwards;
-}
-
-/* Matched (flash done): no highlight, slightly dimmed */
-.memory__card-wrap--matched {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.memory__card-wrap--matched .playing-card {
-  outline: none;
-}
-
-/* Face-down card: pointer cursor */
-.memory__card-wrap--facedown {
-  cursor: pointer;
-}
-
-/* Win banner — overlaid inside the table */
 .memory__win-banner {
   position: absolute;
   inset: 0;
-  z-index: 10;
+  z-index: 1000;
   background: rgba(0, 0, 0, 0.72);
   display: flex;
   flex-direction: column;
@@ -111,7 +53,6 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
-/* Status bar */
 .memory__statusbar {
   display: flex;
   justify-content: space-between;
@@ -124,7 +65,6 @@
   background: #c0c0c0;
 }
 
-/* Controls row */
 .memory__controls {
   display: flex;
   justify-content: center;
@@ -133,7 +73,6 @@
   padding: 8px 10px 10px;
 }
 
-/* Buttons */
 .memory__btn {
   font-family: "Press Start 2P", monospace;
   font-size: 8px;

--- a/src/experiences/Cards/Memory.css
+++ b/src/experiences/Cards/Memory.css
@@ -19,14 +19,19 @@
   border-bottom: 1px solid #808080;
 }
 
+.memory__stage-container {
+  margin: 8px 8px 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
 .memory__stage {
   background: #1a4a1a;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
-  margin: 8px 8px 4px;
+  box-sizing: border-box;
   position: relative;
   overflow: hidden;
-  flex-shrink: 0;
 }
 
 .memory__win-banner {

--- a/src/experiences/Cards/Memory.tsx
+++ b/src/experiences/Cards/Memory.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import "./Cards.css";
 import "./Memory.css";
-import { PlayingCard } from "./PlayingCard";
+import { FlippableCard } from "./FlippableCard";
 import type { CardAppearance, DeckSettings } from "./types";
 import type { Card, Rank, Suit } from "./types";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
@@ -341,7 +341,7 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
                 className={cls}
                 onClick={() => handleCardClick(idx)}
               >
-                <PlayingCard
+                <FlippableCard
                   card={mc.card}
                   faceDown={!mc.faceUp}
                   appearance={appearance}

--- a/src/experiences/Cards/Memory.tsx
+++ b/src/experiences/Cards/Memory.tsx
@@ -154,6 +154,9 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
     offsetY: -0.3,
   }));
 
+  const [scale, setScale] = useState(1);
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const clearTimers = useCallback(() => {
     timers.current.forEach(clearTimeout);
@@ -193,6 +196,7 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
   const startGame = useCallback(() => {
     clearTimers();
     stopTimer();
+    try { localStorage.removeItem("cards-memory-save"); } catch {};
     setElapsed(0);
     startTimeRef.current = null;
     setSelectedIds([]);
@@ -365,9 +369,72 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
   }, [allCards, difficulty]);
 
   useEffect(() => {
+    const MEM_SAVE_KEY = "cards-memory-save";
+    try {
+      const raw = localStorage.getItem(MEM_SAVE_KEY);
+      if (raw) {
+        const saved = JSON.parse(raw) as {
+          version: number; allCards: MemCardData[]; scoredIds: string[];
+          attempts: number; pairsFound: number; elapsed: number;
+        };
+        if (saved?.version === 1 && Array.isArray(saved.allCards) && saved.allCards.length > 0) {
+          const scoredSet = new Set<string>(saved.scoredIds ?? []);
+          scoredStack.current.clear();
+          const initStates: Record<string, CardVisualState> = {};
+          saved.allCards.forEach((mc, idx) => {
+            const pos = gridPos(idx, difficulty);
+            if (scoredSet.has(mc.card.id)) {
+              scoredStack.current.addCard(mc.card, { toTop: true, faceDown: false });
+            } else {
+              initStates[mc.card.id] = { x: pos.x, y: pos.y, z: 200 + idx, rotation: 0, faceDown: true, transitionMs: 0 };
+            }
+          });
+          Object.assign(initStates, scoredStack.current.layout(0));
+          setAllCards(saved.allCards);
+          setCardStates(initStates);
+          setScoredIds(scoredSet);
+          setAttempts(saved.attempts ?? 0);
+          setPairsFound(saved.pairsFound ?? 0);
+          setElapsed(saved.elapsed ?? 0);
+          setSelectedIds([]);
+          setPhase("idle");
+          return clearTimers;
+        }
+      }
+    } catch {}
     startGame();
     return clearTimers;
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const MEM_SAVE_KEY = "cards-memory-save";
+    if (allCards.length === 0 || phase === "shuffle") return;
+    if (phase === "game-over") {
+      try { localStorage.removeItem(MEM_SAVE_KEY); } catch {}
+      return;
+    }
+    try {
+      localStorage.setItem(MEM_SAVE_KEY, JSON.stringify({
+        version: 1,
+        allCards,
+        scoredIds: [...scoredIds],
+        attempts,
+        pairsFound,
+        elapsed,
+      }));
+    } catch {}
+  }, [allCards, scoredIds, attempts, pairsFound, elapsed, phase]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
   }, []);
 
   // ── Card click ────────────────────────────────────────────────────────────
@@ -502,7 +569,8 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
         <span>{difficultyLabel()}</span>
       </div>
 
-      <div className="memory__stage" style={{ width: STAGE_W, height: sh }}>
+      <div className="memory__stage-container" ref={containerRef} style={{ height: Math.round(sh * scale) }}>
+      <div className="memory__stage" style={{ width: STAGE_W, height: sh, transform: scale < 1 ? `scale(${scale})` : undefined, transformOrigin: "top left" }}>
         {phase === "game-over" && (
           <div className="memory__win-banner">
             <div className="memory__win-title">You Won!</div>
@@ -537,6 +605,7 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
             />
           );
         })}
+      </div>
       </div>
 
       <div className="memory__statusbar">

--- a/src/experiences/Cards/Memory.tsx
+++ b/src/experiences/Cards/Memory.tsx
@@ -1,0 +1,377 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import "./Cards.css";
+import "./Memory.css";
+import { PlayingCard } from "./PlayingCard";
+import type { CardAppearance, DeckSettings } from "./types";
+import type { Card, Rank, Suit } from "./types";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { DeckModal } from "./DeckModal";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Phase = "idle" | "one-up" | "checking" | "won";
+
+interface MemoryCard {
+  card: Card;
+  pairId: string;
+  faceUp: boolean;
+  matched: boolean;
+  flashMatch: boolean;  // brief green highlight after match
+}
+
+interface MemoryState {
+  grid: MemoryCard[];
+  phase: Phase;
+  firstIdx: number | null;
+  attempts: number;
+  pairsLeft: number;
+}
+
+// ── Board builders ────────────────────────────────────────────────────────────
+
+const RANKS: Rank[] = ["A","2","3","4","5","6","7","8","9","10","J","Q","K"];
+
+/**
+ * Build the shuffled memory grid for a given difficulty.
+ *
+ * Easy   4×4 = 16 cards = 8 pairs:  ranks A–8, ♠+♥
+ * Medium 4×6 = 24 cards = 12 pairs: ranks A–Q, ♠+♥
+ * Hard   6×6 = 36 cards = 18 pairs: ranks A–K (13 pairs ♠+♥) + ranks A–5 (5 pairs ♦+♣)
+ */
+function buildGrid(difficulty: "easy" | "medium" | "hard"): MemoryCard[] {
+  const pairs: { pairId: string; a: Card; b: Card }[] = [];
+
+  if (difficulty === "easy") {
+    // 8 pairs: A–8, ♠+♥
+    for (let i = 0; i < 8; i++) {
+      const rank = RANKS[i];
+      const pairId = `p-easy-${rank}`;
+      pairs.push({
+        pairId,
+        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+      });
+    }
+  } else if (difficulty === "medium") {
+    // 12 pairs: A–Q, ♠+♥
+    for (let i = 0; i < 12; i++) {
+      const rank = RANKS[i];
+      const pairId = `p-med-${rank}`;
+      pairs.push({
+        pairId,
+        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+      });
+    }
+  } else {
+    // Hard: 13 pairs A–K ♠+♥, then 5 more pairs A–5 ♦+♣
+    for (let i = 0; i < 13; i++) {
+      const rank = RANKS[i];
+      const pairId = `p-h-sh-${rank}`;
+      pairs.push({
+        pairId,
+        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+      });
+    }
+    for (let i = 0; i < 5; i++) {
+      const rank = RANKS[i];
+      const pairId = `p-h-dc-${rank}`;
+      pairs.push({
+        pairId,
+        a: { suit: "diamonds" as Suit, rank, id: `mem-d-${rank}-a` },
+        b: { suit: "clubs"    as Suit, rank, id: `mem-c-${rank}-b` },
+      });
+    }
+  }
+
+  // Flatten pairs into cards
+  const cards: MemoryCard[] = [];
+  for (const pair of pairs) {
+    cards.push({ card: pair.a, pairId: pair.pairId, faceUp: false, matched: false, flashMatch: false });
+    cards.push({ card: pair.b, pairId: pair.pairId, faceUp: false, matched: false, flashMatch: false });
+  }
+
+  // Fisher-Yates shuffle
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = cards[i];
+    cards[i] = cards[j];
+    cards[j] = tmp;
+  }
+
+  return cards;
+}
+
+function makeInitialState(difficulty: "easy" | "medium" | "hard"): MemoryState {
+  const grid = buildGrid(difficulty);
+  const pairsLeft = grid.length / 2;
+  return { grid, phase: "idle", firstIdx: null, attempts: 0, pairsLeft };
+}
+
+// ── Grid columns by difficulty ────────────────────────────────────────────────
+
+function gridCols(difficulty: "easy" | "medium" | "hard"): number {
+  return difficulty === "hard" ? 6 : 4;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface MemoryProps {
+  settings: DeckSettings;
+  onNewGame?: () => void;
+  onQuit?: () => void;
+}
+
+export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
+  const difficulty = settings.memoryDifficulty;
+
+  const [state, setState] = useState<MemoryState>(() => makeInitialState(difficulty));
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [showDeckModal, setShowDeckModal] = useState(false);
+
+  // Timer
+  const [elapsed, setElapsed] = useState(0);
+  const startTimeRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Start timer on first flip
+  const ensureTimerRunning = useCallback(() => {
+    if (timerRef.current !== null) return;
+    startTimeRef.current = Date.now();
+    timerRef.current = setInterval(() => {
+      if (startTimeRef.current !== null) {
+        setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
+      }
+    }, 1000);
+  }, []);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Stop timer on win
+  useEffect(() => {
+    if (state.phase === "won") {
+      stopTimer();
+    }
+  }, [state.phase, stopTimer]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+      }
+    };
+  }, []);
+
+  // ── New game ──────────────────────────────────────────────────────────────
+
+  const newGame = useCallback(() => {
+    stopTimer();
+    setElapsed(0);
+    startTimeRef.current = null;
+    setState(makeInitialState(difficulty));
+  }, [difficulty, stopTimer]);
+
+  // ── Card click ────────────────────────────────────────────────────────────
+
+  const handleCardClick = useCallback((idx: number) => {
+    setState((s) => {
+      const card = s.grid[idx];
+
+      // Ignore clicks during checking phase, or on already-revealed/matched cards
+      if (s.phase === "checking" || s.phase === "won") return s;
+      if (card.faceUp || card.matched) return s;
+
+      if (s.phase === "idle") {
+        // Flip first card
+        const grid = s.grid.map((c, i) =>
+          i === idx ? { ...c, faceUp: true } : c
+        );
+        return { ...s, grid, phase: "one-up", firstIdx: idx };
+      }
+
+      if (s.phase === "one-up") {
+        if (s.firstIdx === null) return s;
+        const firstCard = s.grid[s.firstIdx];
+        // Flip second card
+        const grid = s.grid.map((c, i) =>
+          i === idx ? { ...c, faceUp: true } : c
+        );
+        const isMatch = firstCard.pairId === card.pairId;
+        const attempts = s.attempts + 1;
+        const pairsLeft = isMatch ? s.pairsLeft - 1 : s.pairsLeft;
+        const phase: Phase = "checking";
+
+        if (isMatch) {
+          const gridFlashed = grid.map((c, i) =>
+            (i === idx || i === s.firstIdx) ? { ...c, matched: true, flashMatch: true } : c
+          );
+          const won = pairsLeft === 0;
+          return { ...s, grid: gridFlashed, phase: won ? "won" : phase, firstIdx: null, attempts, pairsLeft };
+        }
+
+        return { ...s, grid, phase, firstIdx: idx, attempts, pairsLeft };
+      }
+
+      return s;
+    });
+
+    ensureTimerRunning();
+  }, [ensureTimerRunning]);
+
+  // ── Checking delay: flip unmatched pair back, or clear flash ─────────────
+
+  useEffect(() => {
+    if (state.phase !== "checking") return;
+
+    // Check if the two face-up, non-matched cards need to flip back
+    const faceUpUnmatched = state.grid
+      .map((c: MemoryCard, i: number) => ({ c, i }))
+      .filter(({ c }: { c: MemoryCard; i: number }) => c.faceUp && !c.matched);
+
+    if (faceUpUnmatched.length === 0) {
+      // All face-up cards are matched — clear flashMatch flags and go idle
+      const t = setTimeout(() => {
+        setState((s) => {
+          if (s.phase !== "checking") return s;
+          const grid = s.grid.map((c) =>
+            c.flashMatch ? { ...c, flashMatch: false } : c
+          );
+          // Check if all matched (won)
+          const allMatched = grid.every((c) => c.matched);
+          const phase: Phase = allMatched ? "won" : "idle";
+          return { ...s, grid, phase, firstIdx: null };
+        });
+      }, 900);
+      return () => clearTimeout(t);
+    }
+
+    // There are unmatched face-up cards — flip them back
+    const t = setTimeout(() => {
+      setState((s) => {
+        if (s.phase !== "checking") return s;
+        const grid = s.grid.map((c) =>
+          c.faceUp && !c.matched ? { ...c, faceUp: false } : c
+        );
+        return { ...s, grid, phase: "idle", firstIdx: null };
+      });
+    }, 900);
+    return () => clearTimeout(t);
+  }, [state.phase, state.grid]);
+
+  // ── Menus ─────────────────────────────────────────────────────────────────
+
+  const menus = useMemo<MenuBarMenu[]>(() => {
+    const gameItems: MenuBarMenu["items"] = [
+      { label: "New Game", onClick: newGame },
+      ...(onNewGame ? [{ label: "Change Game…", onClick: onNewGame }] : []),
+      ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+    ];
+    return [
+      { label: "Game", items: gameItems },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
+    ];
+  }, [newGame, onNewGame, onQuit]);
+
+  useWindowMenus(menus);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const cols = gridCols(difficulty);
+
+  function difficultyLabel(): string {
+    if (difficulty === "easy")   return "Easy (4×4)";
+    if (difficulty === "medium") return "Medium (4×6)";
+    return "Hard (6×6)";
+  }
+
+  return (
+    <div className="memory">
+      {showDeckModal && (
+        <DeckModal
+          appearance={appearance}
+          onUpdate={setAppearance}
+          onClose={() => setShowDeckModal(false)}
+        />
+      )}
+
+      {/* Info bar */}
+      <div className="memory__infobar">
+        <span>{difficultyLabel()}</span>
+      </div>
+
+      {/* Game table */}
+      <div className="memory__table">
+        {state.phase === "won" && (
+          <div className="memory__win-banner">
+            <div className="memory__win-title">You Won!</div>
+            <div className="memory__win-stats">
+              {state.attempts} attempt{state.attempts !== 1 ? "s" : ""} · {elapsed}s
+            </div>
+            <button className="memory__btn memory__btn--primary" onClick={newGame}>
+              Play Again
+            </button>
+          </div>
+        )}
+
+        <div
+          className="memory__grid"
+          style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+        >
+          {state.grid.map((mc, idx) => {
+            const isSelected = !mc.matched && mc.faceUp;
+            const cls = [
+              "memory__card-wrap",
+              isSelected && !mc.matched ? "memory__card-wrap--selected" : "",
+              mc.matched && mc.flashMatch ? "memory__card-wrap--matched-flash" : "",
+              mc.matched && !mc.flashMatch ? "memory__card-wrap--matched" : "",
+              !mc.faceUp && !mc.matched ? "memory__card-wrap--facedown" : "",
+            ].filter(Boolean).join(" ");
+
+            return (
+              <div
+                key={mc.card.id}
+                className={cls}
+                onClick={() => handleCardClick(idx)}
+              >
+                <PlayingCard
+                  card={mc.card}
+                  faceDown={!mc.faceUp}
+                  appearance={appearance}
+                  size="sm"
+                  dealIndex={idx}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="memory__statusbar">
+        <span>Attempts: {state.attempts}</span>
+        <span>Time: {elapsed}s</span>
+        <span>{state.pairsLeft} pair{state.pairsLeft !== 1 ? "s" : ""} left</span>
+      </div>
+
+      {/* Controls */}
+      <div className="memory__controls">
+        <button className="memory__btn memory__btn--primary" onClick={newGame}>
+          New Game
+        </button>
+        {onNewGame && (
+          <button className="memory__btn memory__btn--secondary" onClick={onNewGame}>
+            Change Game
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/Memory.tsx
+++ b/src/experiences/Cards/Memory.tsx
@@ -1,122 +1,128 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./Memory.css";
-import { FlippableCard } from "./FlippableCard";
-import type { CardAppearance, DeckSettings } from "./types";
-import type { Card, Rank, Suit } from "./types";
+import { PermCard } from "./PermCard";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
+import type { Card, CardAppearance, DeckSettings } from "./types";
+import type { Rank, Suit } from "./types";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
-// ── Types ────────────────────────────────────────────────────────────────────
+// ── Types ─────────────────────────────────────────────────────────────────────
 
-type Phase = "idle" | "one-up" | "checking" | "won";
+type MemoryDifficulty = "easy" | "medium" | "hard";
+type Phase = "shuffle" | "idle" | "one-up" | "checking" | "game-over";
 
-interface MemoryCard {
+interface MemCardData {
   card: Card;
   pairId: string;
-  faceUp: boolean;
-  matched: boolean;
-  flashMatch: boolean;  // brief green highlight after match
 }
 
-interface MemoryState {
-  grid: MemoryCard[];
-  phase: Phase;
-  firstIdx: number | null;
-  attempts: number;
-  pairsLeft: number;
+// ── Stage constants ───────────────────────────────────────────────────────────
+
+const STAGE_W = 436;
+const CARD_W  = 52;
+const CARD_H  = 72;
+const GAP     = 8;
+
+// Grid: cols × rows per difficulty
+const GRID_COLS: Record<MemoryDifficulty, number> = { easy: 4, medium: 6, hard: 6 };
+const GRID_ROWS: Record<MemoryDifficulty, number> = { easy: 4, medium: 4, hard: 6 };
+
+// Stage height: top-padding + grid rows + bottom area for scored pile
+const GRID_TOP = 10;
+function stageH(difficulty: MemoryDifficulty): number {
+  const rows = GRID_ROWS[difficulty];
+  return GRID_TOP + rows * CARD_H + (rows - 1) * GAP + 90;
 }
 
-// ── Board builders ────────────────────────────────────────────────────────────
+// Scored pile center at bottom-center of stage
+function pileY(difficulty: MemoryDifficulty): number {
+  return stageH(difficulty) - 44;
+}
+const PILE_X = STAGE_W / 2;
+
+// Grid cell center position for a given index
+function gridPos(index: number, difficulty: MemoryDifficulty): { x: number; y: number } {
+  const cols = GRID_COLS[difficulty];
+  const gridW = cols * CARD_W + (cols - 1) * GAP;
+  const startX = (STAGE_W - gridW) / 2 + CARD_W / 2;
+  const row = Math.floor(index / cols);
+  const col = index % cols;
+  return {
+    x: startX + col * (CARD_W + GAP),
+    y: GRID_TOP + CARD_H / 2 + row * (CARD_H + GAP),
+  };
+}
+
+function rnd(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+// ── Deck builders ─────────────────────────────────────────────────────────────
 
 const RANKS: Rank[] = ["A","2","3","4","5","6","7","8","9","10","J","Q","K"];
 
-/**
- * Build the shuffled memory grid for a given difficulty.
- *
- * Easy   4×4 = 16 cards = 8 pairs:  ranks A–8, ♠+♥
- * Medium 4×6 = 24 cards = 12 pairs: ranks A–Q, ♠+♥
- * Hard   6×6 = 36 cards = 18 pairs: ranks A–K (13 pairs ♠+♥) + ranks A–5 (5 pairs ♦+♣)
- */
-function buildGrid(difficulty: "easy" | "medium" | "hard"): MemoryCard[] {
+function buildMemoryCards(difficulty: MemoryDifficulty): MemCardData[] {
   const pairs: { pairId: string; a: Card; b: Card }[] = [];
 
   if (difficulty === "easy") {
-    // 8 pairs: A–8, ♠+♥
     for (let i = 0; i < 8; i++) {
       const rank = RANKS[i];
-      const pairId = `p-easy-${rank}`;
       pairs.push({
-        pairId,
-        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
-        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+        pairId: `p-e-${rank}`,
+        a: { suit: "spades"  as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts"  as Suit, rank, id: `mem-h-${rank}-b` },
       });
     }
   } else if (difficulty === "medium") {
-    // 12 pairs: A–Q, ♠+♥
     for (let i = 0; i < 12; i++) {
       const rank = RANKS[i];
-      const pairId = `p-med-${rank}`;
       pairs.push({
-        pairId,
-        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
-        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+        pairId: `p-m-${rank}`,
+        a: { suit: "spades"  as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts"  as Suit, rank, id: `mem-h-${rank}-b` },
       });
     }
   } else {
-    // Hard: 13 pairs A–K ♠+♥, then 5 more pairs A–5 ♦+♣
     for (let i = 0; i < 13; i++) {
       const rank = RANKS[i];
-      const pairId = `p-h-sh-${rank}`;
       pairs.push({
-        pairId,
-        a: { suit: "spades" as Suit, rank, id: `mem-s-${rank}-a` },
-        b: { suit: "hearts" as Suit, rank, id: `mem-h-${rank}-b` },
+        pairId: `p-h-sh-${rank}`,
+        a: { suit: "spades"  as Suit, rank, id: `mem-s-${rank}-a` },
+        b: { suit: "hearts"  as Suit, rank, id: `mem-h-${rank}-b` },
       });
     }
     for (let i = 0; i < 5; i++) {
       const rank = RANKS[i];
-      const pairId = `p-h-dc-${rank}`;
       pairs.push({
-        pairId,
+        pairId: `p-h-dc-${rank}`,
         a: { suit: "diamonds" as Suit, rank, id: `mem-d-${rank}-a` },
         b: { suit: "clubs"    as Suit, rank, id: `mem-c-${rank}-b` },
       });
     }
   }
 
-  // Flatten pairs into cards
-  const cards: MemoryCard[] = [];
-  for (const pair of pairs) {
-    cards.push({ card: pair.a, pairId: pair.pairId, faceUp: false, matched: false, flashMatch: false });
-    cards.push({ card: pair.b, pairId: pair.pairId, faceUp: false, matched: false, flashMatch: false });
+  const cards: MemCardData[] = [];
+  for (const p of pairs) {
+    cards.push({ card: p.a, pairId: p.pairId });
+    cards.push({ card: p.b, pairId: p.pairId });
   }
-
-  // Fisher-Yates shuffle
-  for (let i = cards.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = cards[i];
-    cards[i] = cards[j];
-    cards[j] = tmp;
-  }
-
   return cards;
 }
 
-function makeInitialState(difficulty: "easy" | "medium" | "hard"): MemoryState {
-  const grid = buildGrid(difficulty);
-  const pairsLeft = grid.length / 2;
-  return { grid, phase: "idle", firstIdx: null, attempts: 0, pairsLeft };
+function fisherYates<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
 }
 
-// ── Grid columns by difficulty ────────────────────────────────────────────────
-
-function gridCols(difficulty: "easy" | "medium" | "hard"): number {
-  return difficulty === "hard" ? 6 : 4;
-}
-
-// ── Component ────────────────────────────────────────────────────────────────
+// ── Component ─────────────────────────────────────────────────────────────────
 
 interface MemoryProps {
   settings: DeckSettings;
@@ -125,19 +131,48 @@ interface MemoryProps {
 }
 
 export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
-  const difficulty = settings.memoryDifficulty;
+  const difficulty: MemoryDifficulty = settings.memoryDifficulty;
 
-  const [state, setState] = useState<MemoryState>(() => makeInitialState(difficulty));
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [allCards,      setAllCards]      = useState<MemCardData[]>([]);
+  const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
+  const [phase,         setPhase]         = useState<Phase>("shuffle");
+  const [selectedIds,   setSelectedIds]   = useState<string[]>([]);
+  const [scoredIds,     setScoredIds]     = useState<Set<string>>(new Set<string>());
+  const [flashIds,      setFlashIds]      = useState<Set<string>>(new Set<string>());
+  const [attempts,      setAttempts]      = useState(0);
+  const [pairsFound,    setPairsFound]    = useState(0);
+  const [elapsed,       setElapsed]       = useState(0);
+  const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
 
-  // Timer
-  const [elapsed, setElapsed] = useState(0);
-  const startTimeRef = useRef<number | null>(null);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Scored pile — permanent stack, face-up cards fan slightly
+  const scoredStack = useRef(new CardStack({
+    zTier: 1,
+    baseX: PILE_X,
+    baseY: pileY(difficulty),
+    offsetX: 0.4,
+    offsetY: -0.3,
+  }));
 
-  // Start timer on first flip
-  const ensureTimerRunning = useCallback(() => {
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearTimers = useCallback(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+  }, []);
+  function after(ms: number, fn: () => void): void {
+    const id = setTimeout(fn, ms);
+    timers.current.push(id);
+  }
+
+  // Timer
+  const startTimeRef = useRef<number | null>(null);
+  const timerRef     = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) { clearInterval(timerRef.current); timerRef.current = null; }
+  }, []);
+
+  const ensureTimer = useCallback(() => {
     if (timerRef.current !== null) return;
     startTimeRef.current = Date.now();
     timerRef.current = setInterval(() => {
@@ -147,150 +182,311 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
     }, 1000);
   }, []);
 
-  const stopTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  // Stop timer on win
   useEffect(() => {
-    if (state.phase === "won") {
-      stopTimer();
-    }
-  }, [state.phase, stopTimer]);
+    if (phase === "game-over") stopTimer();
+  }, [phase, stopTimer]);
 
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) {
-        clearInterval(timerRef.current);
-      }
-    };
-  }, []);
+  useEffect(() => () => { stopTimer(); }, [stopTimer]);
 
-  // ── New game ──────────────────────────────────────────────────────────────
+  // ── startGame ──────────────────────────────────────────────────────────────
 
-  const newGame = useCallback(() => {
+  const startGame = useCallback(() => {
+    clearTimers();
     stopTimer();
     setElapsed(0);
     startTimeRef.current = null;
-    setState(makeInitialState(difficulty));
-  }, [difficulty, stopTimer]);
+    setSelectedIds([]);
+    setFlashIds(new Set<string>());
+    setAttempts(0);
+    setPairsFound(0);
+
+    const isRestart = allCards.length > 0;
+    const memCards  = buildMemoryCards(difficulty);
+    const shuffled  = fisherYates(memCards);
+
+    // Build initial card states — all at pile center, face-down, instant
+    const initStates: Record<string, CardVisualState> = {};
+    for (const mc of shuffled) {
+      initStates[mc.card.id] = {
+        x: PILE_X, y: pileY(difficulty), z: 10,
+        rotation: 0, faceDown: true, transitionMs: 0,
+      };
+    }
+
+    const GATHER  = 300;
+    const SPLIT   = 280;
+    const PAUSE   = 80;
+    const MERGE   = 200;
+    const STAGGER = 8;
+    const DEAL    = 380;
+    const MERGE_TOTAL = MERGE + (shuffled.length - 1) * STAGGER;
+
+    function mergeStates(cards1: MemCardData[], cards2: MemCardData[]): Record<string, CardVisualState> {
+      const interleaved: MemCardData[] = [];
+      const len = Math.max(cards1.length, cards2.length);
+      for (let i = 0; i < len; i++) {
+        if (i < cards1.length) interleaved.push(cards1[i]);
+        if (i < cards2.length) interleaved.push(cards2[i]);
+      }
+      const states: Record<string, CardVisualState> = {};
+      interleaved.forEach((mc, i) => {
+        states[mc.card.id] = {
+          x: PILE_X, y: pileY(difficulty), z: 10 + i,
+          rotation: rnd(-5, 5), faceDown: true,
+          transitionMs: MERGE, transitionDelay: i * STAGGER,
+        };
+      });
+      return states;
+    }
+
+    const half  = Math.floor(shuffled.length / 2);
+    const left  = shuffled.slice(0, half);
+    const right = shuffled.slice(half);
+    const leftX  = PILE_X - 80;
+    const rightX = PILE_X + 80;
+
+    if (isRestart) {
+      // Gather scored cards back to pile center (face-up, they animate from their scored positions)
+      const gatherStates: Record<string, CardVisualState> = {};
+      for (const mc of allCards) {
+        gatherStates[mc.card.id] = {
+          x: PILE_X, y: pileY(difficulty), z: 10,
+          rotation: rnd(-3, 3), faceDown: false,
+          transitionMs: GATHER,
+        };
+      }
+      scoredStack.current.clear();
+      setScoredIds(new Set<string>());
+      setAllCards(shuffled);
+      setCardStates(gatherStates);
+      setPhase("shuffle");
+
+      let now = GATHER + PAUSE;
+
+      // Flip face-down (split apart so the "flip" is visible)
+      after(now, () => {
+        const states: Record<string, CardVisualState> = {};
+        left.forEach((mc, i) => {
+          states[mc.card.id] = { x: leftX + i * 0.5, y: pileY(difficulty) - i * 0.5, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        right.forEach((mc, i) => {
+          states[mc.card.id] = { x: rightX - i * 0.5, y: pileY(difficulty) - i * 0.5, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        setCardStates(states);
+      });
+      now += SPLIT + PAUSE;
+
+      after(now, () => setCardStates(mergeStates(left, right)));
+      now += MERGE_TOTAL + PAUSE;
+
+      after(now, () => {
+        left.forEach((mc, i) => {
+          setCardStates(prev => ({ ...prev, [mc.card.id]: { x: leftX + i * 0.4, y: pileY(difficulty) - i * 0.4, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT } }));
+        });
+        right.forEach((mc, i) => {
+          setCardStates(prev => ({ ...prev, [mc.card.id]: { x: rightX - i * 0.4, y: pileY(difficulty) - i * 0.4, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT } }));
+        });
+        // Do the second split as a batch
+        const states: Record<string, CardVisualState> = {};
+        left.forEach((mc, i) => {
+          states[mc.card.id] = { x: leftX + i * 0.4, y: pileY(difficulty) - i * 0.4, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        right.forEach((mc, i) => {
+          states[mc.card.id] = { x: rightX - i * 0.4, y: pileY(difficulty) - i * 0.4, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        setCardStates(states);
+      });
+      now += SPLIT + PAUSE;
+
+      after(now, () => setCardStates(mergeStates(left, right)));
+      now += MERGE_TOTAL + PAUSE;
+
+      after(now, () => {
+        const dealStates: Record<string, CardVisualState> = {};
+        shuffled.forEach((mc, idx) => {
+          const pos = gridPos(idx, difficulty);
+          dealStates[mc.card.id] = { x: pos.x, y: pos.y, z: 200 + idx, rotation: 0, faceDown: true, transitionMs: DEAL };
+        });
+        setCardStates(dealStates);
+        after(DEAL + 100, () => setPhase("idle"));
+      });
+
+    } else {
+      // First game: instant placement at pile center, then shuffle and deal
+      scoredStack.current.clear();
+      setScoredIds(new Set<string>());
+      setAllCards(shuffled);
+      setCardStates(initStates);
+      setPhase("shuffle");
+
+      let now = 80;  // let browser paint "all at center" frame first
+
+      after(now, () => {
+        const states: Record<string, CardVisualState> = {};
+        left.forEach((mc, i) => {
+          states[mc.card.id] = { x: leftX + i * 0.5, y: pileY(difficulty) - i * 0.5, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        right.forEach((mc, i) => {
+          states[mc.card.id] = { x: rightX - i * 0.5, y: pileY(difficulty) - i * 0.5, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        setCardStates(states);
+      });
+      now += SPLIT + PAUSE;
+
+      after(now, () => setCardStates(mergeStates(left, right)));
+      now += MERGE_TOTAL + PAUSE;
+
+      after(now, () => {
+        const states: Record<string, CardVisualState> = {};
+        left.forEach((mc, i) => {
+          states[mc.card.id] = { x: leftX + i * 0.4, y: pileY(difficulty) - i * 0.4, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        right.forEach((mc, i) => {
+          states[mc.card.id] = { x: rightX - i * 0.4, y: pileY(difficulty) - i * 0.4, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+        });
+        setCardStates(states);
+      });
+      now += SPLIT + PAUSE;
+
+      after(now, () => setCardStates(mergeStates(left, right)));
+      now += MERGE_TOTAL + PAUSE;
+
+      after(now, () => {
+        const dealStates: Record<string, CardVisualState> = {};
+        shuffled.forEach((mc, idx) => {
+          const pos = gridPos(idx, difficulty);
+          dealStates[mc.card.id] = { x: pos.x, y: pos.y, z: 200 + idx, rotation: 0, faceDown: true, transitionMs: DEAL };
+        });
+        setCardStates(dealStates);
+        after(DEAL + 100, () => setPhase("idle"));
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allCards, difficulty]);
+
+  useEffect(() => {
+    startGame();
+    return clearTimers;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ── Card click ────────────────────────────────────────────────────────────
 
-  const handleCardClick = useCallback((idx: number) => {
-    setState((s) => {
-      const card = s.grid[idx];
+  const handleCardClick = useCallback((cardId: string) => {
+    if (phase !== "idle" && phase !== "one-up") return;
 
-      // Ignore clicks during checking phase, or on already-revealed/matched cards
-      if (s.phase === "checking" || s.phase === "won") return s;
-      if (card.faceUp || card.matched) return s;
-
-      if (s.phase === "idle") {
-        // Flip first card
-        const grid = s.grid.map((c, i) =>
-          i === idx ? { ...c, faceUp: true } : c
-        );
-        return { ...s, grid, phase: "one-up", firstIdx: idx };
-      }
-
-      if (s.phase === "one-up") {
-        if (s.firstIdx === null) return s;
-        const firstCard = s.grid[s.firstIdx];
-        // Flip second card
-        const grid = s.grid.map((c, i) =>
-          i === idx ? { ...c, faceUp: true } : c
-        );
-        const isMatch = firstCard.pairId === card.pairId;
-        const attempts = s.attempts + 1;
-        const pairsLeft = isMatch ? s.pairsLeft - 1 : s.pairsLeft;
-        const phase: Phase = "checking";
-
-        if (isMatch) {
-          const gridFlashed = grid.map((c, i) =>
-            (i === idx || i === s.firstIdx) ? { ...c, matched: true, flashMatch: true } : c
-          );
-          const won = pairsLeft === 0;
-          return { ...s, grid: gridFlashed, phase: won ? "won" : phase, firstIdx: null, attempts, pairsLeft };
-        }
-
-        return { ...s, grid, phase, firstIdx: idx, attempts, pairsLeft };
-      }
-
-      return s;
+    setCardStates(prev => {
+      const cs = prev[cardId];
+      if (!cs || !cs.faceDown) return prev;  // already face-up or scored
+      return { ...prev, [cardId]: { ...cs, faceDown: false, transitionMs: 0 } };
     });
 
-    ensureTimerRunning();
-  }, [ensureTimerRunning]);
+    ensureTimer();
 
-  // ── Checking delay: flip unmatched pair back, or clear flash ─────────────
+    if (phase === "idle") {
+      setSelectedIds([cardId]);
+      setPhase("one-up");
+    } else {
+      // second card
+      setSelectedIds(prev => {
+        const firstId = prev[0];
+        if (!firstId || firstId === cardId) return prev;
 
-  useEffect(() => {
-    if (state.phase !== "checking") return;
+        const firstMc = allCards.find(mc => mc.card.id === firstId);
+        const secondMc = allCards.find(mc => mc.card.id === cardId);
+        if (!firstMc || !secondMc) return prev;
 
-    // Check if the two face-up, non-matched cards need to flip back
-    const faceUpUnmatched = state.grid
-      .map((c: MemoryCard, i: number) => ({ c, i }))
-      .filter(({ c }: { c: MemoryCard; i: number }) => c.faceUp && !c.matched);
+        setAttempts(a => a + 1);
+        setPhase("checking");
 
-    if (faceUpUnmatched.length === 0) {
-      // All face-up cards are matched — clear flashMatch flags and go idle
-      const t = setTimeout(() => {
-        setState((s) => {
-          if (s.phase !== "checking") return s;
-          const grid = s.grid.map((c) =>
-            c.flashMatch ? { ...c, flashMatch: false } : c
-          );
-          // Check if all matched (won)
-          const allMatched = grid.every((c) => c.matched);
-          const phase: Phase = allMatched ? "won" : "idle";
-          return { ...s, grid, phase, firstIdx: null };
-        });
-      }, 900);
-      return () => clearTimeout(t);
-    }
+        if (firstMc.pairId === secondMc.pairId) {
+          // Match!
+          const matchIds = [firstId, cardId];
+          setFlashIds(new Set<string>(matchIds));
 
-    // There are unmatched face-up cards — flip them back
-    const t = setTimeout(() => {
-      setState((s) => {
-        if (s.phase !== "checking") return s;
-        const grid = s.grid.map((c) =>
-          c.faceUp && !c.matched ? { ...c, faceUp: false } : c
-        );
-        return { ...s, grid, phase: "idle", firstIdx: null };
+          after(900, () => {
+            // Move matched cards to scored pile
+            setFlashIds(new Set<string>());
+            const mc1 = allCards.find(m => m.card.id === firstId)!;
+            const mc2 = allCards.find(m => m.card.id === cardId)!;
+
+            scoredStack.current.addCard(mc1.card, { toTop: true, faceDown: false, rotation: rnd(-8, 8) });
+            scoredStack.current.addCard(mc2.card, { toTop: true, faceDown: false, rotation: rnd(-8, 8) });
+
+            const pileLayout = scoredStack.current.layout(350);
+            // During flight: use z=500+ so they fly over everything
+            setCardStates(prev2 => ({
+              ...prev2,
+              [firstId]: { ...pileLayout[firstId], z: 500, transitionMs: 350 },
+              [cardId]:  { ...pileLayout[cardId],  z: 501, transitionMs: 350 },
+            }));
+
+            setScoredIds(prev2 => new Set<string>([...prev2, firstId, cardId]));
+            setPairsFound(p => {
+              const newPairs = p + 1;
+              const totalPairs = allCards.length / 2;
+              after(400, () => {
+                // restore real pile z after flight
+                setCardStates(prev3 => ({
+                  ...prev3,
+                  [firstId]: { ...prev3[firstId], z: pileLayout[firstId].z },
+                  [cardId]:  { ...prev3[cardId],  z: pileLayout[cardId].z },
+                }));
+                if (newPairs >= totalPairs) {
+                  setPhase("game-over");
+                } else {
+                  setPhase("idle");
+                }
+              });
+              return newPairs;
+            });
+          });
+        } else {
+          // No match — flip back after delay
+          after(900, () => {
+            setCardStates(prev2 => {
+              const next = { ...prev2 };
+              if (next[firstId]) next[firstId] = { ...next[firstId], faceDown: true, transitionMs: 0 };
+              if (next[cardId])  next[cardId]  = { ...next[cardId],  faceDown: true, transitionMs: 0 };
+              return next;
+            });
+            setPhase("idle");
+          });
+        }
+
+        return [];
       });
-    }, 900);
-    return () => clearTimeout(t);
-  }, [state.phase, state.grid]);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, allCards]);
 
   // ── Menus ─────────────────────────────────────────────────────────────────
 
   const menus = useMemo<MenuBarMenu[]>(() => {
     const gameItems: MenuBarMenu["items"] = [
-      { label: "New Game", onClick: newGame },
+      { label: "New Game", onClick: startGame },
       ...(onNewGame ? [{ label: "Change Game…", onClick: onNewGame }] : []),
       ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
     ];
     return [
-      { label: "Game", items: gameItems },
+      { label: "Game",    items: gameItems },
       { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
-  }, [newGame, onNewGame, onQuit]);
+  }, [startGame, onNewGame, onQuit]);
 
   useWindowMenus(menus);
 
   // ── Render ────────────────────────────────────────────────────────────────
 
-  const cols = gridCols(difficulty);
-
   function difficultyLabel(): string {
     if (difficulty === "easy")   return "Easy (4×4)";
-    if (difficulty === "medium") return "Medium (4×6)";
+    if (difficulty === "medium") return "Medium (6×4)";
     return "Hard (6×6)";
   }
+
+  const totalPairs = allCards.length / 2;
+  const pairsLeft  = totalPairs - pairsFound;
+  const sh         = stageH(difficulty);
 
   return (
     <div className="memory">
@@ -302,68 +498,55 @@ export default function Memory({ settings, onNewGame, onQuit }: MemoryProps) {
         />
       )}
 
-      {/* Info bar */}
       <div className="memory__infobar">
         <span>{difficultyLabel()}</span>
       </div>
 
-      {/* Game table */}
-      <div className="memory__table">
-        {state.phase === "won" && (
+      <div className="memory__stage" style={{ width: STAGE_W, height: sh }}>
+        {phase === "game-over" && (
           <div className="memory__win-banner">
             <div className="memory__win-title">You Won!</div>
             <div className="memory__win-stats">
-              {state.attempts} attempt{state.attempts !== 1 ? "s" : ""} · {elapsed}s
+              {attempts} attempt{attempts !== 1 ? "s" : ""} · {elapsed}s
             </div>
-            <button className="memory__btn memory__btn--primary" onClick={newGame}>
+            <button className="memory__btn memory__btn--primary" onClick={startGame}>
               Play Again
             </button>
           </div>
         )}
 
-        <div
-          className="memory__grid"
-          style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
-        >
-          {state.grid.map((mc, idx) => {
-            const isSelected = !mc.matched && mc.faceUp;
-            const cls = [
-              "memory__card-wrap",
-              isSelected && !mc.matched ? "memory__card-wrap--selected" : "",
-              mc.matched && mc.flashMatch ? "memory__card-wrap--matched-flash" : "",
-              mc.matched && !mc.flashMatch ? "memory__card-wrap--matched" : "",
-              !mc.faceUp && !mc.matched ? "memory__card-wrap--facedown" : "",
-            ].filter(Boolean).join(" ");
-
-            return (
-              <div
-                key={mc.card.id}
-                className={cls}
-                onClick={() => handleCardClick(idx)}
-              >
-                <FlippableCard
-                  card={mc.card}
-                  faceDown={!mc.faceUp}
-                  appearance={appearance}
-                  size="sm"
-                  dealIndex={idx}
-                />
-              </div>
-            );
-          })}
-        </div>
+        {allCards.map(mc => {
+          const cs = cardStates[mc.card.id];
+          if (!cs) return null;
+          const isSelected = selectedIds.includes(mc.card.id);
+          const isFlash    = flashIds.has(mc.card.id);
+          const isScored   = scoredIds.has(mc.card.id);
+          const highlight  = isFlash    ? "#44cc44"
+                           : isSelected ? "#cc4400"
+                           : undefined;
+          const canClick   = !isScored && cs.faceDown && (phase === "idle" || phase === "one-up");
+          return (
+            <PermCard
+              key={mc.card.id}
+              card={mc.card}
+              cs={isScored ? { ...cs, rotation: cs.rotation } : cs}
+              appearance={appearance}
+              size="sm"
+              highlightColor={highlight}
+              onClick={canClick ? () => handleCardClick(mc.card.id) : undefined}
+            />
+          );
+        })}
       </div>
 
-      {/* Status bar */}
       <div className="memory__statusbar">
-        <span>Attempts: {state.attempts}</span>
+        <span>Attempts: {attempts}</span>
         <span>Time: {elapsed}s</span>
-        <span>{state.pairsLeft} pair{state.pairsLeft !== 1 ? "s" : ""} left</span>
+        <span>{pairsLeft} pair{pairsLeft !== 1 ? "s" : ""} left</span>
       </div>
 
-      {/* Controls */}
       <div className="memory__controls">
-        <button className="memory__btn memory__btn--primary" onClick={newGame}>
+        <button className="memory__btn memory__btn--primary" onClick={startGame}>
           New Game
         </button>
         {onNewGame && (

--- a/src/experiences/Cards/NoGame.tsx
+++ b/src/experiences/Cards/NoGame.tsx
@@ -52,7 +52,7 @@ export default function NoGame({ settings }: NoGameProps) {
           <div className="no-game__pile-label">Draw Pile</div>
           {isEmpty
             ? <div className="playing-card--empty" />
-            : <PlayingCard card={drawPile[0]} faceDown backColor={settings.cardBack} />
+            : <PlayingCard card={drawPile[0]} faceDown appearance={settings.appearance} />
           }
           <div className={`no-game__pile-count${isLow ? " no-game__pile-count--low" : ""}`}>
             {remaining} left

--- a/src/experiences/Cards/PermCard.tsx
+++ b/src/experiences/Cards/PermCard.tsx
@@ -11,6 +11,7 @@ interface PermCardProps {
   size?: "sm";
   highlightColor?: string;
   onClick?: () => void;
+  onDoubleClick?: () => void;
   onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void;
 }
 
@@ -19,7 +20,7 @@ interface PermCardProps {
  * All animation is driven by changes to `cs` — CSS transitions fire automatically
  * because the element always has a prior position in the DOM.
  */
-export function PermCard({ card, cs, appearance, size, highlightColor, onClick, onPointerDown }: PermCardProps) {
+export function PermCard({ card, cs, appearance, size, highlightColor, onClick, onDoubleClick, onPointerDown }: PermCardProps) {
   const cw = size === "sm" ? 52 : 72;
   const ch = size === "sm" ? 72 : 100;
   const delay = cs.transitionDelay ?? 0;
@@ -41,6 +42,7 @@ export function PermCard({ card, cs, appearance, size, highlightColor, onClick, 
         touchAction: onPointerDown ? "none" : undefined,
       }}
       onClick={onClick}
+      onDoubleClick={onDoubleClick}
       onPointerDown={onPointerDown}
     >
       <div

--- a/src/experiences/Cards/PermCard.tsx
+++ b/src/experiences/Cards/PermCard.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import "./Cards.css";
 import { PlayingCard } from "./PlayingCard";
 import type { Card, CardAppearance } from "./types";
@@ -10,6 +11,7 @@ interface PermCardProps {
   size?: "sm";
   highlightColor?: string;
   onClick?: () => void;
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void;
 }
 
 /**
@@ -17,7 +19,7 @@ interface PermCardProps {
  * All animation is driven by changes to `cs` — CSS transitions fire automatically
  * because the element always has a prior position in the DOM.
  */
-export function PermCard({ card, cs, appearance, size, highlightColor, onClick }: PermCardProps) {
+export function PermCard({ card, cs, appearance, size, highlightColor, onClick, onPointerDown }: PermCardProps) {
   const cw = size === "sm" ? 52 : 72;
   const ch = size === "sm" ? 72 : 100;
   const delay = cs.transitionDelay ?? 0;
@@ -28,18 +30,20 @@ export function PermCard({ card, cs, appearance, size, highlightColor, onClick }
   return (
     <div
       style={{
-        position:  "absolute",
-        left:      cs.x - cw / 2,
-        top:       cs.y - ch / 2,
-        width:     cw,
-        height:    ch,
-        zIndex:    cs.z,
-        transition: posTrans,
-        cursor:    onClick ? "pointer" : "default",
-        boxShadow: highlightColor ? `0 0 0 2px ${highlightColor}, 0 0 6px 1px ${highlightColor}` : undefined,
+        position:    "absolute",
+        left:        cs.x - cw / 2,
+        top:         cs.y - ch / 2,
+        width:       cw,
+        height:      ch,
+        zIndex:      cs.z,
+        transition:  posTrans,
+        cursor:      onPointerDown || onClick ? "pointer" : "default",
+        boxShadow:   highlightColor ? `0 0 0 2px ${highlightColor}, 0 0 6px 1px ${highlightColor}` : undefined,
         borderRadius: "4px",
+        touchAction: onPointerDown ? "none" : undefined,
       }}
       onClick={onClick}
+      onPointerDown={onPointerDown}
     >
       <div
         style={{

--- a/src/experiences/Cards/PermCard.tsx
+++ b/src/experiences/Cards/PermCard.tsx
@@ -1,0 +1,66 @@
+import "./Cards.css";
+import { PlayingCard } from "./PlayingCard";
+import type { Card, CardAppearance } from "./types";
+import type { CardVisualState } from "./cardStack";
+
+interface PermCardProps {
+  card: Card;
+  cs: CardVisualState;
+  appearance: CardAppearance;
+  size?: "sm";
+  highlightColor?: string;
+  onClick?: () => void;
+}
+
+/**
+ * A permanently-mounted absolutely-positioned card.
+ * All animation is driven by changes to `cs` — CSS transitions fire automatically
+ * because the element always has a prior position in the DOM.
+ */
+export function PermCard({ card, cs, appearance, size, highlightColor, onClick }: PermCardProps) {
+  const cw = size === "sm" ? 52 : 72;
+  const ch = size === "sm" ? 72 : 100;
+  const delay = cs.transitionDelay ?? 0;
+  const posTrans = cs.transitionMs > 0
+    ? `left ${cs.transitionMs}ms ease-in-out ${delay}ms, top ${cs.transitionMs}ms ease-in-out ${delay}ms`
+    : undefined;
+
+  return (
+    <div
+      style={{
+        position:  "absolute",
+        left:      cs.x - cw / 2,
+        top:       cs.y - ch / 2,
+        width:     cw,
+        height:    ch,
+        zIndex:    cs.z,
+        transition: posTrans,
+        cursor:    onClick ? "pointer" : "default",
+        boxShadow: highlightColor ? `0 0 0 2px ${highlightColor}, 0 0 6px 1px ${highlightColor}` : undefined,
+        borderRadius: "4px",
+      }}
+      onClick={onClick}
+    >
+      <div
+        style={{
+          width:           "100%",
+          height:          "100%",
+          transform:       `rotate(${cs.rotation}deg)`,
+          transformOrigin: "center",
+          transition:      "transform 250ms ease-out",
+        }}
+      >
+        <div className="flippable" style={{ width: cw, height: ch }}>
+          <div className={`flippable__inner${cs.faceDown ? "" : " flippable__inner--face-up"}`}>
+            <div className="flippable__face">
+              <PlayingCard card={card} faceDown appearance={appearance} size={size} />
+            </div>
+            <div className="flippable__face flippable__face--front">
+              <PlayingCard card={card} appearance={appearance} size={size} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/Cards/PermCard.tsx
+++ b/src/experiences/Cards/PermCard.tsx
@@ -38,8 +38,6 @@ export function PermCard({ card, cs, appearance, size, highlightColor, onClick, 
         zIndex:      cs.z,
         transition:  posTrans,
         cursor:      onPointerDown || onClick ? "pointer" : "default",
-        boxShadow:   highlightColor ? `0 0 0 2px ${highlightColor}, 0 0 6px 1px ${highlightColor}` : undefined,
-        borderRadius: "4px",
         touchAction: onPointerDown ? "none" : undefined,
       }}
       onClick={onClick}
@@ -52,6 +50,8 @@ export function PermCard({ card, cs, appearance, size, highlightColor, onClick, 
           transform:       `rotate(${cs.rotation}deg)`,
           transformOrigin: "center",
           transition:      "transform 250ms ease-out",
+          borderRadius:    "4px",
+          boxShadow:       highlightColor ? `0 0 0 2px ${highlightColor}, 0 0 6px 1px ${highlightColor}` : undefined,
         }}
       >
         <div className="flippable" style={{ width: cw, height: ch }}>

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -140,9 +140,9 @@ export function PlayingCard({
         className={`playing-card playing-card--front playing-card--large-idx ${colorClass}${sizeClass}${textClass}${dealClass}`}
         style={dealStyle}
       >
-        <div className="playing-card__large-rank">{card.rank}</div>
-        <div className="playing-card__corner playing-card__corner--br">
-          <span className="playing-card__suit-pip">{symbol}</span>
+        <div className="playing-card__li-center">
+          <span className="playing-card__li-rank">{card.rank}</span>
+          <span className="playing-card__li-suit">{symbol}</span>
         </div>
       </div>
     );

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -1,5 +1,6 @@
 import "./Cards.css";
-import type { Card } from "./types";
+import type { Card, CardAppearance } from "./types";
+import { DEFAULT_APPEARANCE } from "./types";
 
 const SUIT_SYMBOL: Record<string, string> = {
   spades:   "♠",
@@ -8,35 +9,84 @@ const SUIT_SYMBOL: Record<string, string> = {
   clubs:    "♣",
 };
 
-interface PlayingCardProps {
-  card: Card;
-  faceDown?: boolean;
-  backColor?: string;
-  /** "sm" renders a smaller card suitable for pyramid layout */
-  size?: "sm";
+function hexToRgba(hex: string, alpha: number): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-export function PlayingCard({ card, faceDown = false, backColor = "#cc4400", size }: PlayingCardProps) {
+function suitColorClass(suit: string, fourColor: boolean): string {
+  if (suit === "hearts" || suit === "diamonds") return "playing-card--red";
+  if (fourColor) {
+    if (suit === "spades") return "playing-card--blue";
+    if (suit === "clubs")  return "playing-card--green";
+  }
+  return "playing-card--black";
+}
+
+export interface PlayingCardProps {
+  card: Card;
+  faceDown?: boolean;
+  appearance?: CardAppearance;
+  size?: "sm";
+  dealIndex?: number;
+}
+
+export function PlayingCard({
+  card,
+  faceDown = false,
+  appearance = DEFAULT_APPEARANCE,
+  size,
+  dealIndex,
+}: PlayingCardProps) {
   const sizeClass = size === "sm" ? " playing-card--sm" : "";
+  const dealClass = dealIndex !== undefined ? " playing-card--deal" : "";
+  const dealStyle = dealIndex !== undefined
+    ? { "--deal-index": dealIndex } as React.CSSProperties
+    : {};
 
   if (faceDown) {
+    const backCss: React.CSSProperties = {
+      "--cbp": appearance.backPrimaryColor,
+      "--cbs": hexToRgba(appearance.backSecondaryColor, 0.35),
+      ...(appearance.backImageUrl
+        ? { backgroundImage: `url(${appearance.backImageUrl})`, backgroundSize: "cover" }
+        : {}),
+      ...dealStyle,
+    } as React.CSSProperties;
+
     return (
       <div
-        className={`playing-card playing-card--back${sizeClass}`}
-        style={{ "--card-back": backColor } as React.CSSProperties}
+        className={`playing-card playing-card--back${sizeClass}${dealClass}`}
+        data-pattern={appearance.backImageUrl ? undefined : appearance.backPattern}
+        style={backCss}
       >
-        <div className="playing-card__back-inner" />
+        {!appearance.backImageUrl && (
+          <div className="playing-card__back-inner">
+            {appearance.backPattern === "noahsoft" && (
+              <span className="playing-card__back-ns">NS</span>
+            )}
+          </div>
+        )}
       </div>
     );
   }
 
   if (card.suit === "joker") {
     return (
-      <div className={`playing-card playing-card--front playing-card--joker${sizeClass}`}>
+      <div
+        className={`playing-card playing-card--front playing-card--joker${sizeClass}${dealClass}`}
+        style={dealStyle}
+      >
         <div className="playing-card__corner playing-card__corner--tl">
           <span className="playing-card__rank">★</span>
         </div>
-        <div className="playing-card__center" style={{ fontSize: size === "sm" ? 13 : 18, textAlign: "center", lineHeight: 1.4 }}>
+        <div
+          className="playing-card__center"
+          style={{ fontSize: size === "sm" ? 13 : 18, textAlign: "center", lineHeight: 1.4 }}
+        >
           ★<br />JOKER
         </div>
         <div className="playing-card__corner playing-card__corner--br">
@@ -47,11 +97,46 @@ export function PlayingCard({ card, faceDown = false, backColor = "#cc4400", siz
   }
 
   const symbol = SUIT_SYMBOL[card.suit] ?? "?";
-  const isRed = card.suit === "hearts" || card.suit === "diamonds";
-  const colorClass = isRed ? "playing-card--red" : "playing-card--black";
+  const colorClass = suitColorClass(card.suit, appearance.fourColorSuits);
+  const faceStyle = appearance.cardFaceStyle ?? "classic";
+
+  if (faceStyle === "minimal") {
+    return (
+      <div
+        className={`playing-card playing-card--front ${colorClass}${sizeClass}${dealClass}`}
+        style={dealStyle}
+      >
+        <div className="playing-card__corner playing-card__corner--tl">
+          <span className="playing-card__rank">{card.rank}</span>
+          <span className="playing-card__suit-pip">{symbol}</span>
+        </div>
+        <div className="playing-card__corner playing-card__corner--br">
+          <span className="playing-card__rank">{card.rank}</span>
+          <span className="playing-card__suit-pip">{symbol}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (faceStyle === "large-index") {
+    return (
+      <div
+        className={`playing-card playing-card--front playing-card--large-idx ${colorClass}${sizeClass}${dealClass}`}
+        style={dealStyle}
+      >
+        <div className="playing-card__large-rank">{card.rank}</div>
+        <div className="playing-card__corner playing-card__corner--br">
+          <span className="playing-card__suit-pip">{symbol}</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className={`playing-card playing-card--front ${colorClass}${sizeClass}`}>
+    <div
+      className={`playing-card playing-card--front ${colorClass}${sizeClass}${dealClass}`}
+      style={dealStyle}
+    >
       <div className="playing-card__corner playing-card__corner--tl">
         <span className="playing-card__rank">{card.rank}</span>
         <span className="playing-card__suit-pip">{symbol}</span>

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -1,5 +1,5 @@
 import "./Cards.css";
-import type { Card, CardAppearance, SuitColorMode } from "./types";
+import type { Card, CardAppearance, CardTextSize, SuitColorMode } from "./types";
 import { DEFAULT_APPEARANCE } from "./types";
 
 const SUIT_SYMBOL: Record<string, string> = {
@@ -19,20 +19,26 @@ function hexToRgba(hex: string, alpha: number): string {
 
 function suitColorClass(suit: string, mode: SuitColorMode): string {
   if (mode === "high-contrast") {
-    if (suit === "hearts")   return "playing-card--pink";
-    if (suit === "diamonds") return "playing-card--orange";
-    if (suit === "spades")   return "playing-card--blue";
-    if (suit === "clubs")    return "playing-card--green";
+    if (suit === "hearts")   return "playing-card--pink";    // warm pink
+    if (suit === "diamonds") return "playing-card--orange";  // vivid orange
+    if (suit === "spades")   return "playing-card--blue";    // vivid blue
+    if (suit === "clubs")    return "playing-card--green";   // forest green
   }
   if (mode === "four-color") {
-    if (suit === "hearts")   return "playing-card--pink";
-    if (suit === "diamonds") return "playing-card--red";
-    if (suit === "spades")   return "playing-card--blue";
-    if (suit === "clubs")    return "playing-card--green";
+    if (suit === "hearts")   return "playing-card--pink";    // warm pink
+    if (suit === "diamonds") return "playing-card--red";     // deep red (same as standard)
+    if (suit === "spades")   return "playing-card--navy";    // navy (distinct from high-contrast blue)
+    if (suit === "clubs")    return "playing-card--green";   // forest green
   }
   // standard: red for ♥♦, black for ♠♣
   if (suit === "hearts" || suit === "diamonds") return "playing-card--red";
   return "playing-card--black";
+}
+
+function textSizeClass(size: CardTextSize | undefined): string {
+  if (size === "large") return " playing-card--text-lg";
+  if (size === "xl")    return " playing-card--text-xl";
+  return "";
 }
 
 export interface PlayingCardProps {
@@ -50,9 +56,10 @@ export function PlayingCard({
   size,
   dealIndex,
 }: PlayingCardProps) {
-  const sizeClass = size === "sm" ? " playing-card--sm" : "";
-  const dealClass = dealIndex !== undefined ? " playing-card--deal" : "";
-  const dealStyle = dealIndex !== undefined
+  const sizeClass  = size === "sm" ? " playing-card--sm" : "";
+  const dealClass  = dealIndex !== undefined ? " playing-card--deal" : "";
+  const textClass  = textSizeClass(appearance.cardTextSize);
+  const dealStyle  = dealIndex !== undefined
     ? { "--deal-index": dealIndex } as React.CSSProperties
     : {};
 
@@ -112,7 +119,7 @@ export function PlayingCard({
   if (faceStyle === "minimal") {
     return (
       <div
-        className={`playing-card playing-card--front ${colorClass}${sizeClass}${dealClass}`}
+        className={`playing-card playing-card--front ${colorClass}${sizeClass}${textClass}${dealClass}`}
         style={dealStyle}
       >
         <div className="playing-card__corner playing-card__corner--tl">
@@ -130,7 +137,7 @@ export function PlayingCard({
   if (faceStyle === "large-index") {
     return (
       <div
-        className={`playing-card playing-card--front playing-card--large-idx ${colorClass}${sizeClass}${dealClass}`}
+        className={`playing-card playing-card--front playing-card--large-idx ${colorClass}${sizeClass}${textClass}${dealClass}`}
         style={dealStyle}
       >
         <div className="playing-card__large-rank">{card.rank}</div>
@@ -143,7 +150,7 @@ export function PlayingCard({
 
   return (
     <div
-      className={`playing-card playing-card--front ${colorClass}${sizeClass}${dealClass}`}
+      className={`playing-card playing-card--front ${colorClass}${sizeClass}${textClass}${dealClass}`}
       style={dealStyle}
     >
       <div className="playing-card__corner playing-card__corner--tl">

--- a/src/experiences/Cards/PlayingCard.tsx
+++ b/src/experiences/Cards/PlayingCard.tsx
@@ -1,5 +1,5 @@
 import "./Cards.css";
-import type { Card, CardAppearance } from "./types";
+import type { Card, CardAppearance, SuitColorMode } from "./types";
 import { DEFAULT_APPEARANCE } from "./types";
 
 const SUIT_SYMBOL: Record<string, string> = {
@@ -17,12 +17,21 @@ function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-function suitColorClass(suit: string, fourColor: boolean): string {
-  if (suit === "hearts" || suit === "diamonds") return "playing-card--red";
-  if (fourColor) {
-    if (suit === "spades") return "playing-card--blue";
-    if (suit === "clubs")  return "playing-card--green";
+function suitColorClass(suit: string, mode: SuitColorMode): string {
+  if (mode === "high-contrast") {
+    if (suit === "hearts")   return "playing-card--pink";
+    if (suit === "diamonds") return "playing-card--orange";
+    if (suit === "spades")   return "playing-card--blue";
+    if (suit === "clubs")    return "playing-card--green";
   }
+  if (mode === "four-color") {
+    if (suit === "hearts")   return "playing-card--pink";
+    if (suit === "diamonds") return "playing-card--red";
+    if (suit === "spades")   return "playing-card--blue";
+    if (suit === "clubs")    return "playing-card--green";
+  }
+  // standard: red for ♥♦, black for ♠♣
+  if (suit === "hearts" || suit === "diamonds") return "playing-card--red";
   return "playing-card--black";
 }
 
@@ -97,7 +106,7 @@ export function PlayingCard({
   }
 
   const symbol = SUIT_SYMBOL[card.suit] ?? "?";
-  const colorClass = suitColorClass(card.suit, appearance.fourColorSuits);
+  const colorClass = suitColorClass(card.suit, appearance.suitColorMode ?? "standard");
   const faceStyle = appearance.cardFaceStyle ?? "classic";
 
   if (faceStyle === "minimal") {

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -12,85 +12,56 @@
 /* Stage container — measures width for scaling, explicit height set in JS */
 .pyramid__stage-container {
   margin: 8px 8px 4px;
-  overflow: hidden;
   flex-shrink: 0;
+  overflow: hidden;
 }
 
 /* Green felt play area */
-.pyramid__table {
+.pyramid__stage {
   background: #1a4a1a;
+  position: relative;
+  overflow: hidden;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   box-sizing: border-box;
-  padding: 10px 8px 8px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
 }
 
-/* The 7-row card triangle */
-.pyramid__grid {
-  position: relative;
-  /* width/height set by JS via style prop */
-}
-
-/* Each card slot in the pyramid */
-.pyramid__card-wrap {
+/* Dashed outline slot for stock and waste piles */
+.pyramid__pile-slot {
   position: absolute;
-  cursor: pointer;
-  transition: opacity 0.18s ease, transform 0.18s ease;
+  width: 52px;
+  height: 72px;
+  border: 2px dashed rgba(255,255,255,0.2);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.pyramid__card-wrap--unavailable {
-  cursor: default;
-  filter: brightness(0.5) saturate(0.6);
+/* Recycle icon shown when stock is empty */
+.pyramid__pile-icon {
+  font-size: 18px;
+  color: rgba(255,255,255,0.3);
 }
 
-.pyramid__card-wrap--selected .playing-card {
-  outline: 2px solid #ffdd00;
-  outline-offset: 1px;
-  box-shadow: 0 0 6px #ffdd00;
-}
-
-@keyframes pyramid-remove {
-  0%   { transform: scale(1) rotate(0deg); opacity: 1; }
-  20%  { transform: scale(1.06) rotate(-4deg); opacity: 1; }
-  100% { transform: scale(0) rotate(18deg); opacity: 0; }
-}
-
-.pyramid__card-wrap--removed {
-  animation: pyramid-remove 300ms ease-in forwards;
+/* Absolute-positioned pile count labels */
+.pyramid__pile-label-abs {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 5px;
+  color: rgba(255,255,255,0.45);
+  font-family: "Press Start 2P", monospace;
+  white-space: nowrap;
   pointer-events: none;
 }
 
-/* Stock + waste row */
-.pyramid__piles {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-}
-
-.pyramid__pile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
-.pyramid__pile-label {
-  font-size: 6px;
-  color: rgba(255,255,255,0.5);
-}
-
-.pyramid__pile-count {
-  font-size: 6px;
-  color: rgba(255,255,255,0.5);
-}
-
-/* Clickable stock pile */
-.pyramid__stock-card {
+/* Invisible click target over pile positions */
+.pyramid__hit-area {
+  position: absolute;
+  width: 52px;
+  height: 72px;
   cursor: pointer;
+  z-index: 9000;
 }
 
 /* Controls area */

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -44,7 +44,7 @@
 
 .pyramid__card-wrap--unavailable {
   cursor: default;
-  opacity: 0.45;
+  filter: brightness(0.5) saturate(0.6);
 }
 
 .pyramid__card-wrap--selected .playing-card {

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -46,9 +46,14 @@
   box-shadow: 0 0 6px #ffdd00;
 }
 
+@keyframes pyramid-remove {
+  0%   { transform: scale(1) rotate(0deg); opacity: 1; }
+  20%  { transform: scale(1.06) rotate(-4deg); opacity: 1; }
+  100% { transform: scale(0) rotate(18deg); opacity: 0; }
+}
+
 .pyramid__card-wrap--removed {
-  opacity: 0;
-  transform: scale(0.75);
+  animation: pyramid-remove 300ms ease-in forwards;
   pointer-events: none;
 }
 

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -32,6 +32,7 @@
 .pyramid__card-wrap {
   position: absolute;
   cursor: pointer;
+  transition: opacity 0.18s ease, transform 0.18s ease;
 }
 
 .pyramid__card-wrap--unavailable {
@@ -46,7 +47,8 @@
 }
 
 .pyramid__card-wrap--removed {
-  visibility: hidden;
+  opacity: 0;
+  transform: scale(0.75);
   pointer-events: none;
 }
 

--- a/src/experiences/Cards/Pyramid.css
+++ b/src/experiences/Cards/Pyramid.css
@@ -9,12 +9,19 @@
   user-select: none;
 }
 
+/* Stage container — measures width for scaling, explicit height set in JS */
+.pyramid__stage-container {
+  margin: 8px 8px 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
 /* Green felt play area */
 .pyramid__table {
   background: #1a4a1a;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
-  margin: 8px 8px 4px;
+  box-sizing: border-box;
   padding: 10px 8px 8px;
   display: flex;
   flex-direction: column;

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import "./Pyramid.css";
 import { PlayingCard } from "./PlayingCard";
-import type { Card, DeckSettings } from "./types";
+import type { Card, CardAppearance, DeckSettings } from "./types";
 import { buildDeck } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
@@ -120,7 +120,7 @@ interface PyramidProps {
 
 export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
   const [state, setState] = useState<PyramidState>(() => buildPyramid(settings));
-  const [cardBack, setCardBack] = useState(settings.cardBack);
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
 
   const newGame = useCallback(() => setState(buildPyramid(settings)), [settings]);
@@ -223,7 +223,7 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
     ];
     return [
       { label: "Game", items },
-      { label: "Options", items: [{ label: "Deck…", onClick: () => setShowDeckModal(true) }] },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
   }, [newGame, onNewGame, onQuit]);
 
@@ -235,8 +235,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
     <div className="pyramid">
       {showDeckModal && (
         <DeckModal
-          cardBack={cardBack}
-          onSelect={setCardBack}
+          appearance={appearance}
+          onUpdate={setAppearance}
           onClose={() => setShowDeckModal(false)}
         />
       )}
@@ -259,7 +259,7 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
                   style={{ left: cardX(slot.row, slot.col), top: cardY(slot.row) }}
                   onClick={() => avail && selectCard(slot.card.id, false)}
                 >
-                  <PlayingCard card={slot.card} size="sm" backColor={cardBack} />
+                  <PlayingCard card={slot.card} size="sm" appearance={appearance} />
                 </div>
               );
             })}
@@ -271,7 +271,7 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
             <div className="pyramid__pile-label">Stock</div>
             <div className="pyramid__stock-card" onClick={drawFromStock}>
               {state.stock.length > 0
-                ? <PlayingCard card={state.stock[0]} faceDown size="sm" backColor={cardBack} />
+                ? <PlayingCard card={state.stock[0]} faceDown size="sm" appearance={appearance} />
                 : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />
               }
             </div>
@@ -289,7 +289,7 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
                   style={{ position: "relative" }}
                   onClick={() => selectCard(wasteTop.id, true)}
                 >
-                  <PlayingCard card={wasteTop} size="sm" backColor={cardBack} />
+                  <PlayingCard card={wasteTop} size="sm" appearance={appearance} />
                 </div>
               )
               : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -138,7 +138,7 @@ function computePositions(
       result[slot.card.id] = {
         x: REMOVE_X,
         y: REMOVE_Y,
-        z: 50,
+        z: 5000 + slot.row * 10 + slot.col,
         rotation: 12,
         faceDown: false,
         transitionMs: ms,
@@ -157,13 +157,13 @@ function computePositions(
     }
   }
 
-  // Stock: stacked face-down, each card slightly offset so depth is visible
+  // Stock: stacked face-down, depth offset goes UPWARD so stack doesn't cover the label
   const n = s.stock.length;
   s.stock.forEach((card, i) => {
     const depth = n - 1 - i;   // 0 for top card, n-1 for bottom
     result[card.id] = {
       x: STOCK_X + depth * 0.5,
-      y: PILE_Y  + depth * 0.5,
+      y: PILE_Y  - depth * 0.5,
       z: 100 + i,
       faceDown: true,
       rotation: 0,
@@ -171,13 +171,13 @@ function computePositions(
     };
   });
 
-  // Waste: stacked face-up, same depth trick
+  // Waste: stacked face-up, same depth trick (upward)
   const wn = s.waste.length;
   s.waste.forEach((card, i) => {
     const depth = wn - 1 - i;
     result[card.id] = {
       x: WASTE_X + depth * 0.5,
-      y: PILE_Y  + depth * 0.5,
+      y: PILE_Y  - depth * 0.5,
       z: 200 + i,
       faceDown: false,
       rotation: 0,
@@ -253,46 +253,86 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
   // ── Deal animation helper ───────────────────────────────────────────────────
 
   function dealAnimation(s: PyramidState, cards: Card[]): void {
-    // All cards start at stock position, face-down, no transition
+    const total = cards.length;
+    const half = Math.floor(total / 2);
+
+    // Start: all cards stacked at stock, no transition
     const init: Record<string, CardVisualState> = {};
-    for (const c of cards) {
-      init[c.id] = { x: STOCK_X, y: PILE_Y, z: 100, rotation: 0, faceDown: true, transitionMs: 0 };
-    }
+    cards.forEach((c, i) => {
+      const d = total - 1 - i;
+      init[c.id] = { x: STOCK_X + d * 0.3, y: PILE_Y - d * 0.3, z: 100 + i, rotation: 0, faceDown: true, transitionMs: 0 };
+    });
     setCardStates(init);
 
-    after(60, () => {
-      // Animate pyramid cards to their positions with stagger
-      const deal: Record<string, CardVisualState> = { ...init };
-      for (const slot of s.slots) {
-        const staggerIdx = (slot.row - 1) * 7 + slot.col;
-        deal[slot.card.id] = {
-          x: cardX(slot.row, slot.col),
-          y: cardY(slot.row),
-          z: slot.row * 10 + slot.col,
-          faceDown: false,
-          rotation: 0,
-          transitionMs: 280,
-          transitionDelay: staggerIdx * 35,
-        };
-      }
-      // Stock cards stay put (already at stock position)
-      s.stock.forEach((card, i) => {
-        const depth = s.stock.length - 1 - i;
-        deal[card.id] = {
-          x: STOCK_X + depth * 0.5,
-          y: PILE_Y + depth * 0.5,
-          z: 100 + i,
-          faceDown: true,
-          rotation: 0,
-          transitionMs: 0,
-        };
-      });
-      setCardStates(deal);
+    // Riffle shuffle: split left/right then merge back
+    const shufflePass = (delay: number, onDone: () => void): void => {
+      after(delay, () => {
+        const split: Record<string, CardVisualState> = {};
+        cards.forEach((c, i) => {
+          const isLeft = i < half;
+          const pos = isLeft ? i : i - half;
+          const len = isLeft ? half : total - half;
+          const d = len - 1 - pos;
+          split[c.id] = {
+            x: (isLeft ? STOCK_X - 24 : STOCK_X + 24) + d * 0.3,
+            y: PILE_Y - d * 0.3,
+            z: 100 + i,
+            rotation: isLeft ? -3 : 3,
+            faceDown: true,
+            transitionMs: 200,
+          };
+        });
+        setCardStates(split);
 
-      const totalDelay = 28 * 35 + 280 + 80;
-      after(totalDelay, () => {
-        setState(prev => ({ ...prev, phase: "playing" }));
-        // Let the useEffect below sync final positions cleanly
+        after(280, () => {
+          const merged: Record<string, CardVisualState> = {};
+          cards.forEach((c, i) => {
+            const d = total - 1 - i;
+            merged[c.id] = {
+              x: STOCK_X + d * 0.3,
+              y: PILE_Y - d * 0.3,
+              z: 100 + i,
+              rotation: 0,
+              faceDown: true,
+              transitionMs: 200,
+              transitionDelay: i * 3,
+            };
+          });
+          setCardStates(merged);
+          after(420, onDone);
+        });
+      });
+    };
+
+    // Two shuffle passes, then deal pyramid cards to their positions
+    shufflePass(60, () => {
+      shufflePass(0, () => {
+        after(60, () => {
+          const deal: Record<string, CardVisualState> = {};
+          // Stock cards snap to final pile positions (no transition)
+          s.stock.forEach((card, i) => {
+            const d = s.stock.length - 1 - i;
+            deal[card.id] = { x: STOCK_X + d * 0.5, y: PILE_Y - d * 0.5, z: 100 + i, faceDown: true, rotation: 0, transitionMs: 0 };
+          });
+          // Pyramid cards fly to grid positions with stagger (apex first)
+          s.slots.forEach(slot => {
+            const stagger = (slot.row - 1) * 7 + slot.col;
+            deal[slot.card.id] = {
+              x: cardX(slot.row, slot.col),
+              y: cardY(slot.row),
+              z: slot.row * 10 + slot.col,
+              faceDown: false,
+              rotation: 0,
+              transitionMs: 280,
+              transitionDelay: stagger * 35,
+            };
+          });
+          setCardStates(deal);
+
+          after(28 * 35 + 280 + 80, () => {
+            setState(prev => ({ ...prev, phase: "playing" }));
+          });
+        });
       });
     });
   }

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import "./Pyramid.css";
 import { PlayingCard } from "./PlayingCard";
 import type { Card, CardAppearance, DeckSettings } from "./types";
@@ -17,6 +17,10 @@ const V_STEP = 34; // vertical distance between row tops (overlap)
 
 const BASE_ROW_W = ROWS * CARD_W + (ROWS - 1) * H_GAP; // 388
 const GRID_H = (ROWS - 1) * V_STEP + CARD_H;            // 276
+
+// Stage dimensions for scale calculation (table width + horizontal padding; height is approximate)
+const STAGE_W = BASE_ROW_W + 16;  // 404 — table padding 8px each side
+const STAGE_H = GRID_H + CARD_H + 40 + 28;  // grid + piles + gaps + padding ≈ 416
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -118,12 +122,49 @@ interface PyramidProps {
   onQuit?: () => void;
 }
 
+const PYR_SAVE_KEY = "cards-pyramid-save";
+
 export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
-  const [state, setState] = useState<PyramidState>(() => buildPyramid(settings));
+  const [state, setState] = useState<PyramidState>(() => {
+    try {
+      const raw = localStorage.getItem(PYR_SAVE_KEY);
+      if (raw) {
+        const saved = JSON.parse(raw) as { version: number; state: PyramidState };
+        if (saved?.version === 1 && saved.state?.slots) return saved.state;
+      }
+    } catch {}
+    return buildPyramid(settings);
+  });
   const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
+  const [scale, setScale] = useState(1);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  const newGame = useCallback(() => setState(buildPyramid(settings)), [settings]);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (state.phase === "won" || state.phase === "lost") {
+      try { localStorage.removeItem(PYR_SAVE_KEY); } catch {}
+      return;
+    }
+    try {
+      localStorage.setItem(PYR_SAVE_KEY, JSON.stringify({ version: 1, state }));
+    } catch {}
+  }, [state]);
+
+  const newGame = useCallback(() => {
+    try { localStorage.removeItem(PYR_SAVE_KEY); } catch {}
+    setState(buildPyramid(settings));
+  }, [settings]);
 
   const drawFromStock = useCallback(() => {
     setState((s: PyramidState) => {
@@ -240,7 +281,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
           onClose={() => setShowDeckModal(false)}
         />
       )}
-      <div className="pyramid__table">
+      <div className="pyramid__stage-container" ref={containerRef} style={{ height: Math.round(STAGE_H * scale) }}>
+      <div className="pyramid__table" style={{ width: STAGE_W, transform: scale < 1 ? `scale(${scale})` : undefined, transformOrigin: "top left" }}>
         {!pyramidDone && (
           <div className="pyramid__grid" style={{ width: BASE_ROW_W, height: GRID_H }}>
             {state.slots.map((slot) => {
@@ -297,6 +339,7 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
             <div className="pyramid__pile-count">{state.waste.length}</div>
           </div>
         </div>
+      </div>
       </div>
 
       <div className="pyramid__controls">

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -157,27 +157,29 @@ function computePositions(
     }
   }
 
-  // Stock: stacked face-down, depth offset goes UPWARD so stack doesn't cover the label
+  // Stock: stacked face-down, depth goes LEFT so stack doesn't cover pyramid cards above.
+  // stock[0] is the next card drawn (logical top) → depth=0, highest z, no offset.
   const n = s.stock.length;
   s.stock.forEach((card, i) => {
-    const depth = n - 1 - i;   // 0 for top card, n-1 for bottom
+    const depth = i;           // 0 = top card (stock[0]), n-1 = bottom
     result[card.id] = {
-      x: STOCK_X + depth * 0.5,
-      y: PILE_Y  - depth * 0.5,
-      z: 100 + i,
+      x: STOCK_X - depth * 0.5,
+      y: PILE_Y,
+      z: 100 + (n - 1 - i),   // stock[0] gets highest z
       faceDown: true,
       rotation: 0,
       transitionMs: ms,
     };
   });
 
-  // Waste: stacked face-up, same depth trick (upward)
+  // Waste: stacked face-up, depth goes LEFT.
+  // waste[wn-1] is the top card (most recently drawn) → depth=0, highest z.
   const wn = s.waste.length;
   s.waste.forEach((card, i) => {
     const depth = wn - 1 - i;
     result[card.id] = {
-      x: WASTE_X + depth * 0.5,
-      y: PILE_Y  - depth * 0.5,
+      x: WASTE_X - depth * 0.5,
+      y: PILE_Y,
       z: 200 + i,
       faceDown: false,
       rotation: 0,
@@ -256,11 +258,11 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
     const total = cards.length;
     const half = Math.floor(total / 2);
 
-    // Start: all cards stacked at stock, no transition
+    // Start: all cards stacked at stock, depth goes LEFT, no transition
     const init: Record<string, CardVisualState> = {};
     cards.forEach((c, i) => {
       const d = total - 1 - i;
-      init[c.id] = { x: STOCK_X + d * 0.3, y: PILE_Y - d * 0.3, z: 100 + i, rotation: 0, faceDown: true, transitionMs: 0 };
+      init[c.id] = { x: STOCK_X - d * 0.3, y: PILE_Y, z: 100 + i, rotation: 0, faceDown: true, transitionMs: 0 };
     });
     setCardStates(init);
 
@@ -274,8 +276,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
           const len = isLeft ? half : total - half;
           const d = len - 1 - pos;
           split[c.id] = {
-            x: (isLeft ? STOCK_X - 24 : STOCK_X + 24) + d * 0.3,
-            y: PILE_Y - d * 0.3,
+            x: (isLeft ? STOCK_X - 24 : STOCK_X + 24) + (isLeft ? -d : d) * 0.3,
+            y: PILE_Y,
             z: 100 + i,
             rotation: isLeft ? -3 : 3,
             faceDown: true,
@@ -289,8 +291,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
           cards.forEach((c, i) => {
             const d = total - 1 - i;
             merged[c.id] = {
-              x: STOCK_X + d * 0.3,
-              y: PILE_Y - d * 0.3,
+              x: STOCK_X - d * 0.3,
+              y: PILE_Y,
               z: 100 + i,
               rotation: 0,
               faceDown: true,
@@ -309,10 +311,10 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
       shufflePass(0, () => {
         after(60, () => {
           const deal: Record<string, CardVisualState> = {};
-          // Stock cards snap to final pile positions (no transition)
+          // Stock cards snap to final pile positions (no transition).
+          // stock[0] = logical top: depth=0, highest z, no offset.
           s.stock.forEach((card, i) => {
-            const d = s.stock.length - 1 - i;
-            deal[card.id] = { x: STOCK_X + d * 0.5, y: PILE_Y - d * 0.5, z: 100 + i, faceDown: true, rotation: 0, transitionMs: 0 };
+            deal[card.id] = { x: STOCK_X - i * 0.5, y: PILE_Y, z: 100 + (s.stock.length - 1 - i), faceDown: true, rotation: 0, transitionMs: 0 };
           });
           // Pyramid cards fly to grid positions with stagger (apex first)
           s.slots.forEach(slot => {

--- a/src/experiences/Cards/Pyramid.tsx
+++ b/src/experiences/Cards/Pyramid.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import "./Pyramid.css";
-import { PlayingCard } from "./PlayingCard";
+import { PermCard } from "./PermCard";
+import type { CardVisualState } from "./cardStack";
 import type { Card, CardAppearance, DeckSettings } from "./types";
 import { buildDeck } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
@@ -18,9 +19,16 @@ const V_STEP = 34; // vertical distance between row tops (overlap)
 const BASE_ROW_W = ROWS * CARD_W + (ROWS - 1) * H_GAP; // 388
 const GRID_H = (ROWS - 1) * V_STEP + CARD_H;            // 276
 
-// Stage dimensions for scale calculation (table width + horizontal padding; height is approximate)
-const STAGE_W = BASE_ROW_W + 16;  // 404 — table padding 8px each side
-const STAGE_H = GRID_H + CARD_H + 40 + 28;  // grid + piles + gaps + padding ≈ 416
+const STAGE_W = BASE_ROW_W + 32;   // 420
+const PYRAMID_TOP = 20;
+const STAGE_H = PYRAMID_TOP + GRID_H + 28 + CARD_H + 24;  // ~440
+
+// Pile centers (x is card center, y is card center)
+const PILE_Y = PYRAMID_TOP + GRID_H + 28 + CARD_H / 2;
+const STOCK_X = STAGE_W / 2 - 44;
+const WASTE_X = STAGE_W / 2 + 44;
+const REMOVE_X = STAGE_W + 300;   // far off-screen right
+const REMOVE_Y = PILE_Y;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -38,14 +46,15 @@ function pyramidValue(card: Card): number {
   return parseInt(card.rank as string, 10);
 }
 
+// Card center helpers (return CENTER of card, not top-left)
 function cardX(row: number, col: number): number {
   const rowW = row * CARD_W + (row - 1) * H_GAP;
-  const startX = (BASE_ROW_W - rowW) / 2;
-  return startX + col * (CARD_W + H_GAP);
+  const startX = (STAGE_W - rowW) / 2;
+  return startX + col * (CARD_W + H_GAP) + CARD_W / 2;
 }
 
 function cardY(row: number): number {
-  return (row - 1) * V_STEP;
+  return PYRAMID_TOP + (row - 1) * V_STEP + CARD_H / 2;
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -57,7 +66,7 @@ interface PyramidSlot {
   removed: boolean;
 }
 
-type GamePhase = "playing" | "won" | "lost";
+type GamePhase = "dealing" | "playing" | "won" | "lost";
 
 interface PyramidState {
   slots: PyramidSlot[];
@@ -114,6 +123,71 @@ function checkLost(state: PyramidState): boolean {
   return true;
 }
 
+// ── computePositions ─────────────────────────────────────────────────────────
+
+function computePositions(
+  s: PyramidState,
+  peekedId: string | null,
+  ms: number
+): Record<string, CardVisualState> {
+  const result: Record<string, CardVisualState> = {};
+
+  // Pyramid slots
+  for (const slot of s.slots) {
+    if (slot.removed) {
+      result[slot.card.id] = {
+        x: REMOVE_X,
+        y: REMOVE_Y,
+        z: 50,
+        rotation: 12,
+        faceDown: false,
+        transitionMs: ms,
+      };
+    } else {
+      const isPeeked = peekedId === slot.card.id;
+      const isSelected = s.selected === slot.card.id;
+      result[slot.card.id] = {
+        x: cardX(slot.row, slot.col),
+        y: cardY(slot.row) - (isSelected ? 8 : 0),
+        z: (slot.row * 10 + slot.col) + (isPeeked ? 5000 : 0),
+        faceDown: false,
+        rotation: 0,
+        transitionMs: isPeeked ? 0 : ms,
+      };
+    }
+  }
+
+  // Stock: stacked face-down, each card slightly offset so depth is visible
+  const n = s.stock.length;
+  s.stock.forEach((card, i) => {
+    const depth = n - 1 - i;   // 0 for top card, n-1 for bottom
+    result[card.id] = {
+      x: STOCK_X + depth * 0.5,
+      y: PILE_Y  + depth * 0.5,
+      z: 100 + i,
+      faceDown: true,
+      rotation: 0,
+      transitionMs: ms,
+    };
+  });
+
+  // Waste: stacked face-up, same depth trick
+  const wn = s.waste.length;
+  s.waste.forEach((card, i) => {
+    const depth = wn - 1 - i;
+    result[card.id] = {
+      x: WASTE_X + depth * 0.5,
+      y: PILE_Y  + depth * 0.5,
+      z: 200 + i,
+      faceDown: false,
+      rotation: 0,
+      transitionMs: ms,
+    };
+  });
+
+  return result;
+}
+
 // ── Component ────────────────────────────────────────────────────────────────
 
 interface PyramidProps {
@@ -125,12 +199,18 @@ interface PyramidProps {
 const PYR_SAVE_KEY = "cards-pyramid-save";
 
 export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
+  const [allCards, setAllCards] = useState<Card[]>([]);
+  const [cardStates, setCardStates] = useState<Record<string, CardVisualState>>({});
+  const [peekedCardId, setPeekedCardId] = useState<string | null>(null);
+
   const [state, setState] = useState<PyramidState>(() => {
     try {
       const raw = localStorage.getItem(PYR_SAVE_KEY);
       if (raw) {
         const saved = JSON.parse(raw) as { version: number; state: PyramidState };
-        if (saved?.version === 1 && saved.state?.slots) return saved.state;
+        if (saved?.version === 1 && saved.state?.slots) {
+          return { ...saved.state, phase: saved.state.phase === "dealing" ? "playing" : saved.state.phase };
+        }
       }
     } catch {}
     return buildPyramid(settings);
@@ -139,6 +219,12 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearTimers = useCallback(() => { timers.current.forEach(clearTimeout); timers.current = []; }, []);
+  function after(ms: number, fn: () => void) { timers.current.push(setTimeout(fn, ms)); }
+
+  // ── Scale to fit container ──────────────────────────────────────────────────
 
   useEffect(() => {
     const el = containerRef.current;
@@ -151,20 +237,150 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
     return () => obs.disconnect();
   }, []);
 
+  // ── Persistence ─────────────────────────────────────────────────────────────
+
   useEffect(() => {
     if (state.phase === "won" || state.phase === "lost") {
       try { localStorage.removeItem(PYR_SAVE_KEY); } catch {}
       return;
     }
+    if (state.phase === "dealing") return;
     try {
       localStorage.setItem(PYR_SAVE_KEY, JSON.stringify({ version: 1, state }));
     } catch {}
   }, [state]);
 
+  // ── Deal animation helper ───────────────────────────────────────────────────
+
+  function dealAnimation(s: PyramidState, cards: Card[]): void {
+    // All cards start at stock position, face-down, no transition
+    const init: Record<string, CardVisualState> = {};
+    for (const c of cards) {
+      init[c.id] = { x: STOCK_X, y: PILE_Y, z: 100, rotation: 0, faceDown: true, transitionMs: 0 };
+    }
+    setCardStates(init);
+
+    after(60, () => {
+      // Animate pyramid cards to their positions with stagger
+      const deal: Record<string, CardVisualState> = { ...init };
+      for (const slot of s.slots) {
+        const staggerIdx = (slot.row - 1) * 7 + slot.col;
+        deal[slot.card.id] = {
+          x: cardX(slot.row, slot.col),
+          y: cardY(slot.row),
+          z: slot.row * 10 + slot.col,
+          faceDown: false,
+          rotation: 0,
+          transitionMs: 280,
+          transitionDelay: staggerIdx * 35,
+        };
+      }
+      // Stock cards stay put (already at stock position)
+      s.stock.forEach((card, i) => {
+        const depth = s.stock.length - 1 - i;
+        deal[card.id] = {
+          x: STOCK_X + depth * 0.5,
+          y: PILE_Y + depth * 0.5,
+          z: 100 + i,
+          faceDown: true,
+          rotation: 0,
+          transitionMs: 0,
+        };
+      });
+      setCardStates(deal);
+
+      const totalDelay = 28 * 35 + 280 + 80;
+      after(totalDelay, () => {
+        setState(prev => ({ ...prev, phase: "playing" }));
+        // Let the useEffect below sync final positions cleanly
+      });
+    });
+  }
+
+  // ── newGame ─────────────────────────────────────────────────────────────────
+
   const newGame = useCallback(() => {
+    clearTimers();
     try { localStorage.removeItem(PYR_SAVE_KEY); } catch {}
-    setState(buildPyramid(settings));
-  }, [settings]);
+    const s = buildPyramid(settings);
+    const cards = [...s.slots.map(sl => sl.card), ...s.stock];
+    setAllCards(cards);
+    setPeekedCardId(null);
+    const dealingState: PyramidState = { ...s, phase: "dealing" };
+    setState(dealingState);
+    dealAnimation(s, cards);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings, clearTimers]);
+
+  // ── Initial load ────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const raw = localStorage.getItem(PYR_SAVE_KEY);
+    let restoredState: PyramidState | null = null;
+    try {
+      if (raw) {
+        const saved = JSON.parse(raw) as { version: number; state: PyramidState };
+        if (saved?.version === 1 && saved.state?.slots) {
+          restoredState = { ...saved.state, phase: "playing" };
+        }
+      }
+    } catch {}
+
+    if (restoredState) {
+      const s = restoredState;
+      const cards = [...s.slots.map(sl => sl.card), ...s.stock, ...s.waste];
+      setAllCards(cards);
+      setPeekedCardId(null);
+      setState({ ...s, phase: "dealing" });
+
+      // Deal animation for restore
+      const init: Record<string, CardVisualState> = {};
+      for (const c of cards) {
+        init[c.id] = { x: STOCK_X, y: PILE_Y, z: 100, rotation: 0, faceDown: true, transitionMs: 0 };
+      }
+      setCardStates(init);
+
+      after(60, () => {
+        const finalPositions = computePositions({ ...s, phase: "playing" }, null, 260);
+        // Add stagger for pyramid cards
+        s.slots.forEach(slot => {
+          if (!slot.removed && finalPositions[slot.card.id]) {
+            const staggerIdx = (slot.row - 1) * 7 + slot.col;
+            finalPositions[slot.card.id] = {
+              ...finalPositions[slot.card.id],
+              transitionDelay: staggerIdx * 30,
+            };
+          }
+        });
+        setCardStates(finalPositions);
+        const totalDelay = 28 * 30 + 260 + 80;
+        after(totalDelay, () => {
+          setState(prev => ({ ...prev, phase: "playing" }));
+        });
+      });
+    } else {
+      const s = buildPyramid(settings);
+      const cards = [...s.slots.map(sl => sl.card), ...s.stock];
+      setAllCards(cards);
+      setPeekedCardId(null);
+      const dealingState: PyramidState = { ...s, phase: "dealing" };
+      setState(dealingState);
+      dealAnimation(s, cards);
+    }
+
+    return clearTimers;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync positions on every state change ────────────────────────────────────
+
+  useEffect(() => {
+    if (allCards.length === 0) return;
+    if (state.phase === "dealing") return;  // deal animation manages positions
+    setCardStates(computePositions(state, peekedCardId, 200));
+  }, [state, peekedCardId, allCards.length]);
+
+  // ── drawFromStock ───────────────────────────────────────────────────────────
 
   const drawFromStock = useCallback(() => {
     setState((s: PyramidState) => {
@@ -175,6 +391,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
       return checkLost(next) ? { ...next, phase: "lost" } : next;
     });
   }, []);
+
+  // ── selectCard ──────────────────────────────────────────────────────────────
 
   const selectCard = useCallback((cardId: string, fromWaste: boolean) => {
     setState((s: PyramidState) => {
@@ -240,17 +458,10 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
 
   // ── Derived values ────────────────────────────────────────────────────────
 
-  const availableIds = useMemo(
-    () => new Set(state.slots.filter((s) => isAvailable(s, state.slots)).map((s) => s.card.id)),
-    [state.slots]
-  );
-
-  const wasteTop = last<Card>(state.waste);
-  const pyramidDone = state.slots.every((s) => s.removed);
-
   function statusText(): string {
     if (state.phase === "won") return "You cleared the pyramid!";
     if (state.phase === "lost") return "No moves remaining.";
+    if (state.phase === "dealing") return "Dealing…";
     return `${state.removedCount} removed · ${state.stock.length} in stock`;
   }
 
@@ -272,6 +483,8 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
 
   // ── Render ────────────────────────────────────────────────────────────────
 
+  const wasteTop = last<Card>(state.waste);
+
   return (
     <div className="pyramid">
       {showDeckModal && (
@@ -281,73 +494,100 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
           onClose={() => setShowDeckModal(false)}
         />
       )}
-      <div className="pyramid__stage-container" ref={containerRef} style={{ height: Math.round(STAGE_H * scale) }}>
-      <div className="pyramid__table" style={{ width: STAGE_W, transform: scale < 1 ? `scale(${scale})` : undefined, transformOrigin: "top left" }}>
-        {!pyramidDone && (
-          <div className="pyramid__grid" style={{ width: BASE_ROW_W, height: GRID_H }}>
-            {state.slots.map((slot) => {
-              const avail = availableIds.has(slot.card.id);
-              const selected = state.selected === slot.card.id;
-              const cls = [
-                "pyramid__card-wrap",
-                slot.removed ? "pyramid__card-wrap--removed"     : "",
-                !avail       ? "pyramid__card-wrap--unavailable" : "",
-                selected     ? "pyramid__card-wrap--selected"    : "",
-              ].join(" ");
-              return (
-                <div
-                  key={slot.card.id}
-                  className={cls}
-                  style={{ left: cardX(slot.row, slot.col), top: cardY(slot.row) }}
-                  onClick={() => avail && selectCard(slot.card.id, false)}
-                >
-                  <PlayingCard card={slot.card} size="sm" appearance={appearance} />
-                </div>
-              );
-            })}
+      <div
+        className="pyramid__stage-container"
+        ref={containerRef}
+        style={{ height: Math.round(STAGE_H * scale) }}
+      >
+        <div
+          className="pyramid__stage"
+          style={{
+            width: STAGE_W,
+            height: STAGE_H,
+            transform: scale < 1 ? `scale(${scale})` : undefined,
+            transformOrigin: "top left",
+          }}
+          onPointerUp={() => setPeekedCardId(null)}
+        >
+          {/* Pile slot outlines */}
+          <div
+            className="pyramid__pile-slot"
+            style={{ left: STOCK_X - CARD_W / 2, top: PILE_Y - CARD_H / 2 }}
+          >
+            {state.stock.length === 0 && <span className="pyramid__pile-icon">↺</span>}
           </div>
-        )}
+          <div
+            className="pyramid__pile-slot"
+            style={{ left: WASTE_X - CARD_W / 2, top: PILE_Y - CARD_H / 2 }}
+          />
 
-        <div className="pyramid__piles">
-          <div className="pyramid__pile">
-            <div className="pyramid__pile-label">Stock</div>
-            <div className="pyramid__stock-card" onClick={drawFromStock}>
-              {state.stock.length > 0
-                ? <PlayingCard card={state.stock[0]} faceDown size="sm" appearance={appearance} />
-                : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />
-              }
-            </div>
-            <div className="pyramid__pile-count">{state.stock.length}</div>
+          {/* Pile count labels */}
+          <div
+            className="pyramid__pile-label-abs"
+            style={{ left: STOCK_X, top: PILE_Y + CARD_H / 2 + 3 }}
+          >
+            Stock · {state.stock.length}
+          </div>
+          <div
+            className="pyramid__pile-label-abs"
+            style={{ left: WASTE_X, top: PILE_Y + CARD_H / 2 + 3 }}
+          >
+            Waste · {state.waste.length}
           </div>
 
-          <div className="pyramid__pile">
-            <div className="pyramid__pile-label">Waste</div>
-            {wasteTop
-              ? (
-                <div
-                  className={state.selected === wasteTop.id
-                    ? "pyramid__card-wrap pyramid__card-wrap--selected"
-                    : "pyramid__card-wrap"}
-                  style={{ position: "relative" }}
-                  onClick={() => selectCard(wasteTop.id, true)}
-                >
-                  <PlayingCard card={wasteTop} size="sm" appearance={appearance} />
-                </div>
-              )
-              : <div className="playing-card--empty" style={{ width: 52, height: 72 }} />
-            }
-            <div className="pyramid__pile-count">{state.waste.length}</div>
-          </div>
+          {/* All cards as PermCards */}
+          {allCards.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            const slot = state.slots.find(sl => sl.card.id === card.id);
+            const inPyramid = !!slot && !slot.removed;
+            const avail = inPyramid ? isAvailable(slot, state.slots) : false;
+            const isSelected = state.selected === card.id;
+            const canAct = state.phase === "playing";
+            return (
+              <PermCard
+                key={card.id}
+                card={card}
+                cs={cs}
+                appearance={appearance}
+                size="sm"
+                highlightColor={isSelected ? "#ffdd00" : undefined}
+                onClick={canAct && avail ? () => selectCard(card.id, false) : undefined}
+                onPointerDown={canAct && inPyramid && !avail
+                  ? () => setPeekedCardId(card.id)
+                  : undefined}
+              />
+            );
+          })}
+
+          {/* Waste hit area — top waste card selectable */}
+          {state.phase === "playing" && wasteTop && (
+            <div
+              className="pyramid__hit-area"
+              style={{ left: WASTE_X - CARD_W / 2, top: PILE_Y - CARD_H / 2 }}
+              onClick={() => selectCard(wasteTop.id, true)}
+            />
+          )}
+
+          {/* Stock hit area */}
+          {state.phase === "playing" && (
+            <div
+              className="pyramid__hit-area"
+              style={{ left: STOCK_X - CARD_W / 2, top: PILE_Y - CARD_H / 2 }}
+              onClick={drawFromStock}
+            />
+          )}
         </div>
-      </div>
       </div>
 
       <div className="pyramid__controls">
-        <div className={`pyramid__status${state.phase === "won" ? " pyramid__status--win" : state.phase === "lost" ? " pyramid__status--lose" : ""}`}>
+        <div
+          className={`pyramid__status${state.phase === "won" ? " pyramid__status--win" : state.phase === "lost" ? " pyramid__status--lose" : ""}`}
+        >
           {statusText()}
         </div>
         <div className="pyramid__btn-row">
-          {state.phase !== "playing" && (
+          {(state.phase === "won" || state.phase === "lost") && (
             <button className="pyramid__btn pyramid__btn--primary" onClick={newGame}>
               New Game
             </button>
@@ -357,9 +597,11 @@ export default function Pyramid({ settings, onNewGame, onQuit }: PyramidProps) {
               Restart
             </button>
           )}
-          {state.selected && (
-            <button className="pyramid__btn pyramid__btn--secondary"
-              onClick={() => setState((s) => ({ ...s, selected: null }))}>
+          {state.selected && state.phase === "playing" && (
+            <button
+              className="pyramid__btn pyramid__btn--secondary"
+              onClick={() => setState((s) => ({ ...s, selected: null }))}
+            >
               Deselect
             </button>
           )}

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -58,9 +58,10 @@
   color: rgba(255,255,255,0.55);
 }
 
-/* Flipped card revealed in battle */
+/* Flipped card revealed in battle — key changes each round, triggering the animation */
 .war__flipped {
   margin-top: 6px;
+  animation: card-reveal 0.28s ease forwards;
 }
 
 /* War cards row (face-down × 3 + face-up) */

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -1,4 +1,4 @@
-/* ─── War ───────────────────────────────────────────────────────────── */
+/* ─── War ────────────────────────────────────────────────────────────── */
 
 .war {
   display: flex;
@@ -7,6 +7,7 @@
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
   user-select: none;
+  min-height: 340px;
 }
 
 .war__scoreboard {
@@ -17,91 +18,140 @@
   font-size: 7px;
   color: #000;
   border-bottom: 1px solid #808080;
+  flex-shrink: 0;
 }
 
-.war__table {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  padding: 12px 10px;
-  gap: 8px;
+/* ── Stage ──────────────────────────────────────────────────────────── */
+
+.war__stage {
+  position: relative;
+  height: 240px;
   background: #1a4a1a;
   border: 2px solid;
   border-color: #808080 #ffffff #ffffff #808080;
   margin: 8px 8px 4px;
-  min-height: 200px;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
-/* Side columns (player / dealer) */
-.war__side {
+/* ── Stacked pile ────────────────────────────────────────────────────── */
+
+.war__stack {
+  position: relative;
+  width: 72px;
+  height: 100px;
+}
+
+.war__stack-layer {
+  position: absolute;
+}
+
+.war__empty-slot {
+  width: 72px;
+  height: 100px;
+  border: 2px dashed rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+/* ── Pile positioned within stage ────────────────────────────────────── */
+
+.war__pile {
+  position: absolute;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  flex: 1;
+  gap: 5px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
-.war__side-label {
+.war__pile--player {
+  left: 40px;
+}
+
+.war__pile--dealer {
+  right: 40px;
+}
+
+.war__pile-label {
   font-size: 7px;
-  color: rgba(255,255,255,0.6);
-}
-
-.war__pile-stack {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .war__pile-count {
-  font-size: 7px;
-  color: rgba(255,255,255,0.55);
+  font-size: 6px;
+  color: rgba(255, 255, 255, 0.4);
+  margin-top: 2px;
 }
 
-/* Flipped card revealed in battle — key changes each round, triggering the animation */
-@keyframes war-flip-in {
-  0%   { transform: perspective(400px) rotateY(-90deg) scale(0.85); opacity: 0.3; }
-  100% { transform: perspective(400px) rotateY(0deg) scale(1); opacity: 1; }
+/* ── VS label ────────────────────────────────────────────────────────── */
+
+.war__vs-label {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 2px;
+  pointer-events: none;
 }
 
-.war__flipped {
-  margin-top: 6px;
-  animation: war-flip-in 320ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
-}
+/* ── Shuffle animation ───────────────────────────────────────────────── */
 
-/* War cards row (face-down × 3 + face-up) */
-.war__war-cards {
+.war__shuffle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
-  gap: -8px;
-  align-items: flex-end;
+  gap: 4px;
 }
 
-.war__war-cards > * + * {
-  margin-left: -8px;
+.war__shuffle-half {
+  position: relative;
 }
 
-/* Center column */
-.war__center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-top: 40px;
-  min-width: 40px;
+@keyframes war-shuffle-left {
+  0%   { transform: translateX(0) rotate(0deg); }
+  12%  { transform: translateX(-38px) rotate(-7deg); }
+  40%  { transform: translateX(-38px) rotate(-7deg); }
+  55%  { transform: translateX(0) rotate(0deg); }
+  65%  { transform: translateX(-30px) rotate(-5deg); }
+  82%  { transform: translateX(-30px) rotate(-5deg); }
+  95%  { transform: translateX(0) rotate(0deg); }
+  100% { transform: translateX(0) rotate(0deg); }
 }
 
-.war__vs {
-  font-size: 9px;
-  color: rgba(255,255,255,0.4);
-  letter-spacing: 1px;
+@keyframes war-shuffle-right {
+  0%   { transform: translateX(0) rotate(0deg); }
+  12%  { transform: translateX(38px) rotate(7deg); }
+  40%  { transform: translateX(38px) rotate(7deg); }
+  55%  { transform: translateX(0) rotate(0deg); }
+  65%  { transform: translateX(30px) rotate(5deg); }
+  82%  { transform: translateX(30px) rotate(5deg); }
+  95%  { transform: translateX(0) rotate(0deg); }
+  100% { transform: translateX(0) rotate(0deg); }
 }
 
-/* Controls */
+.war__shuffle-half--l {
+  animation: war-shuffle-left 1.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.war__shuffle-half--r {
+  animation: war-shuffle-right 1.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+/* ── Controls ────────────────────────────────────────────────────────── */
+
 .war__controls {
-  padding: 8px 10px 10px;
+  padding: 6px 10px 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
+  flex-shrink: 0;
 }
 
 .war__banner {
@@ -109,6 +159,12 @@
   padding: 5px 12px;
   border: 2px solid;
   text-align: center;
+  animation: war-banner-in 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
+@keyframes war-banner-in {
+  from { transform: translateY(-6px) scale(0.92); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
 }
 
 .war__banner--win  { color: #44cc44; border-color: #44cc44; background: rgba(68,204,68,0.1); }
@@ -123,7 +179,7 @@
 .war__btn {
   font-family: "Press Start 2P", monospace;
   font-size: 8px;
-  padding: 6px 12px;
+  padding: 6px 14px;
   border: 2px solid;
   cursor: pointer;
 }
@@ -133,16 +189,9 @@
   color: #fff;
   border-color: #ffcc88 #664400 #664400 #ffcc88;
 }
-.war__btn--primary:hover  { background: #ee5500; }
-.war__btn--primary:active { border-color: #664400 #ffcc88 #ffcc88 #664400; }
+.war__btn--primary:hover   { background: #ee5500; }
+.war__btn--primary:active  { border-color: #664400 #ffcc88 #ffcc88 #664400; }
 .war__btn--primary:disabled { background: #884400; cursor: default; }
-
-.war__btn--secondary {
-  background: #c0c0c0;
-  color: #000;
-  border-color: #ffffff #808080 #808080 #ffffff;
-}
-.war__btn--secondary:active { border-color: #808080 #ffffff #ffffff #808080; }
 
 .war__auto-notice {
   font-size: 7px;

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -23,15 +23,20 @@
 
 /* ── Stage ──────────────────────────────────────────────────────────── */
 
-.war__stage {
-  position: relative;
-  height: 240px;
-  background: #1a4a1a;
-  border: 2px solid;
-  border-color: #808080 #ffffff #ffffff #808080;
+.war__stage-container {
   margin: 8px 8px 4px;
   overflow: hidden;
   flex-shrink: 0;
+}
+
+.war__stage {
+  position: relative;
+  background: #1a4a1a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  box-sizing: border-box;
+  overflow: hidden;
+  isolation: isolate;
 }
 
 /* ── Stacked pile ────────────────────────────────────────────────────── */

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -59,9 +59,14 @@
 }
 
 /* Flipped card revealed in battle — key changes each round, triggering the animation */
+@keyframes war-flip-in {
+  0%   { transform: perspective(400px) rotateY(-90deg) scale(0.85); opacity: 0.3; }
+  100% { transform: perspective(400px) rotateY(0deg) scale(1); opacity: 1; }
+}
+
 .war__flipped {
   margin-top: 6px;
-  animation: card-reveal 0.28s ease forwards;
+  animation: war-flip-in 320ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
 }
 
 /* War cards row (face-down × 3 + face-up) */

--- a/src/experiences/Cards/War.css
+++ b/src/experiences/Cards/War.css
@@ -107,6 +107,7 @@
   transform: translate(-50%, -50%);
   display: flex;
   gap: 4px;
+  z-index: 1000;
 }
 
 .war__shuffle-half {

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./War.css";
 import { PlayingCard } from "./PlayingCard";
@@ -8,7 +8,7 @@ import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 const RANK_ORDER = ["2","3","4","5","6","7","8","9","10","J","Q","K","A"] as const;
 
@@ -17,57 +17,134 @@ function warValue(card: Card): number {
   return RANK_ORDER.indexOf(card.rank as typeof RANK_ORDER[number]);
 }
 
-const WAR_SPEED_MS: Record<string, number> = {
-  slow: 2000,
-  normal: 900,
-  fast: 250,
+function rnd(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+// ── Stage positions (center coords in px) ────────────────────────────────────
+
+// Stage inner width ≈ 416px (440px window − chrome − margin − border)
+// Player pile: left: 40px → center at 40+36 = 76
+// Dealer pile: right: 40px → center at 416−40−36 = 340
+const P = {
+  player:       { x:  76, y: 108 },
+  dealer:       { x: 340, y: 108 },
+  deck:         { x: 208, y: 108 },
+  playerBattle: { x: 155, y: 108 },
+  dealerBattle: { x: 261, y: 108 },
+  war:          { x: 208, y: 108 },
+} as const;
+
+const CARD_W = 72;
+const CARD_H = 100;
+
+// ── Timing base values (ms) ───────────────────────────────────────────────────
+
+const TB = {
+  SHUFFLE:   1600,
+  DEAL_FLY:    85,
+  DEAL_GAP:   110,
+  DEAL_N:       6,   // sprites per side
+  FLY:         360,
+  JUDGE:       300,
+  RESULT:      480,
+  COLLECT:     340,
+  WAR_TEXT:    650,
+  WAR_FLY:     280,
+  WAR_GAP:     160,
 };
-const GAME_OVER_DELAY_MS = 2500;
 
-// ── Types ────────────────────────────────────────────────────────────────────
+const WAR_SPEED_MS: Record<string, number> = { slow: 2000, normal: 900, fast: 250 };
+const ANIM_MULT: Record<string, number>    = { slow: 1.35, normal: 1.0, fast: 0.5 };
 
-type Phase =
-  | "ready"       // waiting to flip
-  | "revealed"    // cards flipped, showing result
-  | "war-ready"   // tie — waiting to place war cards
-  | "war-revealed"// war cards flipped
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type AnimPhase =
+  | "shuffle" | "dealing" | "idle"
+  | "flying" | "result" | "collecting"
+  | "war-text" | "war-flying" | "war-result" | "war-collecting"
   | "game-over";
 
-interface WarState {
-  playerPile: Card[];
-  dealerPile: Card[];
-  playerCard: Card | null;
-  dealerCard: Card | null;
-  warPlayerCards: Card[];  // face-down war cards
-  warDealerCards: Card[];
-  warPlayerFinal: Card | null;
-  warDealerFinal: Card | null;
-  phase: Phase;
-  roundResult: "player" | "dealer" | "war" | null;
-  gameResult: "player" | "dealer" | null;
-  roundCount: number;
+interface Sprite {
+  id: string;
+  card: Card;
+  x: number;       // center-x
+  y: number;       // center-y
+  rot: number;
+  scale: number;
+  opacity: number;
+  faceDown: boolean;
+  posMs: number;   // position transition duration
+  zIndex: number;
+  side: "player" | "dealer";
+  isDecider?: boolean;
 }
 
-function makeInitialState(settings: DeckSettings): WarState {
-  const deck = buildDeck(settings);
-  const mid = Math.floor(deck.length / 2);
-  return {
-    playerPile: deck.slice(0, mid),
-    dealerPile: deck.slice(mid),
-    playerCard: null,
-    dealerCard: null,
-    warPlayerCards: [],
-    warDealerCards: [],
-    warPlayerFinal: null,
-    warDealerFinal: null,
-    phase: "ready",
-    roundResult: null,
-    gameResult: null,
-    roundCount: 0,
-  };
+// ── StackedPile ───────────────────────────────────────────────────────────────
+
+const DUMMY: Card = { id: "__dum", suit: "spades", rank: "2" };
+
+function StackedPile({ count, appearance }: { count: number; appearance: CardAppearance }) {
+  if (count === 0) return <div className="war__empty-slot" />;
+  const layers = Math.min(5, count);
+  return (
+    <div className="war__stack">
+      {Array.from({ length: layers }).map((_, i) => {
+        const d = layers - 1 - i;
+        return (
+          <div key={i} className="war__stack-layer" style={{ left: d * -1.5, top: d * 1.5, zIndex: i }}>
+            <PlayingCard card={DUMMY} faceDown appearance={appearance} />
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
-// ── Component ────────────────────────────────────────────────────────────────
+// ── FlippableSprite ───────────────────────────────────────────────────────────
+
+function FlippableSprite({ s, appearance }: { s: Sprite; appearance: CardAppearance }) {
+  return (
+    <div
+      key={s.id}
+      style={{
+        position:   "absolute",
+        left:       s.x - CARD_W / 2,
+        top:        s.y - CARD_H / 2,
+        width:      CARD_W,
+        height:     CARD_H,
+        zIndex:     s.zIndex,
+        opacity:    s.opacity,
+        transition: s.posMs > 0
+          ? `left ${s.posMs}ms ease-in-out, top ${s.posMs}ms ease-in-out, opacity 200ms ease`
+          : "opacity 200ms ease",
+      }}
+    >
+      <div style={{
+        width: "100%", height: "100%",
+        transform: `rotate(${s.rot}deg) scale(${s.scale})`,
+        transformOrigin: "center center",
+        transition: "transform 200ms ease-out",
+      }}>
+        <div className="flippable" style={{ width: CARD_W, height: CARD_H }}>
+          <div
+            className={`flippable__inner${!s.faceDown ? " flippable__inner--face-up" : ""}`}
+            style={{ transition: `transform ${Math.round(Math.max(200, s.posMs * 0.55))}ms ease-in-out` }}
+          >
+            <div className="flippable__face">
+              <PlayingCard card={s.card} faceDown appearance={appearance} />
+            </div>
+            <div className="flippable__face flippable__face--front">
+              <PlayingCard card={s.card} appearance={appearance} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── War component ─────────────────────────────────────────────────────────────
 
 interface WarProps {
   settings: DeckSettings;
@@ -76,359 +153,462 @@ interface WarProps {
 }
 
 export default function War({ settings, onNewGame, onQuit }: WarProps) {
-  const [state, setState] = useState<WarState>(() => makeInitialState(settings));
-  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
+  const [playerPile, setPlayerPile] = useState<Card[]>([]);
+  const [dealerPile, setDealerPile] = useState<Card[]>([]);
+  const [roundCount,  setRoundCount]  = useState(0);
+  const [roundResult, setRoundResult] = useState<"player" | "dealer" | "war" | null>(null);
+  const [gameResult,  setGameResult]  = useState<"player" | "dealer" | null>(null);
+  const [animPhase,   setAnimPhase]   = useState<AnimPhase>("shuffle");
+  const [sprites,     setSprites]     = useState<Sprite[]>([]);
+  const [warMsg,      setWarMsg]      = useState("");
+  const [shuffling,   setShuffling]   = useState(true);
+  const [appearance,  setAppearance]  = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
 
-  const autoPlay = settings.warAutoPlay;
-  const speedMs = WAR_SPEED_MS[settings.warSpeed] ?? 900;
+  // Stable refs for pile access inside timeouts
+  const playerPileRef = useRef<Card[]>([]);
+  const dealerPileRef = useRef<Card[]>([]);
+  playerPileRef.current = playerPile;
+  dealerPileRef.current = dealerPile;
 
-  // ── Core actions ──────────────────────────────────────────────────────────
+  // Timer management
+  const timerIds = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearTimers = useCallback(() => {
+    timerIds.current.forEach(clearTimeout);
+    timerIds.current = [];
+  }, []);
+  function after(ms: number, fn: () => void) {
+    const id = setTimeout(fn, ms);
+    timerIds.current.push(id);
+  }
+
+  // Speed helpers
+  const am = ANIM_MULT[settings.warSpeed] ?? 1.0;
+  function t(base: number) { return Math.round(base * am); }
+  const extraPause = Math.max(0, (WAR_SPEED_MS[settings.warSpeed] ?? 900) - t(800));
+
+  // Sprite helpers
+  function patchSprites(id: string, patch: Partial<Sprite>) {
+    setSprites(prev => prev.map(s => s.id === id ? { ...s, ...patch } : s));
+  }
+  function addSprite(sp: Sprite) {
+    setSprites(prev => [...prev, sp]);
+  }
+
+  // ── startGame ─────────────────────────────────────────────────────────────
+
+  const startGame = useCallback(() => {
+    clearTimers();
+    const deck = buildDeck(settings);
+    const mid = Math.floor(deck.length / 2);
+    const pCards = deck.slice(0, mid);
+    const dCards = deck.slice(mid);
+
+    setPlayerPile([]);
+    setDealerPile([]);
+    setRoundCount(0);
+    setRoundResult(null);
+    setGameResult(null);
+    setSprites([]);
+    setWarMsg("");
+    setShuffling(true);
+    setAnimPhase("shuffle");
+
+    after(TB.SHUFFLE, () => {
+      setShuffling(false);
+      setAnimPhase("dealing");
+
+      let flown = 0;
+      const n = TB.DEAL_N;
+
+      function dealNext() {
+        if (flown >= n * 2) {
+          after(t(TB.DEAL_FLY) + 60, () => {
+            setPlayerPile(pCards);
+            setDealerPile(dCards);
+            setSprites([]);
+            setAnimPhase("idle");
+          });
+          return;
+        }
+        const isPlayer = flown % 2 === 0;
+        const idx = Math.floor(flown / 2);
+        const card = isPlayer ? pCards[idx] : dCards[idx];
+        const dest = isPlayer ? P.player : P.dealer;
+        const sid = `deal-${flown}`;
+        const sp: Sprite = {
+          id: sid, card,
+          x: P.deck.x, y: P.deck.y,
+          rot: rnd(-4, 4), scale: 1, opacity: 1,
+          faceDown: true, posMs: 0,
+          zIndex: 80 + flown,
+          side: isPlayer ? "player" : "dealer",
+        };
+        addSprite(sp);
+        after(16, () => patchSprites(sid, { x: dest.x, y: dest.y, posMs: t(TB.DEAL_FLY) }));
+        flown++;
+        after(t(TB.DEAL_GAP), dealNext);
+      }
+
+      dealNext();
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings]);
+
+  useEffect(() => {
+    startGame();
+    return clearTimers;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── flip ─────────────────────────────────────────────────────────────────
 
   const flip = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "ready") return s;
-      if (s.playerPile.length === 0 || s.dealerPile.length === 0) return s;
+    const pp = playerPileRef.current;
+    const dp = dealerPileRef.current;
+    if (pp.length === 0 || dp.length === 0) return;
 
-      const [pc, ...pRest] = s.playerPile;
-      const [dc, ...dRest] = s.dealerPile;
-      const pv = warValue(pc);
-      const dv = warValue(dc);
+    const [pc, ...pRest] = pp;
+    const [dc, ...dRest] = dp;
+    const pv = warValue(pc);
+    const dv = warValue(dc);
+    const result: "player" | "dealer" | "war" =
+      pv > dv ? "player" : pv < dv ? "dealer" : "war";
 
-      const roundResult: "player" | "dealer" | "war" =
-        pv > dv ? "player" : pv < dv ? "dealer" : "war";
+    setPlayerPile(pRest);
+    setDealerPile(dRest);
+    setRoundCount(c => c + 1);
+    setRoundResult(result);
+    setAnimPhase("flying");
 
-      let playerPile = pRest;
-      let dealerPile = dRest;
+    const pSp: Sprite = { id: `pb-${pc.id}`, card: pc, x: P.player.x, y: P.player.y, rot: 0, scale: 1, opacity: 1, faceDown: true, posMs: 0, zIndex: 20, side: "player" };
+    const dSp: Sprite = { id: `db-${dc.id}`, card: dc, x: P.dealer.x, y: P.dealer.y, rot: 0, scale: 1, opacity: 1, faceDown: true, posMs: 0, zIndex: 21, side: "dealer" };
+    setSprites([pSp, dSp]);
 
-      if (roundResult === "player") {
-        playerPile = [...pRest, ...shuffle([pc, dc])];
-      } else if (roundResult === "dealer") {
-        dealerPile = [...dRest, ...shuffle([pc, dc])];
-      }
-      // war: cards go to warCards, resolved after war
-
-      return {
-        ...s,
-        playerPile,
-        dealerPile,
-        playerCard: pc,
-        dealerCard: dc,
-        roundResult,
-        phase: "revealed",
-        roundCount: s.roundCount + 1,
-      };
+    // Fly to battle positions
+    after(16, () => {
+      patchSprites(pSp.id, { x: P.playerBattle.x, y: P.playerBattle.y, posMs: t(TB.FLY) });
+      patchSprites(dSp.id, { x: P.dealerBattle.x, y: P.dealerBattle.y, posMs: t(TB.FLY) });
     });
+
+    // Mid-flight flip to face-up
+    after(t(TB.FLY) / 2, () => {
+      setSprites(prev => prev.map(s => ({ ...s, faceDown: false })));
+    });
+
+    // Show result effects after landing
+    after(t(TB.FLY) + t(TB.JUDGE), () => {
+      setAnimPhase("result");
+      if (result !== "war") {
+        setSprites(prev => prev.map(s => {
+          const wins = (result === "player") === (s.side === "player");
+          return { ...s, scale: wins ? 1.07 : 0.93, opacity: wins ? 1 : 0.5 };
+        }));
+      }
+    });
+
+    const afterResult = t(TB.FLY) + t(TB.JUDGE) + t(TB.RESULT);
+
+    if (result !== "war") {
+      after(afterResult, () => {
+        setAnimPhase("collecting");
+        const winPos = result === "player" ? P.player : P.dealer;
+        setSprites(prev => prev.map(s => ({
+          ...s, x: winPos.x, y: winPos.y,
+          rot: rnd(-6, 6), scale: 1, opacity: 0.75, posMs: t(TB.COLLECT),
+        })));
+        after(t(TB.COLLECT) + 60, () => {
+          const spoils = shuffle([pc, dc]);
+          if (result === "player") setPlayerPile(prev => [...prev, ...spoils]);
+          else setDealerPile(prev => [...prev, ...spoils]);
+          setSprites([]);
+
+          const newPp = result === "player" ? [...pRest, ...spoils] : pRest;
+          const newDp = result === "dealer" ? [...dRest, ...spoils] : dRest;
+          if (newPp.length === 0) { setGameResult("dealer"); setAnimPhase("game-over"); }
+          else if (newDp.length === 0) { setGameResult("player"); setAnimPhase("game-over"); }
+          else setAnimPhase("idle");
+        });
+      });
+    } else {
+      // War! Move battle cards to war pile, then fly more cards
+      after(afterResult, () => {
+        setAnimPhase("war-text");
+        setWarMsg("WAR!");
+        // Scatter existing battle cards to war center
+        setSprites(prev => prev.map((s, i) => ({
+          ...s,
+          x: P.war.x + (s.side === "player" ? -18 : 18),
+          y: P.war.y + rnd(-8, 8),
+          rot: rnd(-15, 15),
+          scale: 1, opacity: 1, posMs: t(200),
+          zIndex: 10 + i,
+        })));
+
+        after(t(TB.WAR_TEXT), () => {
+          setWarMsg("I DECLARE WAR");
+          doWarFly(pc, dc, pRest, dRest);
+        });
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const resolveRevealed = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "revealed") return s;
+  // ── doWarFly ─────────────────────────────────────────────────────────────
 
-      if (s.roundResult === "war") {
-        // Check if both players have cards for war (need at least 1 for face-up)
-        if (s.playerPile.length === 0) {
-          return { ...s, phase: "game-over", gameResult: "dealer" };
+  function doWarFly(pBattle: Card, dBattle: Card, pRest: Card[], dRest: Card[]) {
+    setAnimPhase("war-flying");
+
+    const pFdN = Math.min(3, Math.max(0, pRest.length - 1));
+    const dFdN = Math.min(3, Math.max(0, dRest.length - 1));
+    const pFaceDowns = pRest.slice(0, pFdN);
+    const pFaceUp    = pFdN < pRest.length ? pRest[pFdN] : null;
+    const pRemain    = pRest.slice(pFdN + (pFaceUp ? 1 : 0));
+
+    const dFaceDowns = dRest.slice(0, dFdN);
+    const dFaceUp    = dFdN < dRest.length ? dRest[dFdN] : null;
+    const dRemain    = dRest.slice(dFdN + (dFaceUp ? 1 : 0));
+
+    setPlayerPile(pRemain);
+    setDealerPile(dRemain);
+
+    let z = 30;
+    let delay = 0;
+
+    function flyWarCard(card: Card, side: "player" | "dealer", isDecider: boolean) {
+      const sid = `war-${side}-${card.id}`;
+      const startPos = side === "player" ? P.player : P.dealer;
+      const offX = rnd(-22, 22);
+      const offY = rnd(-14, 14);
+      const targetRot = rnd(-16, 16);
+      const curZ = z++;
+
+      after(delay, () => {
+        addSprite({
+          id: sid, card,
+          x: startPos.x, y: startPos.y,
+          rot: 0, scale: 1, opacity: 1,
+          faceDown: true, posMs: 0,
+          zIndex: curZ, side, isDecider,
+        });
+        after(16, () => patchSprites(sid, {
+          x: P.war.x + offX,
+          y: P.war.y + offY,
+          rot: targetRot,
+          posMs: t(TB.WAR_FLY),
+        }));
+        // Flip deciding card mid-flight
+        if (isDecider) {
+          after(t(TB.WAR_FLY) / 2, () => patchSprites(sid, { faceDown: false }));
         }
-        if (s.dealerPile.length === 0) {
-          return { ...s, phase: "game-over", gameResult: "player" };
-        }
-        return { ...s, phase: "war-ready" };
-      }
+      });
 
-      // Check game over
-      if (s.playerPile.length === 0) {
-        return { ...s, phase: "game-over", gameResult: "dealer" };
-      }
-      if (s.dealerPile.length === 0) {
-        return { ...s, phase: "game-over", gameResult: "player" };
-      }
+      delay += t(TB.WAR_GAP);
+    }
 
-      return { ...s, phase: "ready", playerCard: null, dealerCard: null };
+    const maxFd = Math.max(pFdN, dFdN);
+    for (let i = 0; i < maxFd; i++) {
+      if (i < pFaceDowns.length) flyWarCard(pFaceDowns[i], "player", false);
+      if (i < dFaceDowns.length) flyWarCard(dFaceDowns[i], "dealer", false);
+    }
+    if (pFaceUp) flyWarCard(pFaceUp, "player", true);
+    if (dFaceUp) flyWarCard(dFaceUp, "dealer", true);
+
+    // Determine war result
+    let warResult: "player" | "dealer";
+    if (!pFaceUp && !dFaceUp) {
+      warResult = Math.random() < 0.5 ? "player" : "dealer";
+    } else if (!pFaceUp) {
+      warResult = "dealer";
+    } else if (!dFaceUp) {
+      warResult = "player";
+    } else {
+      const pv = warValue(pFaceUp);
+      const dv = warValue(dFaceUp);
+      warResult = pv >= dv ? "player" : "dealer"; // tiebreaker: player
+    }
+
+    const afterFly = delay + t(TB.WAR_FLY) + t(TB.JUDGE);
+
+    after(afterFly, () => {
+      setRoundCount(c => c + 1);
+      setRoundResult(warResult);
+      setAnimPhase("war-result");
+
+      // Highlight deciders
+      setSprites(prev => prev.map(s => {
+        if (!s.isDecider) return s;
+        const wins = warResult === s.side;
+        return { ...s, scale: wins ? 1.07 : 0.93, opacity: wins ? 1 : 0.5 };
+      }));
+
+      after(t(TB.RESULT), () => {
+        setAnimPhase("war-collecting");
+        const winPos = warResult === "player" ? P.player : P.dealer;
+        setSprites(prev => prev.map(s => ({
+          ...s, x: winPos.x, y: winPos.y,
+          rot: rnd(-6, 6), scale: 1, opacity: 0.75, posMs: t(TB.COLLECT),
+        })));
+
+        after(t(TB.COLLECT) + 60, () => {
+          const allSpoils = shuffle([
+            pBattle, dBattle,
+            ...pFaceDowns, ...dFaceDowns,
+            ...(pFaceUp ? [pFaceUp] : []),
+            ...(dFaceUp ? [dFaceUp] : []),
+          ]);
+          if (warResult === "player") setPlayerPile(prev => [...prev, ...allSpoils]);
+          else setDealerPile(prev => [...prev, ...allSpoils]);
+          setSprites([]);
+          setWarMsg("");
+
+          const newPp = warResult === "player" ? [...pRemain, ...allSpoils] : pRemain;
+          const newDp = warResult === "dealer" ? [...dRemain, ...allSpoils] : dRemain;
+          if (newPp.length === 0) { setGameResult("dealer"); setAnimPhase("game-over"); }
+          else if (newDp.length === 0) { setGameResult("player"); setAnimPhase("game-over"); }
+          else setAnimPhase("idle");
+        });
+      });
     });
-  }, []);
-
-  const flipWar = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "war-ready") return s;
-
-      // Each player puts up to 3 face-down + 1 face-up
-      const pSlice = s.playerPile.length;
-      const dSlice = s.dealerPile.length;
-
-      const pFaceDownCount = Math.min(3, pSlice - 1);
-      const dFaceDownCount = Math.min(3, dSlice - 1);
-
-      const pFaceDown = s.playerPile.slice(0, pFaceDownCount);
-      const pFaceUp   = s.playerPile[pFaceDownCount] ?? null;
-      const pRemain   = s.playerPile.slice(pFaceDownCount + 1);
-
-      const dFaceDown = s.dealerPile.slice(0, dFaceDownCount);
-      const dFaceUp   = s.dealerPile[dFaceDownCount] ?? null;
-      const dRemain   = s.dealerPile.slice(dFaceDownCount + 1);
-
-      // All battle cards: original face-up + war face-down + war face-up
-      const allBattleCards = [
-        s.playerCard!, s.dealerCard!,
-        ...pFaceDown, ...dFaceDown,
-      ];
-
-      let playerPile = pRemain;
-      let dealerPile = dRemain;
-      let roundResult: "player" | "dealer" | "war" = "war";
-
-      if (!pFaceUp) {
-        roundResult = "dealer";
-        dealerPile = [...dRemain, ...shuffle([...allBattleCards, ...dFaceDown])];
-      } else if (!dFaceUp) {
-        roundResult = "player";
-        playerPile = [...pRemain, ...shuffle([...allBattleCards, ...pFaceDown])];
-      } else {
-        const pv = warValue(pFaceUp);
-        const dv = warValue(dFaceUp);
-        roundResult = pv > dv ? "player" : pv < dv ? "dealer" : "war";
-        const spoils = shuffle([...allBattleCards, pFaceUp, dFaceUp]);
-        if (roundResult === "player") playerPile = [...pRemain, ...spoils];
-        else if (roundResult === "dealer") dealerPile = [...dRemain, ...spoils];
-        // war again: cards stay off table until next war resolution
-      }
-
-      return {
-        ...s,
-        playerPile,
-        dealerPile,
-        warPlayerCards: pFaceDown,
-        warDealerCards: dFaceDown,
-        warPlayerFinal: pFaceUp,
-        warDealerFinal: dFaceUp,
-        roundResult,
-        phase: "war-revealed",
-        roundCount: s.roundCount + 1,
-      };
-    });
-  }, []);
-
-  const resolveWarRevealed = useCallback(() => {
-    setState((s) => {
-      if (s.phase !== "war-revealed") return s;
-
-      if (s.roundResult === "war") {
-        if (s.playerPile.length === 0) return { ...s, phase: "game-over", gameResult: "dealer" };
-        if (s.dealerPile.length === 0) return { ...s, phase: "game-over", gameResult: "player" };
-        return { ...s, phase: "war-ready" };
-      }
-      if (s.playerPile.length === 0) return { ...s, phase: "game-over", gameResult: "dealer" };
-      if (s.dealerPile.length === 0) return { ...s, phase: "game-over", gameResult: "player" };
-
-      return {
-        ...s,
-        phase: "ready",
-        playerCard: null,
-        dealerCard: null,
-        warPlayerCards: [],
-        warDealerCards: [],
-        warPlayerFinal: null,
-        warDealerFinal: null,
-        roundResult: null,
-      };
-    });
-  }, []);
-
-  const newGame = useCallback(() => {
-    setState(makeInitialState(settings));
-  }, [settings]);
+  }
 
   // ── Menus ─────────────────────────────────────────────────────────────────
 
-  const warMenus = useMemo<MenuBarMenu[]>(() => {
-    const items: MenuBarMenu["items"] = [
-      { label: "Restart", onClick: newGame },
+  const menus = useMemo<MenuBarMenu[]>(() => {
+    const gameItems: MenuBarMenu["items"] = [
+      { label: "Restart", onClick: startGame },
       ...(onNewGame ? [{ label: "New Game", onClick: onNewGame }] : []),
       ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
     ];
     return [
-      { label: "Game", items },
+      { label: "Game", items: gameItems },
       { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
-  }, [newGame, onNewGame, onQuit]);
+  }, [startGame, onNewGame, onQuit]);
 
-  useWindowMenus(warMenus);
+  useWindowMenus(menus);
 
   // ── Auto-play ─────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (!autoPlay) return;
+    if (!settings.warAutoPlay || animPhase !== "idle") return;
+    const id = setTimeout(flip, extraPause);
+    return () => clearTimeout(id);
+  }, [settings.warAutoPlay, animPhase, flip, extraPause]);
 
-    const advance = () => {
-      setState((s) => {
-        switch (s.phase) {
-          case "ready":       { flip(); return s; }
-          case "revealed":    { resolveRevealed(); return s; }
-          case "war-ready":   { flipWar(); return s; }
-          case "war-revealed":{ resolveWarRevealed(); return s; }
-          default: return s;
-        }
-      });
-    };
+  useEffect(() => {
+    if (!settings.warAutoPlay || animPhase !== "game-over") return;
+    const id = setTimeout(startGame, 2500);
+    return () => clearTimeout(id);
+  }, [settings.warAutoPlay, animPhase, startGame]);
 
-    // For game-over, use a longer fixed delay then restart
-    if (state.phase === "game-over") {
-      const t = setTimeout(newGame, GAME_OVER_DELAY_MS);
-      return () => clearTimeout(t);
-    }
+  // ── Render ─────────────────────────────────────────────────────────────────
 
-    const t = setTimeout(() => {
-      if (state.phase === "ready") flip();
-      else if (state.phase === "revealed") resolveRevealed();
-      else if (state.phase === "war-ready") flipWar();
-      else if (state.phase === "war-revealed") resolveWarRevealed();
-    }, speedMs);
-
-    return () => { clearTimeout(t); void advance; };
-  }, [autoPlay, speedMs, state.phase, flip, resolveRevealed, flipWar, resolveWarRevealed, newGame]);
-
-  // ── Render helpers ────────────────────────────────────────────────────────
-
-  const { phase, playerCard, dealerCard, playerPile, dealerPile,
-          warPlayerCards, warDealerCards, warPlayerFinal, warDealerFinal,
-          roundResult, gameResult, roundCount } = state as WarState;
-
-  const isWar = phase === "war-ready" || phase === "war-revealed";
-
-  function resultBanner(): string {
-    if (phase === "revealed" || phase === "war-revealed") {
+  function bannerText(): string {
+    if (warMsg) return warMsg;
+    if (animPhase === "result" || animPhase === "collecting") {
       if (roundResult === "player") return "You win the round!";
       if (roundResult === "dealer") return "Dealer wins the round.";
-      if (roundResult === "war") return "WAR!";
     }
-    if (phase === "game-over") {
-      if (gameResult === "player") return "🏆 YOU WIN!";
-      return "Dealer wins.";
+    if (animPhase === "war-result" || animPhase === "war-collecting") {
+      if (roundResult === "player") return "You win the war!";
+      if (roundResult === "dealer") return "Dealer wins the war.";
+    }
+    if (animPhase === "game-over") {
+      return gameResult === "player" ? "YOU WIN!" : "Dealer wins.";
     }
     return "";
   }
 
-  function cardCount(pile: Card[], extra?: (Card | null)[]): number {
-    return pile.length + (extra ?? []).filter(Boolean).length;
+  function bannerMod(): string {
+    if (gameResult === "player" || roundResult === "player") return "win";
+    if (gameResult === "dealer" || roundResult === "dealer") return "lose";
+    return "war";
   }
+
+  const playerCount = playerPile.length + sprites.filter(s => s.side === "player").length;
+  const dealerCount = dealerPile.length + sprites.filter(s => s.side === "dealer").length;
 
   return (
     <div className="war">
       {showDeckModal && (
-        <DeckModal
-          appearance={appearance}
-          onUpdate={setAppearance}
-          onClose={() => setShowDeckModal(false)}
-        />
+        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
       )}
-      {/* Scoreboard */}
+
       <div className="war__scoreboard">
         <span>Round {roundCount}</span>
-        <span>You: {cardCount(playerPile, [playerCard, warPlayerFinal, ...warPlayerCards])} cards</span>
-        <span>Dealer: {cardCount(dealerPile, [dealerCard, warDealerFinal, ...warDealerCards])} cards</span>
+        <span>You: {playerCount} cards</span>
+        <span>Dealer: {dealerCount} cards</span>
       </div>
 
-      {/* Battle area */}
-      <div className="war__table">
-        {/* Player side */}
-        <div className="war__side war__side--player">
-          <div className="war__side-label">You</div>
-          <div className="war__pile-stack">
-            {playerPile.length > 0
-              ? <PlayingCard card={playerPile[0]} faceDown appearance={appearance} />
-              : <div className="playing-card--empty" />
-            }
+      {/* Stage: position:relative container for all animated elements */}
+      <div className="war__stage">
+        {/* Shuffle animation */}
+        {shuffling && (
+          <div className="war__shuffle">
+            <div className="war__shuffle-half war__shuffle-half--l">
+              <StackedPile count={20} appearance={appearance} />
+            </div>
+            <div className="war__shuffle-half war__shuffle-half--r">
+              <StackedPile count={20} appearance={appearance} />
+            </div>
+          </div>
+        )}
+
+        {/* Player pile */}
+        {!shuffling && (
+          <div className="war__pile war__pile--player">
+            <div className="war__pile-label">You</div>
+            <StackedPile count={playerPile.length} appearance={appearance} />
             <div className="war__pile-count">{playerPile.length} left</div>
           </div>
-          {isWar && (
-            <div className="war__war-cards">
-              {warPlayerCards.map((c) => (
-                <PlayingCard key={c.id} card={c} faceDown appearance={appearance} />
-              ))}
-              {warPlayerFinal
-                ? <PlayingCard card={warPlayerFinal} />
-                : phase === "war-ready" ? null : null
-              }
-            </div>
-          )}
-          {playerCard && (
-            <div key={playerCard.id} className="war__flipped">
-              <PlayingCard card={playerCard} />
-            </div>
-          )}
-        </div>
+        )}
 
-        {/* Center VS */}
-        <div className="war__center">
-          <span className="war__vs">{isWar ? "WAR" : "VS"}</span>
-        </div>
+        {/* VS label */}
+        {!shuffling && animPhase === "idle" && (
+          <div className="war__vs-label">VS</div>
+        )}
 
-        {/* Dealer side */}
-        <div className="war__side war__side--dealer">
-          <div className="war__side-label">Dealer</div>
-          <div className="war__pile-stack">
-            {dealerPile.length > 0
-              ? <PlayingCard card={dealerPile[0]} faceDown appearance={appearance} />
-              : <div className="playing-card--empty" />
-            }
+        {/* Dealer pile */}
+        {!shuffling && (
+          <div className="war__pile war__pile--dealer">
+            <div className="war__pile-label">Dealer</div>
+            <StackedPile count={dealerPile.length} appearance={appearance} />
             <div className="war__pile-count">{dealerPile.length} left</div>
           </div>
-          {isWar && (
-            <div className="war__war-cards">
-              {warDealerCards.map((c) => (
-                <PlayingCard key={c.id} card={c} faceDown appearance={appearance} />
-              ))}
-              {warDealerFinal && <PlayingCard card={warDealerFinal} />}
-            </div>
-          )}
-          {dealerCard && (
-            <div key={dealerCard.id} className="war__flipped">
-              <PlayingCard card={dealerCard} />
-            </div>
-          )}
-        </div>
+        )}
+
+        {/* Animated sprites */}
+        {sprites.map(s => (
+          <FlippableSprite key={s.id} s={s} appearance={appearance} />
+        ))}
       </div>
 
-      {/* Result / controls */}
+      {/* Controls */}
       <div className="war__controls">
-        {resultBanner() && (
-          <div className={`war__banner ${gameResult === "player" ? "war__banner--win" : gameResult === "dealer" ? "war__banner--lose" : roundResult === "player" ? "war__banner--win" : roundResult === "dealer" ? "war__banner--lose" : "war__banner--war"}`}>
-            {resultBanner()}
+        {bannerText() && (
+          <div className={`war__banner war__banner--${bannerMod()}`}>
+            {bannerText()}
           </div>
         )}
 
-        {!autoPlay && (
-          <div className="war__btn-row">
-            {phase === "ready" && (
-              <button className="war__btn war__btn--primary"
-                disabled={playerPile.length === 0 || dealerPile.length === 0}
-                onClick={flip}>
-                ▶ Flip
-              </button>
-            )}
-            {phase === "revealed" && (
-              <button className="war__btn war__btn--secondary" onClick={resolveRevealed}>
-                {roundResult === "war" ? "Go to War →" : "Next Round →"}
-              </button>
-            )}
-            {phase === "war-ready" && (
-              <button className="war__btn war__btn--primary" onClick={flipWar}>
-                ⚔ Flip War Cards
-              </button>
-            )}
-            {phase === "war-revealed" && (
-              <button className="war__btn war__btn--secondary" onClick={resolveWarRevealed}>
-                {roundResult === "war" ? "War Again →" : "Next Round →"}
-              </button>
-            )}
-            {phase === "game-over" && (
-              <button className="war__btn war__btn--primary" onClick={newGame}>
-                New Game
-              </button>
-            )}
-          </div>
+        {animPhase === "idle" && !settings.warAutoPlay && (
+          <button
+            className="war__btn war__btn--primary"
+            onClick={flip}
+            disabled={playerPile.length === 0 || dealerPile.length === 0}
+          >
+            ▶ Flip
+          </button>
         )}
-        {autoPlay && phase === "game-over" && (
+
+        {animPhase === "game-over" && !settings.warAutoPlay && (
+          <button className="war__btn war__btn--primary" onClick={startGame}>
+            New Game
+          </button>
+        )}
+
+        {animPhase === "game-over" && settings.warAutoPlay && (
           <div className="war__auto-notice">Starting new game…</div>
         )}
       </div>

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import "./Cards.css";
 import "./War.css";
 import { PlayingCard } from "./PlayingCard";
-import type { Card, DeckSettings } from "./types";
+import type { Card, CardAppearance, DeckSettings } from "./types";
 import { buildDeck, shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
@@ -77,7 +77,7 @@ interface WarProps {
 
 export default function War({ settings, onNewGame, onQuit }: WarProps) {
   const [state, setState] = useState<WarState>(() => makeInitialState(settings));
-  const [cardBack, setCardBack] = useState(settings.cardBack);
+  const [appearance, setAppearance] = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
 
   const autoPlay = settings.warAutoPlay;
@@ -248,7 +248,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     ];
     return [
       { label: "Game", items },
-      { label: "Options", items: [{ label: "Deck…", onClick: () => setShowDeckModal(true) }] },
+      { label: "Options", items: [{ label: "Card Appearance…", onClick: () => setShowDeckModal(true) }] },
     ];
   }, [newGame, onNewGame, onQuit]);
 
@@ -316,8 +316,8 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     <div className="war">
       {showDeckModal && (
         <DeckModal
-          cardBack={cardBack}
-          onSelect={setCardBack}
+          appearance={appearance}
+          onUpdate={setAppearance}
           onClose={() => setShowDeckModal(false)}
         />
       )}
@@ -335,7 +335,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
           <div className="war__side-label">You</div>
           <div className="war__pile-stack">
             {playerPile.length > 0
-              ? <PlayingCard card={playerPile[0]} faceDown backColor={cardBack} />
+              ? <PlayingCard card={playerPile[0]} faceDown appearance={appearance} />
               : <div className="playing-card--empty" />
             }
             <div className="war__pile-count">{playerPile.length} left</div>
@@ -343,7 +343,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
           {isWar && (
             <div className="war__war-cards">
               {warPlayerCards.map((c) => (
-                <PlayingCard key={c.id} card={c} faceDown backColor={cardBack} />
+                <PlayingCard key={c.id} card={c} faceDown appearance={appearance} />
               ))}
               {warPlayerFinal
                 ? <PlayingCard card={warPlayerFinal} />
@@ -352,7 +352,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
             </div>
           )}
           {playerCard && (
-            <div className="war__flipped">
+            <div key={playerCard.id} className="war__flipped">
               <PlayingCard card={playerCard} />
             </div>
           )}
@@ -368,7 +368,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
           <div className="war__side-label">Dealer</div>
           <div className="war__pile-stack">
             {dealerPile.length > 0
-              ? <PlayingCard card={dealerPile[0]} faceDown backColor={cardBack} />
+              ? <PlayingCard card={dealerPile[0]} faceDown appearance={appearance} />
               : <div className="playing-card--empty" />
             }
             <div className="war__pile-count">{dealerPile.length} left</div>
@@ -376,13 +376,13 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
           {isWar && (
             <div className="war__war-cards">
               {warDealerCards.map((c) => (
-                <PlayingCard key={c.id} card={c} faceDown backColor={cardBack} />
+                <PlayingCard key={c.id} card={c} faceDown appearance={appearance} />
               ))}
               {warDealerFinal && <PlayingCard card={warDealerFinal} />}
             </div>
           )}
           {dealerCard && (
-            <div className="war__flipped">
+            <div key={dealerCard.id} className="war__flipped">
               <PlayingCard card={dealerCard} />
             </div>
           )}

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -58,8 +58,9 @@ function PermCard({
   cs: CardVisualState;
   appearance: CardAppearance;
 }) {
+  const delay = cs.transitionDelay ?? 0;
   const posTrans = cs.transitionMs > 0
-    ? `left ${cs.transitionMs}ms ease-in-out, top ${cs.transitionMs}ms ease-in-out`
+    ? `left ${cs.transitionMs}ms ease-in-out ${delay}ms, top ${cs.transitionMs}ms ease-in-out ${delay}ms`
     : undefined;
 
   return (
@@ -186,12 +187,35 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     setAllCards(deck);
     setCardStates(initStates);
 
-    // Timing blocks — all scaled by speed multiplier
-    const SPLIT = t(320);
-    const PAUSE = t(150);
-    const MERGE = t(280);
-    const DEAL  = t(400);
-    let now = 80;  // initial paint delay before first transition
+    // Timing — all scaled by speed multiplier
+    const SPLIT   = t(280);
+    const PAUSE   = t(80);
+    const MERGE   = t(200);
+    const STAGGER = t(8);    // per-card delay in merge for riffle effect
+    const DEAL    = t(380);
+    // Total merge animation = MERGE + last card's delay
+    const MERGE_TOTAL = MERGE + (deck.length - 1) * STAGGER;
+    let now = 80;  // initial paint delay so browser renders the "all at center" frame first
+
+    // Helper: interleave cards from two halves (left[0], right[0], left[1], right[1], ...)
+    // then build merge states with per-card stagger
+    function mergeStates(cards1: Card[], cards2: Card[]): Record<string, CardVisualState> {
+      const interleaved: Card[] = [];
+      const len = Math.max(cards1.length, cards2.length);
+      for (let i = 0; i < len; i++) {
+        if (i < cards1.length) interleaved.push(cards1[i]);
+        if (i < cards2.length) interleaved.push(cards2[i]);
+      }
+      const states: Record<string, CardVisualState> = {};
+      interleaved.forEach((card, i) => {
+        states[card.id] = {
+          x: WAR_X, y: CY, z: 10 + i,
+          rotation: rnd(-5, 5), faceDown: true,
+          transitionMs: MERGE, transitionDelay: i * STAGGER,
+        };
+      });
+      return states;
+    }
 
     // Step 1: Split deck into two halves (pCards left, dCards right)
     after(now, () => {
@@ -206,17 +230,11 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     });
     now += SPLIT + PAUSE;
 
-    // Step 2: Merge both halves back to center (interleaved z-order)
-    after(now, () => {
-      const states: Record<string, CardVisualState> = {};
-      deck.forEach((card, i) => {
-        states[card.id] = { x: WAR_X, y: CY, z: 10 + i, rotation: rnd(-5, 5), faceDown: true, transitionMs: MERGE };
-      });
-      setCardStates(states);
-    });
-    now += MERGE + PAUSE;
+    // Step 2: Merge — cards riffle together one by one
+    after(now, () => setCardStates(mergeStates(pCards, dCards)));
+    now += MERGE_TOTAL + PAUSE;
 
-    // Step 3: Split again (slightly different spread)
+    // Step 3: Split again (slightly tighter spread)
     after(now, () => {
       const states: Record<string, CardVisualState> = {};
       pCards.forEach((card, i) => {
@@ -229,23 +247,18 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     });
     now += SPLIT + PAUSE;
 
-    // Step 4: Merge back to center again
-    after(now, () => {
-      const states: Record<string, CardVisualState> = {};
-      deck.forEach((card, i) => {
-        states[card.id] = { x: WAR_X, y: CY, z: 10 + i, rotation: rnd(-4, 4), faceDown: true, transitionMs: MERGE };
-      });
-      setCardStates(states);
-    });
-    now += MERGE + PAUSE;
+    // Step 4: Merge again with riffle
+    after(now, () => setCardStates(mergeStates(pCards, dCards)));
+    now += MERGE_TOTAL + PAUSE;
 
-    // Step 5: Deal — all cards fan out to their permanent pile positions
+    // Step 5: Deal — all cards fan out to their pile positions (no stagger, clean spread)
     after(now, () => {
       for (const card of pCards) ps.current.addCard(card, { toTop: true, faceDown: true });
       for (const card of dCards) ds.current.addCard(card, { toTop: true, faceDown: true });
 
       setPlayerCount(ps.current.size);
       setDealerCount(ds.current.size);
+      // transitionDelay resets to 0 since layout() doesn't set it
       setCardStates({ ...ps.current.layout(DEAL), ...ds.current.layout(DEAL) });
 
       after(DEAL + 100, () => setPhase("idle"));

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -47,27 +47,6 @@ const ANIM_MULT: Record<string, number> = { slow: 1.5, normal: 1.0, fast: 0.5 };
 type Phase = "shuffle" | "idle" | "animating" | "game-over";
 type BannerType = "win" | "lose" | "war";
 
-// ─── StackedPile — used only for the shuffle animation overlay ────────────────
-
-const DUMMY: Card = { id: "__dum", suit: "spades", rank: "2" };
-
-function StackedPile({ count, appearance }: { count: number; appearance: CardAppearance }) {
-  if (count === 0) return <div className="war__empty-slot" />;
-  const layers = Math.min(5, count);
-  return (
-    <div className="war__stack">
-      {Array.from({ length: layers }).map((_, i) => {
-        const d = layers - 1 - i;
-        return (
-          <div key={i} className="war__stack-layer" style={{ left: d * -1.5, top: d * 1.5, zIndex: i }}>
-            <PlayingCard card={DUMMY} faceDown appearance={appearance} />
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 // ─── PermCard — one permanently-mounted card div ──────────────────────────────
 
 function PermCard({
@@ -199,7 +178,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     setBanner("");
     setPhase("shuffle");
 
-    // All 52 cards start at deck center (instant, hidden behind shuffle overlay)
+    // Step 0: All cards stacked at deck center (instant — no transition)
     const initStates: Record<string, CardVisualState> = {};
     for (const card of deck) {
       initStates[card.id] = { x: WAR_X, y: CY, z: 10, rotation: 0, faceDown: true, transitionMs: 0 };
@@ -207,16 +186,69 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     setAllCards(deck);
     setCardStates(initStates);
 
-    after(1600, () => {
+    // Timing blocks — all scaled by speed multiplier
+    const SPLIT = t(320);
+    const PAUSE = t(150);
+    const MERGE = t(280);
+    const DEAL  = t(400);
+    let now = 80;  // initial paint delay before first transition
+
+    // Step 1: Split deck into two halves (pCards left, dCards right)
+    after(now, () => {
+      const states: Record<string, CardVisualState> = {};
+      pCards.forEach((card, i) => {
+        states[card.id] = { x: 130 + i * 0.5, y: CY - i * 0.5, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+      });
+      dCards.forEach((card, i) => {
+        states[card.id] = { x: 286 - i * 0.5, y: CY - i * 0.5, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+      });
+      setCardStates(states);
+    });
+    now += SPLIT + PAUSE;
+
+    // Step 2: Merge both halves back to center (interleaved z-order)
+    after(now, () => {
+      const states: Record<string, CardVisualState> = {};
+      deck.forEach((card, i) => {
+        states[card.id] = { x: WAR_X, y: CY, z: 10 + i, rotation: rnd(-5, 5), faceDown: true, transitionMs: MERGE };
+      });
+      setCardStates(states);
+    });
+    now += MERGE + PAUSE;
+
+    // Step 3: Split again (slightly different spread)
+    after(now, () => {
+      const states: Record<string, CardVisualState> = {};
+      pCards.forEach((card, i) => {
+        states[card.id] = { x: 136 + i * 0.4, y: CY - i * 0.4, z: 300 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+      });
+      dCards.forEach((card, i) => {
+        states[card.id] = { x: 280 - i * 0.4, y: CY - i * 0.4, z: 400 + i, rotation: rnd(-2, 2), faceDown: true, transitionMs: SPLIT };
+      });
+      setCardStates(states);
+    });
+    now += SPLIT + PAUSE;
+
+    // Step 4: Merge back to center again
+    after(now, () => {
+      const states: Record<string, CardVisualState> = {};
+      deck.forEach((card, i) => {
+        states[card.id] = { x: WAR_X, y: CY, z: 10 + i, rotation: rnd(-4, 4), faceDown: true, transitionMs: MERGE };
+      });
+      setCardStates(states);
+    });
+    now += MERGE + PAUSE;
+
+    // Step 5: Deal — all cards fan out to their permanent pile positions
+    after(now, () => {
       for (const card of pCards) ps.current.addCard(card, { toTop: true, faceDown: true });
       for (const card of dCards) ds.current.addCard(card, { toTop: true, faceDown: true });
 
       setPlayerCount(ps.current.size);
       setDealerCount(ds.current.size);
+      setCardStates({ ...ps.current.layout(DEAL), ...ds.current.layout(DEAL) });
 
-      // Instantly place all cards at pile positions (transitionMs=0 → no animation)
-      setCardStates({ ...ps.current.layout(0), ...ds.current.layout(0) });
-      setPhase("idle");
+      after(DEAL + 100, () => setPhase("idle"));
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings]);
@@ -471,18 +503,6 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
       </div>
 
       <div className="war__stage">
-        {/* Shuffle animation overlay — sits above permanent cards */}
-        {phase === "shuffle" && (
-          <div className="war__shuffle">
-            <div className="war__shuffle-half war__shuffle-half--l">
-              <StackedPile count={20} appearance={appearance} />
-            </div>
-            <div className="war__shuffle-half war__shuffle-half--r">
-              <StackedPile count={20} appearance={appearance} />
-            </div>
-          </div>
-        )}
-
         {/* VS label when waiting for flip */}
         {phase === "idle" && <div className="war__vs-label">VS</div>}
 

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -25,8 +25,9 @@ function rnd(min: number, max: number): number {
 
 // ─── Stage constants ──────────────────────────────────────────────────────────
 
-// Stage inner: 416px wide × 240px tall (440 window − chrome − margin − border)
-const CY = 120;  // vertical center of stage
+const STAGE_W = 420;
+const STAGE_H = 240;
+const CY = STAGE_H / 2;  // vertical center of stage
 
 const PLAYER_X = 76;
 const DEALER_X = 340;
@@ -64,6 +65,8 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
   const [bannerType,    setBannerType]    = useState<BannerType>("win");
   const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
+  const [scale,         setScale]         = useState(1);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Card stacks — mutable refs, never triggers re-renders themselves
   const ps = useRef(new CardStack({ zTier: 1, baseX: PLAYER_X, baseY: CY, offsetX:  0.5, offsetY: -0.5 }));
@@ -81,6 +84,17 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
     const id = setTimeout(fn, ms);
     timers.current.push(id);
   }
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width;
+      setScale(Math.min(1, w / STAGE_W));
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
 
   const am = ANIM_MULT[settings.warSpeed] ?? 1.0;
   function t(ms: number): number { return Math.round(ms * am); }
@@ -461,16 +475,26 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
         <span>Dealer: {dealerCount}</span>
       </div>
 
-      <div className="war__stage">
-        {/* VS label when waiting for flip */}
-        {phase === "idle" && <div className="war__vs-label">VS</div>}
+      <div className="war__stage-container" ref={containerRef} style={{ height: Math.round(STAGE_H * scale) }}>
+        <div
+          className="war__stage"
+          style={{
+            width: STAGE_W,
+            height: STAGE_H,
+            transform: scale < 1 ? `scale(${scale})` : undefined,
+            transformOrigin: "top left",
+          }}
+        >
+          {/* VS label when waiting for flip */}
+          {phase === "idle" && <div className="war__vs-label">VS</div>}
 
-        {/* All 52 cards — permanently mounted, CSS transitions drive all animation */}
-        {allCards.map(card => {
-          const cs = cardStates[card.id];
-          if (!cs) return null;
-          return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} />;
-        })}
+          {/* All 52 cards — permanently mounted, CSS transitions drive all animation */}
+          {allCards.map(card => {
+            const cs = cardStates[card.id];
+            if (!cs) return null;
+            return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} />;
+          })}
+        </div>
       </div>
 
       <div className="war__controls">

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -123,6 +123,7 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
 
   const startGame = useCallback(() => {
     clearTimers();
+    try { localStorage.removeItem("cards-war-save"); } catch {}
 
     const deck = buildDeck(settings);
     const mid  = Math.floor(deck.length / 2);
@@ -227,10 +228,46 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
   }, [settings]);
 
   useEffect(() => {
+    const WAR_SAVE_KEY = "cards-war-save";
+    try {
+      const raw = localStorage.getItem(WAR_SAVE_KEY);
+      if (raw) {
+        const saved = JSON.parse(raw) as { version: number; playerCards: Card[]; dealerCards: Card[]; roundCount: number };
+        if (saved?.version === 1 && Array.isArray(saved.playerCards) && Array.isArray(saved.dealerCards)) {
+          const allC = [...saved.playerCards, ...saved.dealerCards];
+          ps.current.clear(); ds.current.clear(); ws.current.clear();
+          for (const c of saved.playerCards) ps.current.addCard(c, { toTop: true, faceDown: true });
+          for (const c of saved.dealerCards) ds.current.addCard(c, { toTop: true, faceDown: true });
+          setRoundCount(saved.roundCount);
+          setPlayerCount(ps.current.size);
+          setDealerCount(ds.current.size);
+          setAllCards(allC);
+          setCardStates({ ...ps.current.layout(0), ...ds.current.layout(0) });
+          setPhase("idle");
+          return clearTimers;
+        }
+      }
+    } catch {}
     startGame();
     return clearTimers;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const WAR_SAVE_KEY = "cards-war-save";
+    if (phase === "idle") {
+      try {
+        localStorage.setItem(WAR_SAVE_KEY, JSON.stringify({
+          version: 1,
+          playerCards: ps.current.cards,
+          dealerCards: ds.current.cards,
+          roundCount,
+        }));
+      } catch {}
+    } else if (phase === "game-over") {
+      try { localStorage.removeItem(WAR_SAVE_KEY); } catch {}
+    }
+  }, [phase, roundCount]);
 
   // ── flip ──────────────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -1,8 +1,8 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./Cards.css";
 import "./War.css";
-import { PlayingCard } from "./PlayingCard";
 import type { Card, CardAppearance, DeckSettings } from "./types";
+import { PermCard } from "./PermCard";
 import { buildDeck, shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
@@ -26,8 +26,6 @@ function rnd(min: number, max: number): number {
 // ─── Stage constants ──────────────────────────────────────────────────────────
 
 // Stage inner: 416px wide × 240px tall (440 window − chrome − margin − border)
-const CARD_W = 72;
-const CARD_H = 100;
 const CY = 120;  // vertical center of stage
 
 const PLAYER_X = 76;
@@ -46,58 +44,6 @@ const ANIM_MULT: Record<string, number> = { slow: 1.5, normal: 1.0, fast: 0.5 };
 
 type Phase = "shuffle" | "idle" | "animating" | "game-over";
 type BannerType = "win" | "lose" | "war";
-
-// ─── PermCard — one permanently-mounted card div ──────────────────────────────
-
-function PermCard({
-  card,
-  cs,
-  appearance,
-}: {
-  card: Card;
-  cs: CardVisualState;
-  appearance: CardAppearance;
-}) {
-  const delay = cs.transitionDelay ?? 0;
-  const posTrans = cs.transitionMs > 0
-    ? `left ${cs.transitionMs}ms ease-in-out ${delay}ms, top ${cs.transitionMs}ms ease-in-out ${delay}ms`
-    : undefined;
-
-  return (
-    <div
-      style={{
-        position:   "absolute",
-        left:       cs.x - CARD_W / 2,
-        top:        cs.y - CARD_H / 2,
-        width:      CARD_W,
-        height:     CARD_H,
-        zIndex:     cs.z,
-        transition: posTrans,
-      }}
-    >
-      <div
-        style={{
-          width:           "100%",
-          height:          "100%",
-          transform:       `rotate(${cs.rotation}deg)`,
-          transformOrigin: "center",
-          transition:      "transform 250ms ease-out",
-        }}
-      >
-        <div className="flippable" style={{ width: CARD_W, height: CARD_H }}>
-          <div className={`flippable__inner${cs.faceDown ? "" : " flippable__inner--face-up"}`}>
-            <div className="flippable__face">
-              <PlayingCard card={card} faceDown appearance={appearance} />
-            </div>
-            <div className="flippable__face flippable__face--front">
-              <PlayingCard card={card} appearance={appearance} />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 // ─── War ──────────────────────────────────────────────────────────────────────
 

--- a/src/experiences/Cards/War.tsx
+++ b/src/experiences/Cards/War.tsx
@@ -7,8 +7,10 @@ import { buildDeck, shuffle } from "./deckUtils";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { DeckModal } from "./DeckModal";
+import { CardStack } from "./cardStack";
+import type { CardVisualState } from "./cardStack";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const RANK_ORDER = ["2","3","4","5","6","7","8","9","10","J","Q","K","A"] as const;
 
@@ -21,66 +23,31 @@ function rnd(min: number, max: number): number {
   return min + Math.random() * (max - min);
 }
 
-// ── Stage positions (center coords in px) ────────────────────────────────────
+// ─── Stage constants ──────────────────────────────────────────────────────────
 
-// Stage inner width ≈ 416px (440px window − chrome − margin − border)
-// Player pile: left: 40px → center at 40+36 = 76
-// Dealer pile: right: 40px → center at 416−40−36 = 340
-const P = {
-  player:       { x:  76, y: 108 },
-  dealer:       { x: 340, y: 108 },
-  deck:         { x: 208, y: 108 },
-  playerBattle: { x: 155, y: 108 },
-  dealerBattle: { x: 261, y: 108 },
-  war:          { x: 208, y: 108 },
-} as const;
-
+// Stage inner: 416px wide × 240px tall (440 window − chrome − margin − border)
 const CARD_W = 72;
 const CARD_H = 100;
+const CY = 120;  // vertical center of stage
 
-// ── Timing base values (ms) ───────────────────────────────────────────────────
+const PLAYER_X = 76;
+const DEALER_X = 340;
+const WAR_X    = 208;
 
-const TB = {
-  SHUFFLE:   1600,
-  DEAL_FLY:    85,
-  DEAL_GAP:   110,
-  DEAL_N:       6,   // sprites per side
-  FLY:         360,
-  JUDGE:       300,
-  RESULT:      480,
-  COLLECT:     340,
-  WAR_TEXT:    650,
-  WAR_FLY:     280,
-  WAR_GAP:     160,
-};
+// Battle zone (not stacks — fixed positions)
+const BP_X = 155;   // player battle card center-x
+const BD_X = 261;   // dealer battle card center-x
+const Z_BP  = 500;  // tier 5
+const Z_BD  = 600;  // tier 6
 
-const WAR_SPEED_MS: Record<string, number> = { slow: 2000, normal: 900, fast: 250 };
-const ANIM_MULT: Record<string, number>    = { slow: 1.35, normal: 1.0, fast: 0.5 };
+const ANIM_MULT: Record<string, number> = { slow: 1.5, normal: 1.0, fast: 0.5 };
 
-// ── Types ─────────────────────────────────────────────────────────────────────
+// ─── Types ────────────────────────────────────────────────────────────────────
 
-type AnimPhase =
-  | "shuffle" | "dealing" | "idle"
-  | "flying" | "result" | "collecting"
-  | "war-text" | "war-flying" | "war-result" | "war-collecting"
-  | "game-over";
+type Phase = "shuffle" | "idle" | "animating" | "game-over";
+type BannerType = "win" | "lose" | "war";
 
-interface Sprite {
-  id: string;
-  card: Card;
-  x: number;       // center-x
-  y: number;       // center-y
-  rot: number;
-  scale: number;
-  opacity: number;
-  faceDown: boolean;
-  posMs: number;   // position transition duration
-  zIndex: number;
-  side: "player" | "dealer";
-  isDecider?: boolean;
-}
-
-// ── StackedPile ───────────────────────────────────────────────────────────────
+// ─── StackedPile — used only for the shuffle animation overlay ────────────────
 
 const DUMMY: Card = { id: "__dum", suit: "spades", rank: "2" };
 
@@ -101,41 +68,49 @@ function StackedPile({ count, appearance }: { count: number; appearance: CardApp
   );
 }
 
-// ── FlippableSprite ───────────────────────────────────────────────────────────
+// ─── PermCard — one permanently-mounted card div ──────────────────────────────
 
-function FlippableSprite({ s, appearance }: { s: Sprite; appearance: CardAppearance }) {
+function PermCard({
+  card,
+  cs,
+  appearance,
+}: {
+  card: Card;
+  cs: CardVisualState;
+  appearance: CardAppearance;
+}) {
+  const posTrans = cs.transitionMs > 0
+    ? `left ${cs.transitionMs}ms ease-in-out, top ${cs.transitionMs}ms ease-in-out`
+    : undefined;
+
   return (
     <div
-      key={s.id}
       style={{
         position:   "absolute",
-        left:       s.x - CARD_W / 2,
-        top:        s.y - CARD_H / 2,
+        left:       cs.x - CARD_W / 2,
+        top:        cs.y - CARD_H / 2,
         width:      CARD_W,
         height:     CARD_H,
-        zIndex:     s.zIndex,
-        opacity:    s.opacity,
-        transition: s.posMs > 0
-          ? `left ${s.posMs}ms ease-in-out, top ${s.posMs}ms ease-in-out, opacity 200ms ease`
-          : "opacity 200ms ease",
+        zIndex:     cs.z,
+        transition: posTrans,
       }}
     >
-      <div style={{
-        width: "100%", height: "100%",
-        transform: `rotate(${s.rot}deg) scale(${s.scale})`,
-        transformOrigin: "center center",
-        transition: "transform 200ms ease-out",
-      }}>
+      <div
+        style={{
+          width:           "100%",
+          height:          "100%",
+          transform:       `rotate(${cs.rotation}deg)`,
+          transformOrigin: "center",
+          transition:      "transform 250ms ease-out",
+        }}
+      >
         <div className="flippable" style={{ width: CARD_W, height: CARD_H }}>
-          <div
-            className={`flippable__inner${!s.faceDown ? " flippable__inner--face-up" : ""}`}
-            style={{ transition: `transform ${Math.round(Math.max(200, s.posMs * 0.55))}ms ease-in-out` }}
-          >
+          <div className={`flippable__inner${cs.faceDown ? "" : " flippable__inner--face-up"}`}>
             <div className="flippable__face">
-              <PlayingCard card={s.card} faceDown appearance={appearance} />
+              <PlayingCard card={card} faceDown appearance={appearance} />
             </div>
             <div className="flippable__face flippable__face--front">
-              <PlayingCard card={s.card} appearance={appearance} />
+              <PlayingCard card={card} appearance={appearance} />
             </div>
           </div>
         </div>
@@ -144,7 +119,7 @@ function FlippableSprite({ s, appearance }: { s: Sprite; appearance: CardAppeara
   );
 }
 
-// ── War component ─────────────────────────────────────────────────────────────
+// ─── War ──────────────────────────────────────────────────────────────────────
 
 interface WarProps {
   settings: DeckSettings;
@@ -153,104 +128,95 @@ interface WarProps {
 }
 
 export default function War({ settings, onNewGame, onQuit }: WarProps) {
-  const [playerPile, setPlayerPile] = useState<Card[]>([]);
-  const [dealerPile, setDealerPile] = useState<Card[]>([]);
-  const [roundCount,  setRoundCount]  = useState(0);
-  const [roundResult, setRoundResult] = useState<"player" | "dealer" | "war" | null>(null);
-  const [gameResult,  setGameResult]  = useState<"player" | "dealer" | null>(null);
-  const [animPhase,   setAnimPhase]   = useState<AnimPhase>("shuffle");
-  const [sprites,     setSprites]     = useState<Sprite[]>([]);
-  const [warMsg,      setWarMsg]      = useState("");
-  const [shuffling,   setShuffling]   = useState(true);
-  const [appearance,  setAppearance]  = useState<CardAppearance>(settings.appearance);
+  const [allCards,      setAllCards]      = useState<Card[]>([]);
+  const [cardStates,    setCardStates]    = useState<Record<string, CardVisualState>>({});
+  const [phase,         setPhase]         = useState<Phase>("shuffle");
+  const [playerCount,   setPlayerCount]   = useState(0);
+  const [dealerCount,   setDealerCount]   = useState(0);
+  const [roundCount,    setRoundCount]    = useState(0);
+  const [banner,        setBanner]        = useState("");
+  const [bannerType,    setBannerType]    = useState<BannerType>("win");
+  const [appearance,    setAppearance]    = useState<CardAppearance>(settings.appearance);
   const [showDeckModal, setShowDeckModal] = useState(false);
 
-  // Stable refs for pile access inside timeouts
-  const playerPileRef = useRef<Card[]>([]);
-  const dealerPileRef = useRef<Card[]>([]);
-  playerPileRef.current = playerPile;
-  dealerPileRef.current = dealerPile;
+  // Card stacks — mutable refs, never triggers re-renders themselves
+  const ps = useRef(new CardStack({ zTier: 1, baseX: PLAYER_X, baseY: CY, offsetX:  0.5, offsetY: -0.5 }));
+  const ds = useRef(new CardStack({ zTier: 2, baseX: DEALER_X, baseY: CY, offsetX: -0.5, offsetY: -0.5 }));
+  const ws = useRef(new CardStack({ zTier: 8, baseX: WAR_X,    baseY: CY, offsetX:  2.0, offsetY:  0.5 }));
 
-  // Timer management
-  const timerIds = useRef<ReturnType<typeof setTimeout>[]>([]);
+  // Timer tracking for cleanup
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const clearTimers = useCallback(() => {
-    timerIds.current.forEach(clearTimeout);
-    timerIds.current = [];
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
   }, []);
-  function after(ms: number, fn: () => void) {
+
+  function after(ms: number, fn: () => void): void {
     const id = setTimeout(fn, ms);
-    timerIds.current.push(id);
+    timers.current.push(id);
   }
 
-  // Speed helpers
   const am = ANIM_MULT[settings.warSpeed] ?? 1.0;
-  function t(base: number) { return Math.round(base * am); }
-  const extraPause = Math.max(0, (WAR_SPEED_MS[settings.warSpeed] ?? 900) - t(800));
+  function t(ms: number): number { return Math.round(ms * am); }
 
-  // Sprite helpers
-  function patchSprites(id: string, patch: Partial<Sprite>) {
-    setSprites(prev => prev.map(s => s.id === id ? { ...s, ...patch } : s));
-  }
-  function addSprite(sp: Sprite) {
-    setSprites(prev => [...prev, sp]);
+  // Patch specific card states by id
+  function patchCards(patches: Record<string, Partial<CardVisualState>>): void {
+    setCardStates(prev => {
+      const next = { ...prev };
+      for (const [id, p] of Object.entries(patches)) {
+        if (next[id]) next[id] = { ...next[id], ...p };
+      }
+      return next;
+    });
   }
 
-  // ── startGame ─────────────────────────────────────────────────────────────
+  // Merge one or more layout records into cardStates
+  function applyLayouts(...layouts: Record<string, CardVisualState>[]): void {
+    setCardStates(prev => {
+      const next = { ...prev };
+      for (const layout of layouts) Object.assign(next, layout);
+      return next;
+    });
+  }
+
+  // ── startGame ──────────────────────────────────────────────────────────────
 
   const startGame = useCallback(() => {
     clearTimers();
+
     const deck = buildDeck(settings);
-    const mid = Math.floor(deck.length / 2);
+    const mid  = Math.floor(deck.length / 2);
     const pCards = deck.slice(0, mid);
     const dCards = deck.slice(mid);
 
-    setPlayerPile([]);
-    setDealerPile([]);
+    ps.current.clear();
+    ds.current.clear();
+    ws.current.clear();
+
     setRoundCount(0);
-    setRoundResult(null);
-    setGameResult(null);
-    setSprites([]);
-    setWarMsg("");
-    setShuffling(true);
-    setAnimPhase("shuffle");
+    setPlayerCount(0);
+    setDealerCount(0);
+    setBanner("");
+    setPhase("shuffle");
 
-    after(TB.SHUFFLE, () => {
-      setShuffling(false);
-      setAnimPhase("dealing");
+    // All 52 cards start at deck center (instant, hidden behind shuffle overlay)
+    const initStates: Record<string, CardVisualState> = {};
+    for (const card of deck) {
+      initStates[card.id] = { x: WAR_X, y: CY, z: 10, rotation: 0, faceDown: true, transitionMs: 0 };
+    }
+    setAllCards(deck);
+    setCardStates(initStates);
 
-      let flown = 0;
-      const n = TB.DEAL_N;
+    after(1600, () => {
+      for (const card of pCards) ps.current.addCard(card, { toTop: true, faceDown: true });
+      for (const card of dCards) ds.current.addCard(card, { toTop: true, faceDown: true });
 
-      function dealNext() {
-        if (flown >= n * 2) {
-          after(t(TB.DEAL_FLY) + 60, () => {
-            setPlayerPile(pCards);
-            setDealerPile(dCards);
-            setSprites([]);
-            setAnimPhase("idle");
-          });
-          return;
-        }
-        const isPlayer = flown % 2 === 0;
-        const idx = Math.floor(flown / 2);
-        const card = isPlayer ? pCards[idx] : dCards[idx];
-        const dest = isPlayer ? P.player : P.dealer;
-        const sid = `deal-${flown}`;
-        const sp: Sprite = {
-          id: sid, card,
-          x: P.deck.x, y: P.deck.y,
-          rot: rnd(-4, 4), scale: 1, opacity: 1,
-          faceDown: true, posMs: 0,
-          zIndex: 80 + flown,
-          side: isPlayer ? "player" : "dealer",
-        };
-        addSprite(sp);
-        after(16, () => patchSprites(sid, { x: dest.x, y: dest.y, posMs: t(TB.DEAL_FLY) }));
-        flown++;
-        after(t(TB.DEAL_GAP), dealNext);
-      }
+      setPlayerCount(ps.current.size);
+      setDealerCount(ds.current.size);
 
-      dealNext();
+      // Instantly place all cards at pile positions (transitionMs=0 → no animation)
+      setCardStates({ ...ps.current.layout(0), ...ds.current.layout(0) });
+      setPhase("idle");
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings]);
@@ -261,212 +227,195 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── flip ─────────────────────────────────────────────────────────────────
+  // ── flip ──────────────────────────────────────────────────────────────────
 
   const flip = useCallback(() => {
-    const pp = playerPileRef.current;
-    const dp = dealerPileRef.current;
-    if (pp.length === 0 || dp.length === 0) return;
+    if (ps.current.size === 0 || ds.current.size === 0) return;
+    setPhase("animating");
+    setBanner("");
 
-    const [pc, ...pRest] = pp;
-    const [dc, ...dRest] = dp;
-    const pv = warValue(pc);
-    const dv = warValue(dc);
+    const pCard = ps.current.removeTop()!;
+    const dCard = ds.current.removeTop()!;
+    const pv = warValue(pCard);
+    const dv = warValue(dCard);
     const result: "player" | "dealer" | "war" =
       pv > dv ? "player" : pv < dv ? "dealer" : "war";
 
-    setPlayerPile(pRest);
-    setDealerPile(dRest);
     setRoundCount(c => c + 1);
-    setRoundResult(result);
-    setAnimPhase("flying");
+    setPlayerCount(ps.current.size);
+    setDealerCount(ds.current.size);
 
-    const pSp: Sprite = { id: `pb-${pc.id}`, card: pc, x: P.player.x, y: P.player.y, rot: 0, scale: 1, opacity: 1, faceDown: true, posMs: 0, zIndex: 20, side: "player" };
-    const dSp: Sprite = { id: `db-${dc.id}`, card: dc, x: P.dealer.x, y: P.dealer.y, rot: 0, scale: 1, opacity: 1, faceDown: true, posMs: 0, zIndex: 21, side: "dealer" };
-    setSprites([pSp, dSp]);
+    const FLY     = t(350);
+    const JUDGE   = t(200);
+    const SHOW    = t(600);
+    const COLLECT = t(350);
 
-    // Fly to battle positions
-    after(16, () => {
-      patchSprites(pSp.id, { x: P.playerBattle.x, y: P.playerBattle.y, posMs: t(TB.FLY) });
-      patchSprites(dSp.id, { x: P.dealerBattle.x, y: P.dealerBattle.y, posMs: t(TB.FLY) });
+    // Step 1: Fly both cards to battle zone (face-down, with transition)
+    setCardStates(prev => ({
+      ...prev,
+      ...ps.current.layout(FLY),
+      ...ds.current.layout(FLY),
+      [pCard.id]: { x: BP_X, y: CY, z: Z_BP, rotation: 0, faceDown: true, transitionMs: FLY },
+      [dCard.id]: { x: BD_X, y: CY, z: Z_BD, rotation: 0, faceDown: true, transitionMs: FLY },
+    }));
+
+    // Step 2: Flip both cards mid-flight
+    after(FLY / 2, () => {
+      patchCards({
+        [pCard.id]: { faceDown: false },
+        [dCard.id]: { faceDown: false },
+      });
     });
 
-    // Mid-flight flip to face-up
-    after(t(TB.FLY) / 2, () => {
-      setSprites(prev => prev.map(s => ({ ...s, faceDown: false })));
-    });
-
-    // Show result effects after landing
-    after(t(TB.FLY) + t(TB.JUDGE), () => {
-      setAnimPhase("result");
-      if (result !== "war") {
-        setSprites(prev => prev.map(s => {
-          const wins = (result === "player") === (s.side === "player");
-          return { ...s, scale: wins ? 1.07 : 0.93, opacity: wins ? 1 : 0.5 };
-        }));
+    // Step 3: Show round result
+    after(FLY + JUDGE, () => {
+      if (result === "player") {
+        setBanner("You win the round!"); setBannerType("win");
+      } else if (result === "dealer") {
+        setBanner("Dealer wins the round."); setBannerType("lose");
+      } else {
+        setBanner("WAR!"); setBannerType("war");
       }
     });
 
-    const afterResult = t(TB.FLY) + t(TB.JUDGE) + t(TB.RESULT);
-
     if (result !== "war") {
-      after(afterResult, () => {
-        setAnimPhase("collecting");
-        const winPos = result === "player" ? P.player : P.dealer;
-        setSprites(prev => prev.map(s => ({
-          ...s, x: winPos.x, y: winPos.y,
-          rot: rnd(-6, 6), scale: 1, opacity: 0.75, posMs: t(TB.COLLECT),
-        })));
-        after(t(TB.COLLECT) + 60, () => {
-          const spoils = shuffle([pc, dc]);
-          if (result === "player") setPlayerPile(prev => [...prev, ...spoils]);
-          else setDealerPile(prev => [...prev, ...spoils]);
-          setSprites([]);
+      // Step 4: Collect won cards to bottom of winner pile
+      after(FLY + JUDGE + SHOW, () => {
+        const spoils  = shuffle([pCard, dCard]);
+        const winner  = result === "player" ? ps.current : ds.current;
+        winner.addCard(spoils[0], { toTop: false, faceDown: true, rotation: rnd(-5, 5) });
+        winner.addCard(spoils[1], { toTop: false, faceDown: true, rotation: rnd(-5, 5) });
 
-          const newPp = result === "player" ? [...pRest, ...spoils] : pRest;
-          const newDp = result === "dealer" ? [...dRest, ...spoils] : dRest;
-          if (newPp.length === 0) { setGameResult("dealer"); setAnimPhase("game-over"); }
-          else if (newDp.length === 0) { setGameResult("player"); setAnimPhase("game-over"); }
-          else setAnimPhase("idle");
+        setPlayerCount(ps.current.size);
+        setDealerCount(ds.current.size);
+        setBanner("");
+
+        // Update winner's layout — won cards animate FROM battle zone TO pile bottom
+        applyLayouts(winner.layout(COLLECT));
+
+        after(COLLECT + 100, () => {
+          if (ps.current.size === 0) {
+            setPhase("game-over"); setBanner("Dealer wins."); setBannerType("lose");
+          } else if (ds.current.size === 0) {
+            setPhase("game-over"); setBanner("YOU WIN!"); setBannerType("win");
+          } else {
+            setPhase("idle");
+          }
         });
       });
     } else {
-      // War! Move battle cards to war pile, then fly more cards
-      after(afterResult, () => {
-        setAnimPhase("war-text");
-        setWarMsg("WAR!");
-        // Scatter existing battle cards to war center
-        setSprites(prev => prev.map((s, i) => ({
-          ...s,
-          x: P.war.x + (s.side === "player" ? -18 : 18),
-          y: P.war.y + rnd(-8, 8),
-          rot: rnd(-15, 15),
-          scale: 1, opacity: 1, posMs: t(200),
-          zIndex: 10 + i,
-        })));
-
-        after(t(TB.WAR_TEXT), () => {
-          setWarMsg("I DECLARE WAR");
-          doWarFly(pc, dc, pRest, dRest);
-        });
-      });
+      // WAR — short pause before escalation
+      after(FLY + JUDGE + t(400), () => doWar(pCard, dCard));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── doWarFly ─────────────────────────────────────────────────────────────
+  // ── doWar ─────────────────────────────────────────────────────────────────
 
-  function doWarFly(pBattle: Card, dBattle: Card, pRest: Card[], dRest: Card[]) {
-    setAnimPhase("war-flying");
+  function doWar(pCard: Card, dCard: Card): void {
+    setBanner("I DECLARE WAR");
+    setBannerType("war");
 
-    const pFdN = Math.min(3, Math.max(0, pRest.length - 1));
-    const dFdN = Math.min(3, Math.max(0, dRest.length - 1));
-    const pFaceDowns = pRest.slice(0, pFdN);
-    const pFaceUp    = pFdN < pRest.length ? pRest[pFdN] : null;
-    const pRemain    = pRest.slice(pFdN + (pFaceUp ? 1 : 0));
+    const WAR_FLY     = t(350);
+    const WAR_COLLECT = t(350);
 
-    const dFaceDowns = dRest.slice(0, dFdN);
-    const dFaceUp    = dFdN < dRest.length ? dRest[dFdN] : null;
-    const dRemain    = dRest.slice(dFdN + (dFaceUp ? 1 : 0));
+    ws.current.clear();
 
-    setPlayerPile(pRemain);
-    setDealerPile(dRemain);
+    // Scatter the two battle cards to war pile at center
+    ws.current.addCard(pCard, { toTop: true, faceDown: true, rotation: rnd(-15, 15) });
+    ws.current.addCard(dCard, { toTop: true, faceDown: true, rotation: rnd(-15, 15) });
 
-    let z = 30;
-    let delay = 0;
+    // Pull up to 3 face-down cards + 1 deciding card from each pile
+    const pFdN = Math.min(3, Math.max(0, ps.current.size - 1));
+    const dFdN = Math.min(3, Math.max(0, ds.current.size - 1));
 
-    function flyWarCard(card: Card, side: "player" | "dealer", isDecider: boolean) {
-      const sid = `war-${side}-${card.id}`;
-      const startPos = side === "player" ? P.player : P.dealer;
-      const offX = rnd(-22, 22);
-      const offY = rnd(-14, 14);
-      const targetRot = rnd(-16, 16);
-      const curZ = z++;
+    const pFaceDowns: Card[] = [];
+    for (let i = 0; i < pFdN; i++) {
+      const c = ps.current.removeTop();
+      if (c) pFaceDowns.push(c);
+    }
+    const pDecider = ps.current.removeTop();  // may be null if pile exhausted
 
-      after(delay, () => {
-        addSprite({
-          id: sid, card,
-          x: startPos.x, y: startPos.y,
-          rot: 0, scale: 1, opacity: 1,
-          faceDown: true, posMs: 0,
-          zIndex: curZ, side, isDecider,
-        });
-        after(16, () => patchSprites(sid, {
-          x: P.war.x + offX,
-          y: P.war.y + offY,
-          rot: targetRot,
-          posMs: t(TB.WAR_FLY),
-        }));
-        // Flip deciding card mid-flight
-        if (isDecider) {
-          after(t(TB.WAR_FLY) / 2, () => patchSprites(sid, { faceDown: false }));
-        }
+    const dFaceDowns: Card[] = [];
+    for (let i = 0; i < dFdN; i++) {
+      const c = ds.current.removeTop();
+      if (c) dFaceDowns.push(c);
+    }
+    const dDecider = ds.current.removeTop();
+
+    for (const c of pFaceDowns) ws.current.addCard(c, { toTop: true, faceDown: true, rotation: rnd(-20, 20) });
+    for (const c of dFaceDowns) ws.current.addCard(c, { toTop: true, faceDown: true, rotation: rnd(-20, 20) });
+
+    setPlayerCount(ps.current.size + (pDecider ? 1 : 0));
+    setDealerCount(ds.current.size + (dDecider ? 1 : 0));
+
+    // Fly all face-down war cards to war pile simultaneously
+    setCardStates(prev => ({
+      ...prev,
+      ...ps.current.layout(WAR_FLY),
+      ...ds.current.layout(WAR_FLY),
+      ...ws.current.layout(WAR_FLY),
+    }));
+
+    // Fly deciders slightly after face-downs
+    after(t(200), () => {
+      if (pDecider) ws.current.addCard(pDecider, { toTop: true, faceDown: true, rotation: rnd(-10, 10) });
+      if (dDecider) ws.current.addCard(dDecider, { toTop: true, faceDown: true, rotation: rnd(-10, 10) });
+
+      setPlayerCount(ps.current.size);
+      setDealerCount(ds.current.size);
+
+      setCardStates(prev => ({ ...prev, ...ws.current.layout(WAR_FLY) }));
+
+      // Flip deciders mid-flight
+      after(WAR_FLY / 2, () => {
+        const patches: Record<string, Partial<CardVisualState>> = {};
+        if (pDecider) patches[pDecider.id] = { faceDown: false };
+        if (dDecider) patches[dDecider.id] = { faceDown: false };
+        if (Object.keys(patches).length > 0) patchCards(patches);
       });
 
-      delay += t(TB.WAR_GAP);
-    }
+      // Resolve war after deciders land
+      after(WAR_FLY + t(300), () => {
+        let warResult: "player" | "dealer";
+        if (!pDecider && !dDecider) {
+          warResult = Math.random() < 0.5 ? "player" : "dealer";
+        } else if (!pDecider) {
+          warResult = "dealer";
+        } else if (!dDecider) {
+          warResult = "player";
+        } else {
+          warResult = warValue(pDecider) >= warValue(dDecider) ? "player" : "dealer";
+        }
 
-    const maxFd = Math.max(pFdN, dFdN);
-    for (let i = 0; i < maxFd; i++) {
-      if (i < pFaceDowns.length) flyWarCard(pFaceDowns[i], "player", false);
-      if (i < dFaceDowns.length) flyWarCard(dFaceDowns[i], "dealer", false);
-    }
-    if (pFaceUp) flyWarCard(pFaceUp, "player", true);
-    if (dFaceUp) flyWarCard(dFaceUp, "dealer", true);
+        setRoundCount(c => c + 1);
+        setBanner(warResult === "player" ? "You win the war!" : "Dealer wins the war.");
+        setBannerType(warResult === "player" ? "win" : "lose");
 
-    // Determine war result
-    let warResult: "player" | "dealer";
-    if (!pFaceUp && !dFaceUp) {
-      warResult = Math.random() < 0.5 ? "player" : "dealer";
-    } else if (!pFaceUp) {
-      warResult = "dealer";
-    } else if (!dFaceUp) {
-      warResult = "player";
-    } else {
-      const pv = warValue(pFaceUp);
-      const dv = warValue(dFaceUp);
-      warResult = pv >= dv ? "player" : "dealer"; // tiebreaker: player
-    }
+        after(t(600), () => {
+          const allWarCards = ws.current.cards;
+          ws.current.clear();
 
-    const afterFly = delay + t(TB.WAR_FLY) + t(TB.JUDGE);
+          const winner  = warResult === "player" ? ps.current : ds.current;
+          const shuffled = shuffle(allWarCards);
+          for (const c of shuffled) {
+            winner.addCard(c, { toTop: false, faceDown: true, rotation: rnd(-6, 6) });
+          }
 
-    after(afterFly, () => {
-      setRoundCount(c => c + 1);
-      setRoundResult(warResult);
-      setAnimPhase("war-result");
+          setPlayerCount(ps.current.size);
+          setDealerCount(ds.current.size);
+          setBanner("");
+          applyLayouts(winner.layout(WAR_COLLECT));
 
-      // Highlight deciders
-      setSprites(prev => prev.map(s => {
-        if (!s.isDecider) return s;
-        const wins = warResult === s.side;
-        return { ...s, scale: wins ? 1.07 : 0.93, opacity: wins ? 1 : 0.5 };
-      }));
-
-      after(t(TB.RESULT), () => {
-        setAnimPhase("war-collecting");
-        const winPos = warResult === "player" ? P.player : P.dealer;
-        setSprites(prev => prev.map(s => ({
-          ...s, x: winPos.x, y: winPos.y,
-          rot: rnd(-6, 6), scale: 1, opacity: 0.75, posMs: t(TB.COLLECT),
-        })));
-
-        after(t(TB.COLLECT) + 60, () => {
-          const allSpoils = shuffle([
-            pBattle, dBattle,
-            ...pFaceDowns, ...dFaceDowns,
-            ...(pFaceUp ? [pFaceUp] : []),
-            ...(dFaceUp ? [dFaceUp] : []),
-          ]);
-          if (warResult === "player") setPlayerPile(prev => [...prev, ...allSpoils]);
-          else setDealerPile(prev => [...prev, ...allSpoils]);
-          setSprites([]);
-          setWarMsg("");
-
-          const newPp = warResult === "player" ? [...pRemain, ...allSpoils] : pRemain;
-          const newDp = warResult === "dealer" ? [...dRemain, ...allSpoils] : dRemain;
-          if (newPp.length === 0) { setGameResult("dealer"); setAnimPhase("game-over"); }
-          else if (newDp.length === 0) { setGameResult("player"); setAnimPhase("game-over"); }
-          else setAnimPhase("idle");
+          after(WAR_COLLECT + 100, () => {
+            if (ps.current.size === 0) {
+              setPhase("game-over"); setBanner("Dealer wins."); setBannerType("lose");
+            } else if (ds.current.size === 0) {
+              setPhase("game-over"); setBanner("YOU WIN!"); setBannerType("win");
+            } else {
+              setPhase("idle");
+            }
+          });
         });
       });
     });
@@ -491,60 +440,39 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
   // ── Auto-play ─────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (!settings.warAutoPlay || animPhase !== "idle") return;
-    const id = setTimeout(flip, extraPause);
+    if (!settings.warAutoPlay || phase !== "idle") return;
+    const delay = Math.round(500 * (ANIM_MULT[settings.warSpeed] ?? 1.0));
+    const id = setTimeout(flip, delay);
     return () => clearTimeout(id);
-  }, [settings.warAutoPlay, animPhase, flip, extraPause]);
+  }, [settings.warAutoPlay, settings.warSpeed, phase, flip]);
 
   useEffect(() => {
-    if (!settings.warAutoPlay || animPhase !== "game-over") return;
+    if (!settings.warAutoPlay || phase !== "game-over") return;
     const id = setTimeout(startGame, 2500);
     return () => clearTimeout(id);
-  }, [settings.warAutoPlay, animPhase, startGame]);
+  }, [settings.warAutoPlay, phase, startGame]);
 
   // ── Render ─────────────────────────────────────────────────────────────────
-
-  function bannerText(): string {
-    if (warMsg) return warMsg;
-    if (animPhase === "result" || animPhase === "collecting") {
-      if (roundResult === "player") return "You win the round!";
-      if (roundResult === "dealer") return "Dealer wins the round.";
-    }
-    if (animPhase === "war-result" || animPhase === "war-collecting") {
-      if (roundResult === "player") return "You win the war!";
-      if (roundResult === "dealer") return "Dealer wins the war.";
-    }
-    if (animPhase === "game-over") {
-      return gameResult === "player" ? "YOU WIN!" : "Dealer wins.";
-    }
-    return "";
-  }
-
-  function bannerMod(): string {
-    if (gameResult === "player" || roundResult === "player") return "win";
-    if (gameResult === "dealer" || roundResult === "dealer") return "lose";
-    return "war";
-  }
-
-  const playerCount = playerPile.length + sprites.filter(s => s.side === "player").length;
-  const dealerCount = dealerPile.length + sprites.filter(s => s.side === "dealer").length;
 
   return (
     <div className="war">
       {showDeckModal && (
-        <DeckModal appearance={appearance} onUpdate={setAppearance} onClose={() => setShowDeckModal(false)} />
+        <DeckModal
+          appearance={appearance}
+          onUpdate={setAppearance}
+          onClose={() => setShowDeckModal(false)}
+        />
       )}
 
       <div className="war__scoreboard">
         <span>Round {roundCount}</span>
-        <span>You: {playerCount} cards</span>
-        <span>Dealer: {dealerCount} cards</span>
+        <span>You: {playerCount}</span>
+        <span>Dealer: {dealerCount}</span>
       </div>
 
-      {/* Stage: position:relative container for all animated elements */}
       <div className="war__stage">
-        {/* Shuffle animation */}
-        {shuffling && (
+        {/* Shuffle animation overlay — sits above permanent cards */}
+        {phase === "shuffle" && (
           <div className="war__shuffle">
             <div className="war__shuffle-half war__shuffle-half--l">
               <StackedPile count={20} appearance={appearance} />
@@ -555,60 +483,41 @@ export default function War({ settings, onNewGame, onQuit }: WarProps) {
           </div>
         )}
 
-        {/* Player pile */}
-        {!shuffling && (
-          <div className="war__pile war__pile--player">
-            <div className="war__pile-label">You</div>
-            <StackedPile count={playerPile.length} appearance={appearance} />
-            <div className="war__pile-count">{playerPile.length} left</div>
-          </div>
-        )}
+        {/* VS label when waiting for flip */}
+        {phase === "idle" && <div className="war__vs-label">VS</div>}
 
-        {/* VS label */}
-        {!shuffling && animPhase === "idle" && (
-          <div className="war__vs-label">VS</div>
-        )}
-
-        {/* Dealer pile */}
-        {!shuffling && (
-          <div className="war__pile war__pile--dealer">
-            <div className="war__pile-label">Dealer</div>
-            <StackedPile count={dealerPile.length} appearance={appearance} />
-            <div className="war__pile-count">{dealerPile.length} left</div>
-          </div>
-        )}
-
-        {/* Animated sprites */}
-        {sprites.map(s => (
-          <FlippableSprite key={s.id} s={s} appearance={appearance} />
-        ))}
+        {/* All 52 cards — permanently mounted, CSS transitions drive all animation */}
+        {allCards.map(card => {
+          const cs = cardStates[card.id];
+          if (!cs) return null;
+          return <PermCard key={card.id} card={card} cs={cs} appearance={appearance} />;
+        })}
       </div>
 
-      {/* Controls */}
       <div className="war__controls">
-        {bannerText() && (
-          <div className={`war__banner war__banner--${bannerMod()}`}>
-            {bannerText()}
+        {banner && (
+          <div className={`war__banner war__banner--${bannerType}`}>
+            {banner}
           </div>
         )}
 
-        {animPhase === "idle" && !settings.warAutoPlay && (
+        {phase === "idle" && !settings.warAutoPlay && (
           <button
             className="war__btn war__btn--primary"
             onClick={flip}
-            disabled={playerPile.length === 0 || dealerPile.length === 0}
+            disabled={playerCount === 0 || dealerCount === 0}
           >
             ▶ Flip
           </button>
         )}
 
-        {animPhase === "game-over" && !settings.warAutoPlay && (
+        {phase === "game-over" && !settings.warAutoPlay && (
           <button className="war__btn war__btn--primary" onClick={startGame}>
             New Game
           </button>
         )}
 
-        {animPhase === "game-over" && settings.warAutoPlay && (
+        {phase === "game-over" && settings.warAutoPlay && (
           <div className="war__auto-notice">Starting new game…</div>
         )}
       </div>

--- a/src/experiences/Cards/cardStack.ts
+++ b/src/experiences/Cards/cardStack.ts
@@ -7,6 +7,7 @@ export interface CardVisualState {
   rotation: number;
   faceDown: boolean;
   transitionMs: number;
+  transitionDelay?: number;  // per-card stagger for riffle effect
 }
 
 interface StackEntry {

--- a/src/experiences/Cards/cardStack.ts
+++ b/src/experiences/Cards/cardStack.ts
@@ -27,6 +27,11 @@ interface StackEntry {
  * accumulates Y positions using the per-card state rather than a uniform step.
  * This lets Klondike tableau columns fan face-down cards tightly and face-up
  * cards wider so rank/suit remains readable.
+ *
+ * Fan arc: startRotation / endRotation interpolate per-card rotation linearly
+ * from first card to last. centered=true treats baseX/baseY as the midpoint of
+ * the fan rather than the anchor of the first card — essential for hand fans
+ * that need to rebalance as cards are played.
  */
 export class CardStack {
   readonly zTier: number;
@@ -36,6 +41,9 @@ export class CardStack {
   readonly offsetY: number;
   readonly faceDownOffsetY?: number;
   readonly faceUpOffsetY?: number;
+  readonly centered: boolean;
+  readonly startRotation: number;
+  readonly endRotation: number;
   private entries: StackEntry[] = [];
 
   constructor(opts: {
@@ -46,6 +54,9 @@ export class CardStack {
     offsetY?: number;
     faceDownOffsetY?: number;
     faceUpOffsetY?: number;
+    centered?: boolean;
+    startRotation?: number;
+    endRotation?: number;
   }) {
     this.zTier            = opts.zTier;
     this.baseX            = opts.baseX;
@@ -54,6 +65,9 @@ export class CardStack {
     this.offsetY          = opts.offsetY ?? 0;
     this.faceDownOffsetY  = opts.faceDownOffsetY;
     this.faceUpOffsetY    = opts.faceUpOffsetY;
+    this.centered         = opts.centered      ?? false;
+    this.startRotation    = opts.startRotation ?? 0;
+    this.endRotation      = opts.endRotation   ?? 0;
   }
 
   get size(): number { return this.entries.length; }
@@ -125,20 +139,33 @@ export class CardStack {
    * If faceDownOffsetY / faceUpOffsetY are set, Y positions are accumulated
    * (each card's Y = previous card's Y + that card's step), allowing columns
    * where face-down cards are packed tighter than face-up cards.
+   *
+   * If centered=true and not in variable-fan mode, baseX/baseY is treated as
+   * the midpoint so the fan rebalances symmetrically as cards are added/removed.
+   *
+   * startRotation/endRotation interpolate per-card rotation linearly from the
+   * first card (startRotation) to the last (endRotation), creating an arc.
+   * When both are equal the fan is flat; all existing callers default to 0/0.
    */
   layout(transitionMs = 350): Record<string, CardVisualState> {
     const result: Record<string, CardVisualState> = {};
+    const n = this.entries.length;
     const variableFan = this.faceDownOffsetY !== undefined || this.faceUpOffsetY !== undefined;
+    // Center offset: shift indices so midpoint lands on baseX/baseY.
+    // Only applied in uniform-offset mode; variable-fan (Klondike tableau) ignores it.
+    const centerOff = (this.centered && !variableFan) ? (n - 1) / 2 : 0;
 
     if (variableFan) {
       let accumY = this.baseY;
-      for (let i = 0; i < this.entries.length; i++) {
+      for (let i = 0; i < n; i++) {
         const e = this.entries[i];
+        const t = n > 1 ? i / (n - 1) : 0.5;
+        const rot = e.rotation + this.startRotation + t * (this.endRotation - this.startRotation);
         result[e.card.id] = {
           x:          this.baseX + i * this.offsetX,
           y:          accumY,
           z:          this.zTier * 100 + i,
-          rotation:   e.rotation,
+          rotation:   rot,
           faceDown:   e.faceDown,
           transitionMs,
         };
@@ -148,13 +175,15 @@ export class CardStack {
         accumY += step;
       }
     } else {
-      for (let i = 0; i < this.entries.length; i++) {
+      for (let i = 0; i < n; i++) {
         const e = this.entries[i];
+        const t = n > 1 ? i / (n - 1) : 0.5;
+        const rot = e.rotation + this.startRotation + t * (this.endRotation - this.startRotation);
         result[e.card.id] = {
-          x:          this.baseX + i * this.offsetX,
-          y:          this.baseY + i * this.offsetY,
+          x:          this.baseX + (i - centerOff) * this.offsetX,
+          y:          this.baseY + (i - centerOff) * this.offsetY,
           z:          this.zTier * 100 + i,
-          rotation:   e.rotation,
+          rotation:   rot,
           faceDown:   e.faceDown,
           transitionMs,
         };

--- a/src/experiences/Cards/cardStack.ts
+++ b/src/experiences/Cards/cardStack.ts
@@ -22,6 +22,11 @@ interface StackEntry {
  * Manages an ordered list of cards (index 0 = bottom, index n-1 = top) and
  * computes absolute x/y/z positions within a stage. Call layout() after any
  * mutation to get the new CardVisualState map, then merge into React state.
+ *
+ * Variable fan: when faceDownOffsetY / faceUpOffsetY are provided, layout()
+ * accumulates Y positions using the per-card state rather than a uniform step.
+ * This lets Klondike tableau columns fan face-down cards tightly and face-up
+ * cards wider so rank/suit remains readable.
  */
 export class CardStack {
   readonly zTier: number;
@@ -29,6 +34,8 @@ export class CardStack {
   baseY: number;
   readonly offsetX: number;
   readonly offsetY: number;
+  readonly faceDownOffsetY?: number;
+  readonly faceUpOffsetY?: number;
   private entries: StackEntry[] = [];
 
   constructor(opts: {
@@ -37,18 +44,30 @@ export class CardStack {
     baseY: number;
     offsetX?: number;
     offsetY?: number;
+    faceDownOffsetY?: number;
+    faceUpOffsetY?: number;
   }) {
-    this.zTier = opts.zTier;
-    this.baseX = opts.baseX;
-    this.baseY = opts.baseY;
-    this.offsetX = opts.offsetX ?? 0;
-    this.offsetY = opts.offsetY ?? 0;
+    this.zTier            = opts.zTier;
+    this.baseX            = opts.baseX;
+    this.baseY            = opts.baseY;
+    this.offsetX          = opts.offsetX ?? 0;
+    this.offsetY          = opts.offsetY ?? 0;
+    this.faceDownOffsetY  = opts.faceDownOffsetY;
+    this.faceUpOffsetY    = opts.faceUpOffsetY;
   }
 
   get size(): number { return this.entries.length; }
 
   /** Returns a snapshot of card references, bottom → top. */
   get cards(): Card[] { return this.entries.map(e => e.card); }
+
+  /** Top card reference without removing it. */
+  get top(): Card | null { return this.entries.length > 0 ? this.entries[this.entries.length - 1].card : null; }
+
+  /** Whether the top card is face-down. */
+  get topFaceDown(): boolean {
+    return this.entries.length > 0 ? this.entries[this.entries.length - 1].faceDown : false;
+  }
 
   clear(): void { this.entries = []; }
 
@@ -60,12 +79,22 @@ export class CardStack {
   addCard(card: Card, opts: { toTop: boolean; faceDown: boolean; rotation?: number }): void {
     const entry: StackEntry = { card, faceDown: opts.faceDown, rotation: opts.rotation ?? 0 };
     if (opts.toTop) { this.entries.push(entry); }
-    else { this.entries.unshift(entry); }
+    else            { this.entries.unshift(entry); }
   }
 
   /** Remove and return the top card, or null if empty. */
   removeTop(): Card | null {
     return this.entries.pop()?.card ?? null;
+  }
+
+  /**
+   * Remove the top N cards (as a run, bottom→top order) and return them.
+   * Used by Klondike to lift a sequence off a tableau column.
+   */
+  removeTopN(n: number): Card[] {
+    if (n <= 0) return [];
+    const run = this.entries.splice(this.entries.length - n, n).map(e => e.card);
+    return run;
   }
 
   /** Remove a specific card by id. Returns the card, or null if not found. */
@@ -75,21 +104,55 @@ export class CardStack {
     return this.entries.splice(idx, 1)[0].card;
   }
 
+  /** Flip the top card face-up. No-op if stack is empty or top is already face-up. */
+  flipTop(): void {
+    if (this.entries.length > 0) {
+      this.entries[this.entries.length - 1].faceDown = false;
+    }
+  }
+
   setBase(x: number, y: number): void { this.baseX = x; this.baseY = y; }
 
-  /** Compute visual state for every card in this stack. */
+  /**
+   * Compute visual state for every card in this stack.
+   *
+   * If faceDownOffsetY / faceUpOffsetY are set, Y positions are accumulated
+   * (each card's Y = previous card's Y + that card's step), allowing columns
+   * where face-down cards are packed tighter than face-up cards.
+   */
   layout(transitionMs = 350): Record<string, CardVisualState> {
     const result: Record<string, CardVisualState> = {};
-    for (let i = 0; i < this.entries.length; i++) {
-      const e = this.entries[i];
-      result[e.card.id] = {
-        x: this.baseX + i * this.offsetX,
-        y: this.baseY + i * this.offsetY,
-        z: this.zTier * 100 + i,
-        rotation: e.rotation,
-        faceDown: e.faceDown,
-        transitionMs,
-      };
+    const variableFan = this.faceDownOffsetY !== undefined || this.faceUpOffsetY !== undefined;
+
+    if (variableFan) {
+      let accumY = this.baseY;
+      for (let i = 0; i < this.entries.length; i++) {
+        const e = this.entries[i];
+        result[e.card.id] = {
+          x:          this.baseX + i * this.offsetX,
+          y:          accumY,
+          z:          this.zTier * 100 + i,
+          rotation:   e.rotation,
+          faceDown:   e.faceDown,
+          transitionMs,
+        };
+        const step = e.faceDown
+          ? (this.faceDownOffsetY ?? this.offsetY)
+          : (this.faceUpOffsetY  ?? this.offsetY);
+        accumY += step;
+      }
+    } else {
+      for (let i = 0; i < this.entries.length; i++) {
+        const e = this.entries[i];
+        result[e.card.id] = {
+          x:          this.baseX + i * this.offsetX,
+          y:          this.baseY + i * this.offsetY,
+          z:          this.zTier * 100 + i,
+          rotation:   e.rotation,
+          faceDown:   e.faceDown,
+          transitionMs,
+        };
+      }
     }
     return result;
   }

--- a/src/experiences/Cards/cardStack.ts
+++ b/src/experiences/Cards/cardStack.ts
@@ -1,0 +1,95 @@
+import type { Card } from "./types";
+
+export interface CardVisualState {
+  x: number;
+  y: number;
+  z: number;
+  rotation: number;
+  faceDown: boolean;
+  transitionMs: number;
+}
+
+interface StackEntry {
+  card: Card;
+  faceDown: boolean;
+  rotation: number;
+}
+
+/**
+ * Pure-logic stack primitive — no React.
+ *
+ * Manages an ordered list of cards (index 0 = bottom, index n-1 = top) and
+ * computes absolute x/y/z positions within a stage. Call layout() after any
+ * mutation to get the new CardVisualState map, then merge into React state.
+ */
+export class CardStack {
+  readonly zTier: number;
+  baseX: number;
+  baseY: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  private entries: StackEntry[] = [];
+
+  constructor(opts: {
+    zTier: number;
+    baseX: number;
+    baseY: number;
+    offsetX?: number;
+    offsetY?: number;
+  }) {
+    this.zTier = opts.zTier;
+    this.baseX = opts.baseX;
+    this.baseY = opts.baseY;
+    this.offsetX = opts.offsetX ?? 0;
+    this.offsetY = opts.offsetY ?? 0;
+  }
+
+  get size(): number { return this.entries.length; }
+
+  /** Returns a snapshot of card references, bottom → top. */
+  get cards(): Card[] { return this.entries.map(e => e.card); }
+
+  clear(): void { this.entries = []; }
+
+  /**
+   * Add a card.
+   * toTop=true  → top of stack (highest z, rendered on top).
+   * toTop=false → bottom of stack (z = zTier*100 + 0, slides under existing cards).
+   */
+  addCard(card: Card, opts: { toTop: boolean; faceDown: boolean; rotation?: number }): void {
+    const entry: StackEntry = { card, faceDown: opts.faceDown, rotation: opts.rotation ?? 0 };
+    if (opts.toTop) { this.entries.push(entry); }
+    else { this.entries.unshift(entry); }
+  }
+
+  /** Remove and return the top card, or null if empty. */
+  removeTop(): Card | null {
+    return this.entries.pop()?.card ?? null;
+  }
+
+  /** Remove a specific card by id. Returns the card, or null if not found. */
+  removeCard(id: string): Card | null {
+    const idx = this.entries.findIndex(e => e.card.id === id);
+    if (idx === -1) return null;
+    return this.entries.splice(idx, 1)[0].card;
+  }
+
+  setBase(x: number, y: number): void { this.baseX = x; this.baseY = y; }
+
+  /** Compute visual state for every card in this stack. */
+  layout(transitionMs = 350): Record<string, CardVisualState> {
+    const result: Record<string, CardVisualState> = {};
+    for (let i = 0; i < this.entries.length; i++) {
+      const e = this.entries[i];
+      result[e.card.id] = {
+        x: this.baseX + i * this.offsetX,
+        y: this.baseY + i * this.offsetY,
+        z: this.zTier * 100 + i,
+        rotation: e.rotation,
+        faceDown: e.faceDown,
+        transitionMs,
+      };
+    }
+    return result;
+  }
+}

--- a/src/experiences/Cards/cardStack.ts
+++ b/src/experiences/Cards/cardStack.ts
@@ -111,6 +111,12 @@ export class CardStack {
     }
   }
 
+  /** Update the faceDown state of a specific card by id (used for hole-card reveal). */
+  setFaceDown(id: string, faceDown: boolean): void {
+    const entry = this.entries.find(e => e.card.id === id);
+    if (entry) entry.faceDown = faceDown;
+  }
+
   setBase(x: number, y: number): void { this.baseX = x; this.baseY = y; }
 
   /**

--- a/src/experiences/Cards/trickTakingEngine.ts
+++ b/src/experiences/Cards/trickTakingEngine.ts
@@ -1,0 +1,74 @@
+import type { Card, Suit } from "./types";
+
+export interface TrickPlay {
+  playerIndex: number;
+  card: Card;
+}
+
+const RANK_VALUES: Record<string, number> = {
+  "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8,
+  "9": 9, "10": 10, "J": 11, "Q": 12, "K": 13, "A": 14,
+};
+
+export function rankValue(rank: string): number {
+  return RANK_VALUES[rank] ?? 0;
+}
+
+export function dealHands(deck: Card[], numPlayers: number): Card[][] {
+  const hands: Card[][] = Array.from({ length: numPlayers }, () => [] as Card[]);
+  deck.forEach((card, i) => {
+    hands[i % numPlayers].push(card);
+  });
+  return hands;
+}
+
+export function getValidHeartPlays(
+  hand: Card[],
+  ledSuit: Suit | null,
+  heartsAreBroken: boolean,
+  isFirstTrick: boolean,
+): Card[] {
+  if (ledSuit) {
+    const suitCards = hand.filter((c) => c.suit === ledSuit);
+    if (suitCards.length > 0) return suitCards;
+    // Can't follow suit; can't play hearts/QoS on trick 1 if avoidable
+    if (isFirstTrick) {
+      const safe = hand.filter(
+        (c) => c.suit !== "hearts" && !(c.suit === "spades" && c.rank === "Q"),
+      );
+      if (safe.length > 0) return safe;
+    }
+    return hand;
+  }
+  // Leading — block hearts until broken (unless hand is all hearts)
+  if (!heartsAreBroken) {
+    const nonHearts = hand.filter((c) => c.suit !== "hearts");
+    if (nonHearts.length > 0) return nonHearts;
+  }
+  return hand;
+}
+
+export function resolveTrick(trick: TrickPlay[], ledSuit: Suit): number {
+  let winnerIdx = 0;
+  let winnerVal = -1;
+  for (const play of trick) {
+    if (play.card.suit === ledSuit) {
+      const v = rankValue(play.card.rank as string);
+      if (v > winnerVal) {
+        winnerVal = v;
+        winnerIdx = play.playerIndex;
+      }
+    }
+  }
+  return winnerIdx;
+}
+
+export function heartPoints(card: Card): number {
+  if (card.suit === "hearts") return 1;
+  if (card.suit === "spades" && card.rank === "Q") return 13;
+  return 0;
+}
+
+export function trickPoints(cards: Card[]): number {
+  return cards.reduce((sum, c) => sum + heartPoints(c), 0);
+}

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -9,6 +9,7 @@ export interface Card {
 
 export type BackPattern = "crosshatch" | "diagonal" | "diamonds" | "noahsoft";
 export type CardFaceStyle = "classic" | "minimal" | "large-index";
+export type SuitColorMode = "standard" | "four-color" | "high-contrast";
 export type WarSpeed = "slow" | "normal" | "fast";
 export type MemoryDifficulty = "easy" | "medium" | "hard";
 
@@ -17,7 +18,7 @@ export interface CardAppearance {
   backSecondaryColor: string;
   backPattern: BackPattern;
   backImageUrl: string | null;
-  fourColorSuits: boolean;
+  suitColorMode: SuitColorMode;
   cardFaceStyle: CardFaceStyle;
 }
 
@@ -30,6 +31,7 @@ export interface DeckSettings {
   warSpeed: WarSpeed;
   memoryDifficulty: MemoryDifficulty;
   klondikeDraw: 1 | 3;
+  klondikeRelaxed: boolean;
 }
 
 export type CardsGame =
@@ -46,7 +48,7 @@ export const DEFAULT_APPEARANCE: CardAppearance = {
   backSecondaryColor: "#ffffff",
   backPattern: "crosshatch",
   backImageUrl: null,
-  fourColorSuits: false,
+  suitColorMode: "standard",
   cardFaceStyle: "classic",
 };
 
@@ -59,4 +61,5 @@ export const DEFAULT_DECK_SETTINGS: DeckSettings = {
   warSpeed: "normal",
   memoryDifficulty: "easy",
   klondikeDraw: 1,
+  klondikeRelaxed: false,
 };

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -9,6 +9,7 @@ export interface Card {
 
 export type BackPattern = "crosshatch" | "diagonal" | "diamonds" | "noahsoft";
 export type CardFaceStyle = "classic" | "minimal" | "large-index";
+export type CardTextSize = "normal" | "large" | "xl";
 export type SuitColorMode = "standard" | "four-color" | "high-contrast";
 export type WarSpeed = "slow" | "normal" | "fast";
 export type MemoryDifficulty = "easy" | "medium" | "hard";
@@ -20,6 +21,7 @@ export interface CardAppearance {
   backImageUrl: string | null;
   suitColorMode: SuitColorMode;
   cardFaceStyle: CardFaceStyle;
+  cardTextSize: CardTextSize;
 }
 
 export interface DeckSettings {
@@ -50,6 +52,7 @@ export const DEFAULT_APPEARANCE: CardAppearance = {
   backImageUrl: null,
   suitColorMode: "standard",
   cardFaceStyle: "classic",
+  cardTextSize: "normal",
 };
 
 export const DEFAULT_DECK_SETTINGS: DeckSettings = {

--- a/src/experiences/Cards/types.ts
+++ b/src/experiences/Cards/types.ts
@@ -7,38 +7,56 @@ export interface Card {
   id: string;
 }
 
-export interface CardBackColor {
-  label: string;
-  color: string;
-}
-
-export const CARD_BACK_COLORS: CardBackColor[] = [
-  { label: "Orange",  color: "#cc4400" },
-  { label: "Purple",  color: "#5b2d8e" },
-  { label: "Blue",    color: "#1a4a8a" },
-  { label: "Green",   color: "#1a5c2a" },
-  { label: "Red",     color: "#8a1a1a" },
-  { label: "Black",   color: "#1a1a1a" },
-];
-
+export type BackPattern = "crosshatch" | "diagonal" | "diamonds" | "noahsoft";
+export type CardFaceStyle = "classic" | "minimal" | "large-index";
 export type WarSpeed = "slow" | "normal" | "fast";
+export type MemoryDifficulty = "easy" | "medium" | "hard";
+
+export interface CardAppearance {
+  backPrimaryColor: string;
+  backSecondaryColor: string;
+  backPattern: BackPattern;
+  backImageUrl: string | null;
+  fourColorSuits: boolean;
+  cardFaceStyle: CardFaceStyle;
+}
 
 export interface DeckSettings {
   numDecks: number;
   suits: Suit[];
   includeJokers: boolean;
-  cardBack: string;
+  appearance: CardAppearance;
   warAutoPlay: boolean;
   warSpeed: WarSpeed;
+  memoryDifficulty: MemoryDifficulty;
+  klondikeDraw: 1 | 3;
 }
 
-export type CardsGame = "war" | "blackjack" | "pyramid";
+export type CardsGame =
+  | "war"
+  | "blackjack"
+  | "pyramid"
+  | "memory"
+  | "klondike"
+  | "freecell"
+  | "hearts";
+
+export const DEFAULT_APPEARANCE: CardAppearance = {
+  backPrimaryColor: "#cc4400",
+  backSecondaryColor: "#ffffff",
+  backPattern: "crosshatch",
+  backImageUrl: null,
+  fourColorSuits: false,
+  cardFaceStyle: "classic",
+};
 
 export const DEFAULT_DECK_SETTINGS: DeckSettings = {
   numDecks: 1,
   suits: ["spades", "hearts", "diamonds", "clubs"],
   includeJokers: false,
-  cardBack: "#cc4400",
+  appearance: DEFAULT_APPEARANCE,
   warAutoPlay: false,
   warSpeed: "normal",
+  memoryDifficulty: "easy",
+  klondikeDraw: 1,
 };

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -36,6 +36,10 @@ import CardsLauncher from "../Cards/CardsLauncher";
 import War from "../Cards/War";
 import Blackjack from "../Cards/Blackjack";
 import Pyramid from "../Cards/Pyramid";
+import Memory from "../Cards/Memory";
+import Klondike from "../Cards/Klondike";
+import FreeCell from "../Cards/FreeCell";
+import Hearts from "../Cards/Hearts";
 import type { CardsGame, DeckSettings } from "../Cards/types";
 import BootScreen, { shouldShowBoot, playShutdownSound } from "./BootScreen";
 import DisplayApp, { WALLPAPER_PRESET_URLS } from "./DisplayApp";
@@ -214,8 +218,8 @@ let windowSeq = 0;
 let maxZ = 100;
 
 const TTT_WINDOW_WIDTHS: Record<3 | 5 | 7, number> = { 3: 380, 5: 480, 7: 580 };
-const CARDS_GAME_TITLES: Record<CardsGame, string> = { "war": "War", "blackjack": "Blackjack", "pyramid": "Pyramid" };
-const CARDS_GAME_WIDTHS: Record<CardsGame, number> = { "war": 440, "blackjack": 520, "pyramid": 460 };
+const CARDS_GAME_TITLES: Record<CardsGame, string> = { "war": "War", "blackjack": "Blackjack", "pyramid": "Pyramid", "memory": "Memory", "klondike": "Klondike", "freecell": "FreeCell", "hearts": "Hearts" };
+const CARDS_GAME_WIDTHS: Record<CardsGame, number> = { "war": 440, "blackjack": 520, "pyramid": 460, "memory": 460, "klondike": 620, "freecell": 620, "hearts": 560 };
 const BF_WINDOW_WIDTHS: Record<BfDifficulty, number> = {
   beginner: 310,
   intermediate: 470,
@@ -841,6 +845,18 @@ export default function NsDoors97() {
           )}
           {win.content.type === "cards-game" && win.content.game === "pyramid" && (
             <Pyramid settings={win.content.settings} onNewGame={() => handleCardsGameClose(win.id)} onQuit={() => closeWindow(win.id)} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "memory" && (
+            <Memory settings={win.content.settings} onNewGame={() => handleCardsGameClose(win.id)} onQuit={() => closeWindow(win.id)} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "klondike" && (
+            <Klondike settings={win.content.settings} onNewGame={() => handleCardsGameClose(win.id)} onQuit={() => closeWindow(win.id)} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "freecell" && (
+            <FreeCell settings={win.content.settings} onNewGame={() => handleCardsGameClose(win.id)} onQuit={() => closeWindow(win.id)} />
+          )}
+          {win.content.type === "cards-game" && win.content.game === "hearts" && (
+            <Hearts settings={win.content.settings} onNewGame={() => handleCardsGameClose(win.id)} onQuit={() => closeWindow(win.id)} />
           )}
           {win.content.type === "bombfinder" && (
             <BombFinder

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -665,9 +665,9 @@ export default function NsDoors97() {
   const handleCardsLaunch = useCallback(
     (launcherWinId: string, game: CardsGame, settings: DeckSettings) => {
       setOpenWindows((prev) => {
+        const launcherPos = prev.find((w) => w.id === launcherWinId)?.defaultPosition
+          ?? { x: 80, y: 48 };
         const filtered = prev.filter((w) => w.id !== launcherWinId);
-        const offset = (windowSeq % 8) * 32;
-        windowSeq++;
         maxZ++;
         setActiveWindowId("cards-game");
         return [
@@ -678,7 +678,7 @@ export default function NsDoors97() {
             icon: "🃏",
             content: { type: "cards-game" as const, game, settings },
             zIndex: maxZ,
-            defaultPosition: { x: 80 + offset, y: 48 + offset },
+            defaultPosition: launcherPos,
             width: CARDS_GAME_WIDTHS[game],
             minimized: false,
           },
@@ -691,9 +691,9 @@ export default function NsDoors97() {
   // Close the Cards game and reopen the launcher
   const handleCardsGameClose = useCallback((id: string) => {
     setOpenWindows((prev) => {
+      const gamePos = prev.find((w) => w.id === id)?.defaultPosition
+        ?? { x: 80, y: 48 };
       const filtered = prev.filter((w) => w.id !== id);
-      const offset = (windowSeq % 8) * 32;
-      windowSeq++;
       maxZ++;
       setActiveWindowId("cards");
       return [
@@ -704,7 +704,7 @@ export default function NsDoors97() {
           icon: "🃏",
           content: { type: "cards-launcher" as const },
           zIndex: maxZ,
-          defaultPosition: { x: 80 + offset, y: 48 + offset },
+          defaultPosition: gamePos,
           width: 320,
           minimized: false,
         },


### PR DESCRIPTION
New games:
- Memory/Concentration (Easy/Medium/Hard difficulties)
- Klondike Solitaire (Draw 1 or Draw 3)
- FreeCell (with supermove rule)
- Hearts (4-player with AI, passing phase, shoot-the-moon)
- trickTakingEngine.ts — shared engine for future trick-taking games

Deck customization:
- Expanded DeckModal with Back/Face tabs
- 4 card back patterns: crosshatch, diagonal, diamonds, noahsoft (NS watermark)
- Primary + secondary color pickers with presets + native color input
- Custom image upload for card backs (stored as data URL)
- Four-color suits: ♠ dark blue, ♣ dark green
- Card face styles: Classic, Minimal, Large Index

Animations:
- Deal-in animation: cards slide in with staggered delay (dealIndex prop)
- Card-reveal animation in War (re-keyed per round)
- Blackjack staggered deal on new hand
- Pyramid: smooth fade+scale-out on card removal (CSS transition)

UI polish:
- Checkboxes now use accent-color: #cc4400 (was bare browser default)
- All existing games updated to use new CardAppearance system
- Menu label renamed to "Card Appearance…"

https://claude.ai/code/session_01J2AMnd2V9LhoWmHCyUwVEF