### PR TITLE
Add Mahjong Solitaire (turtle match-2) game

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,37 @@ Add new stable IDs here when an app needs to find a specific file without traver
 3. In the component: use `fsStore.writeFile(id, content)` to save, `fsStore.getFile(id)?.content` to load. Check FS first, then any legacy storage key, then delete the legacy key (one-time migration).
 4. If the file needs to open with a specific app when double-clicked from FilesApp, set `appId` on the FSFile.
 
+### Mandatory: in-progress game state must survive reload/rotation
+
+**The web is brittle.** Mobile browsers reload pages on screen rotation, tab
+suspension reclaims memory, and users refresh by habit. Any game with an
+in-progress session (a board, a score, a timer) MUST persist that session to
+`fsStore` so it survives a reload — not just final high scores. Losing a
+half-finished game is a bad user experience and is treated as a bug.
+
+Pattern (see `MahjongSolitaire.tsx` for a full example using `MJ_STATE_ID` /
+`SAVE.DAT`):
+
+1. Add a stable `*_STATE_ID` constant (e.g. `MJ_STATE_ID = "fs:mj-state"`) and
+   create a `SAVE.DAT` file for it in both `seed.ts` and `migrate()`, alongside
+   any `SCORES.DAT`.
+2. On mount, lazily read and `JSON.parse` the save file. Validate its shape
+   (version number, expected slot/cell IDs) before trusting it — fall back to
+   a fresh game if it doesn't match. Use the parsed result to lazily initialize
+   `useState` for board/score/etc.
+3. For elapsed time, store `elapsedSec` *and* a `savedAt` timestamp; on reload,
+   add `(Date.now() - savedAt) / 1000` to the saved `elapsedSec` rather than
+   running a continuous interval-driven write.
+4. Write the save file (`fsStore.writeFile`) after each meaningful state
+   change (a move, a match, a shuffle, a new game) and once on mount so a
+   rotation immediately after opening the game doesn't lose the initial state.
+   Avoid writing on every timer tick — `fsStore.save()` serializes the entire
+   filesystem on every write, so per-second writes are wasteful.
+5. On a win/game-over, clear the save (`fsStore.writeFile(id, "")`) — a
+   finished game has nothing to resume.
+
+This applies to all new games and toys with session state, not just Mahjong.
+
 ### Key API
 
 ```typescript

--- a/public/mahjong-tiles/bamboo-1.svg
+++ b/public/mahjong-tiles/bamboo-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<path d="M32 20 C 24 24, 18 32, 18 42 C 18 50, 24 56, 30 58 L 26 66 L 34 60 C 42 60, 48 52, 47 42 C 46 34, 40 26, 32 20 Z M 38 30 L 48 24 L 44 34 Z" fill="#1a5c28"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-1.svg
+++ b/public/mahjong-tiles/bamboo-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <path d="M32 20 C 24 24, 18 32, 18 42 C 18 50, 24 56, 30 58 L 26 66 L 34 60 C 42 60, 48 52, 47 42 C 46 34, 40 26, 32 20 Z M 38 30 L 48 24 L 44 34 Z" fill="#1a5c28"/>
 </svg>

--- a/public/mahjong-tiles/bamboo-2.svg
+++ b/public/mahjong-tiles/bamboo-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="10.4" y="7.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="10.9" y1="17.1" x2="21.1" y2="17.1" stroke="#145522" stroke-width="1.2"/><line x1="10.9" y1="26.6" x2="21.1" y2="26.6" stroke="#145522" stroke-width="1.2"/>
 <rect x="42.4" y="51.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="42.9" y1="61.1" x2="53.1" y2="61.1" stroke="#145522" stroke-width="1.2"/><line x1="42.9" y1="70.6" x2="53.1" y2="70.6" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-2.svg
+++ b/public/mahjong-tiles/bamboo-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="10.4" y="7.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="10.9" y1="17.1" x2="21.1" y2="17.1" stroke="#145522" stroke-width="1.2"/><line x1="10.9" y1="26.6" x2="21.1" y2="26.6" stroke="#145522" stroke-width="1.2"/>
+<rect x="42.4" y="51.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="42.9" y1="61.1" x2="53.1" y2="61.1" stroke="#145522" stroke-width="1.2"/><line x1="42.9" y1="70.6" x2="53.1" y2="70.6" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-3.svg
+++ b/public/mahjong-tiles/bamboo-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="10.4" y="7.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="10.9" y1="17.1" x2="21.1" y2="17.1" stroke="#145522" stroke-width="1.2"/><line x1="10.9" y1="26.6" x2="21.1" y2="26.6" stroke="#145522" stroke-width="1.2"/>
+<rect x="26.4" y="29.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="26.9" y1="39.1" x2="37.1" y2="39.1" stroke="#145522" stroke-width="1.2"/><line x1="26.9" y1="48.6" x2="37.1" y2="48.6" stroke="#145522" stroke-width="1.2"/>
+<rect x="42.4" y="51.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="42.9" y1="61.1" x2="53.1" y2="61.1" stroke="#145522" stroke-width="1.2"/><line x1="42.9" y1="70.6" x2="53.1" y2="70.6" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-3.svg
+++ b/public/mahjong-tiles/bamboo-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="10.4" y="7.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="10.9" y1="17.1" x2="21.1" y2="17.1" stroke="#145522" stroke-width="1.2"/><line x1="10.9" y1="26.6" x2="21.1" y2="26.6" stroke="#145522" stroke-width="1.2"/>
 <rect x="26.4" y="29.6" width="11.2" height="28.8" rx="5.1" fill="#228833"/><line x1="26.9" y1="39.1" x2="37.1" y2="39.1" stroke="#145522" stroke-width="1.2"/><line x1="26.9" y1="48.6" x2="37.1" y2="48.6" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-4.svg
+++ b/public/mahjong-tiles/bamboo-4.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="12.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="62.6" x2="19.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="69.2" x2="19.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="62.6" x2="51.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="69.2" x2="51.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-4.svg
+++ b/public/mahjong-tiles/bamboo-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
 <rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-5.svg
+++ b/public/mahjong-tiles/bamboo-5.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="28.1" y="34.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="28.6" y1="40.6" x2="35.4" y2="40.6" stroke="#145522" stroke-width="1.2"/><line x1="28.6" y1="47.2" x2="35.4" y2="47.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="12.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="62.6" x2="19.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="69.2" x2="19.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="62.6" x2="51.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="69.2" x2="51.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-5.svg
+++ b/public/mahjong-tiles/bamboo-5.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
 <rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-6.svg
+++ b/public/mahjong-tiles/bamboo-6.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="12.1" y="34.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="40.6" x2="19.4" y2="40.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="47.2" x2="19.4" y2="47.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="34.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="40.6" x2="51.4" y2="40.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="47.2" x2="51.4" y2="47.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="12.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="62.6" x2="19.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="69.2" x2="19.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+<rect x="44.1" y="56.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="62.6" x2="51.4" y2="62.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="69.2" x2="51.4" y2="69.2" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-6.svg
+++ b/public/mahjong-tiles/bamboo-6.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="12.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="12.6" y1="18.6" x2="19.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="12.6" y1="25.2" x2="19.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>
 <rect x="44.1" y="12.1" width="7.7" height="19.8" rx="3.5" fill="#228833"/><line x1="44.6" y1="18.6" x2="51.4" y2="18.6" stroke="#145522" stroke-width="1.2"/><line x1="44.6" y1="25.2" x2="51.4" y2="25.2" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-7.svg
+++ b/public/mahjong-tiles/bamboo-7.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
 <rect x="45.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="19.4" x2="50.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="24.4" x2="50.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-7.svg
+++ b/public/mahjong-tiles/bamboo-7.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="19.4" x2="50.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="24.4" x2="50.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="41.4" x2="34.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="46.4" x2="34.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="41.4" x2="18.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="46.4" x2="18.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="63.4" x2="18.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="68.4" x2="18.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="63.4" x2="34.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="68.4" x2="34.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="63.4" x2="50.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="68.4" x2="50.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-8.svg
+++ b/public/mahjong-tiles/bamboo-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
 <rect x="29.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="19.4" x2="34.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="24.4" x2="34.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/bamboo-8.svg
+++ b/public/mahjong-tiles/bamboo-8.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="19.4" x2="34.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="24.4" x2="34.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="19.4" x2="50.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="24.4" x2="50.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="63.4" x2="18.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="68.4" x2="18.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="63.4" x2="34.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="68.4" x2="34.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="63.4" x2="50.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="68.4" x2="50.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="41.4" x2="18.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="46.4" x2="18.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="41.4" x2="50.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="46.4" x2="50.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-9.svg
+++ b/public/mahjong-tiles/bamboo-9.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="19.4" x2="34.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="24.4" x2="34.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="19.4" x2="50.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="24.4" x2="50.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="41.4" x2="18.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="46.4" x2="18.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="41.4" x2="34.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="46.4" x2="34.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="36.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="41.4" x2="50.5" y2="41.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="46.4" x2="50.5" y2="46.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="13.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="63.4" x2="18.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="68.4" x2="18.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="29.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="63.4" x2="34.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="68.4" x2="34.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+<rect x="45.0" y="58.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="45.5" y1="63.4" x2="50.5" y2="63.4" stroke="#145522" stroke-width="1.2"/><line x1="45.5" y1="68.4" x2="50.5" y2="68.4" stroke="#145522" stroke-width="1.2"/>
+</svg>

--- a/public/mahjong-tiles/bamboo-9.svg
+++ b/public/mahjong-tiles/bamboo-9.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="13.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="13.5" y1="19.4" x2="18.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="13.5" y1="24.4" x2="18.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>
 <rect x="29.0" y="14.4" width="6.0" height="15.3" rx="2.7" fill="#228833"/><line x1="29.5" y1="19.4" x2="34.5" y2="19.4" stroke="#145522" stroke-width="1.2"/><line x1="29.5" y1="24.4" x2="34.5" y2="24.4" stroke="#145522" stroke-width="1.2"/>

--- a/public/mahjong-tiles/chars-1.svg
+++ b/public/mahjong-tiles/chars-1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">1</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-1.svg
+++ b/public/mahjong-tiles/chars-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">1</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-2.svg
+++ b/public/mahjong-tiles/chars-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">2</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-2.svg
+++ b/public/mahjong-tiles/chars-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">2</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-3.svg
+++ b/public/mahjong-tiles/chars-3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">3</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-3.svg
+++ b/public/mahjong-tiles/chars-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">3</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-4.svg
+++ b/public/mahjong-tiles/chars-4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">4</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-4.svg
+++ b/public/mahjong-tiles/chars-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">4</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-5.svg
+++ b/public/mahjong-tiles/chars-5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">5</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-5.svg
+++ b/public/mahjong-tiles/chars-5.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">5</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-6.svg
+++ b/public/mahjong-tiles/chars-6.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">6</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-6.svg
+++ b/public/mahjong-tiles/chars-6.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">6</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-7.svg
+++ b/public/mahjong-tiles/chars-7.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">7</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-7.svg
+++ b/public/mahjong-tiles/chars-7.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">7</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-8.svg
+++ b/public/mahjong-tiles/chars-8.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">8</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/chars-8.svg
+++ b/public/mahjong-tiles/chars-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">8</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-9.svg
+++ b/public/mahjong-tiles/chars-9.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">9</text>
 <rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>

--- a/public/mahjong-tiles/chars-9.svg
+++ b/public/mahjong-tiles/chars-9.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<text x="32" y="38" font-family="Georgia, serif" font-weight="bold" font-size="32" fill="#000000" text-anchor="middle" dominant-baseline="middle">9</text>
+<rect x="18" y="58" width="28" height="4" fill="#cc4400"/><rect x="24" y="64" width="4" height="14" fill="#cc4400"/><rect x="36" y="64" width="4" height="14" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-1.svg
+++ b/public/mahjong-tiles/dots-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
 </svg>

--- a/public/mahjong-tiles/dots-1.svg
+++ b/public/mahjong-tiles/dots-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-2.svg
+++ b/public/mahjong-tiles/dots-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-2.svg
+++ b/public/mahjong-tiles/dots-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-3.svg
+++ b/public/mahjong-tiles/dots-3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-3.svg
+++ b/public/mahjong-tiles/dots-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-4.svg
+++ b/public/mahjong-tiles/dots-4.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-4.svg
+++ b/public/mahjong-tiles/dots-4.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-5.svg
+++ b/public/mahjong-tiles/dots-5.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-5.svg
+++ b/public/mahjong-tiles/dots-5.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-6.svg
+++ b/public/mahjong-tiles/dots-6.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-6.svg
+++ b/public/mahjong-tiles/dots-6.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-7.svg
+++ b/public/mahjong-tiles/dots-7.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-7.svg
+++ b/public/mahjong-tiles/dots-7.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-8.svg
+++ b/public/mahjong-tiles/dots-8.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="32" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-8.svg
+++ b/public/mahjong-tiles/dots-8.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="44" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dots-9.svg
+++ b/public/mahjong-tiles/dots-9.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
 <circle cx="32" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="22" r="2.4" fill="#cc4400"/>

--- a/public/mahjong-tiles/dots-9.svg
+++ b/public/mahjong-tiles/dots-9.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<circle cx="16" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="22" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="22" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="44" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="44" r="2.4" fill="#cc4400"/>
+<circle cx="16" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="16" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="32" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="32" cy="66" r="2.4" fill="#cc4400"/>
+<circle cx="48" cy="66" r="7" fill="white" stroke="#1a5fb4" stroke-width="3"/><circle cx="48" cy="66" r="2.4" fill="#cc4400"/>
+</svg>

--- a/public/mahjong-tiles/dragon-green.svg
+++ b/public/mahjong-tiles/dragon-green.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="17" y="24" width="30" height="40" rx="6" fill="#228833"/><rect x="25" y="34" width="14" height="20" rx="3" fill="#f5f0e0"/>
 </svg>

--- a/public/mahjong-tiles/dragon-green.svg
+++ b/public/mahjong-tiles/dragon-green.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="17" y="24" width="30" height="40" rx="6" fill="#228833"/><rect x="25" y="34" width="14" height="20" rx="3" fill="#f5f0e0"/>
+</svg>

--- a/public/mahjong-tiles/dragon-red.svg
+++ b/public/mahjong-tiles/dragon-red.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="17" y="24" width="30" height="40" rx="6" fill="#cc4400"/><rect x="25" y="34" width="14" height="20" rx="3" fill="#f5f0e0"/>
+</svg>

--- a/public/mahjong-tiles/dragon-red.svg
+++ b/public/mahjong-tiles/dragon-red.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="17" y="24" width="30" height="40" rx="6" fill="#cc4400"/><rect x="25" y="34" width="14" height="20" rx="3" fill="#f5f0e0"/>
 </svg>

--- a/public/mahjong-tiles/dragon-white.svg
+++ b/public/mahjong-tiles/dragon-white.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="10" y="10" width="44" height="68" fill="none" stroke="#1a5fb4" stroke-width="2"/><rect x="15" y="15" width="34" height="58" fill="none" stroke="#1a5fb4" stroke-width="1.5"/>
 </svg>

--- a/public/mahjong-tiles/dragon-white.svg
+++ b/public/mahjong-tiles/dragon-white.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="10" y="10" width="44" height="68" fill="none" stroke="#1a5fb4" stroke-width="2"/><rect x="15" y="15" width="34" height="58" fill="none" stroke="#1a5fb4" stroke-width="1.5"/>
+</svg>

--- a/public/mahjong-tiles/flower-1.svg
+++ b/public/mahjong-tiles/flower-1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <ellipse cx="32.0" cy="30.0" rx="13" ry="8" fill="#7b3dbe" transform="rotate(0.0 32.0 30.0)"/>
 <ellipse cx="45.3" cy="39.7" rx="13" ry="8" fill="#7b3dbe" transform="rotate(72.0 45.3 39.7)"/>

--- a/public/mahjong-tiles/flower-1.svg
+++ b/public/mahjong-tiles/flower-1.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<ellipse cx="32.0" cy="30.0" rx="13" ry="8" fill="#7b3dbe" transform="rotate(0.0 32.0 30.0)"/>
+<ellipse cx="45.3" cy="39.7" rx="13" ry="8" fill="#7b3dbe" transform="rotate(72.0 45.3 39.7)"/>
+<ellipse cx="40.2" cy="55.3" rx="13" ry="8" fill="#7b3dbe" transform="rotate(144.0 40.2 55.3)"/>
+<ellipse cx="23.8" cy="55.3" rx="13" ry="8" fill="#7b3dbe" transform="rotate(216.0 23.8 55.3)"/>
+<ellipse cx="18.7" cy="39.7" rx="13" ry="8" fill="#7b3dbe" transform="rotate(288.0 18.7 39.7)"/>
+<circle cx="32" cy="44" r="7" fill="#ffcc00"/>
+</svg>

--- a/public/mahjong-tiles/flower-2.svg
+++ b/public/mahjong-tiles/flower-2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <polygon points="32.0,22.0 36.5,36.2 51.1,33.0 41.0,44.0 51.1,55.0 36.5,51.8 32.0,66.0 27.5,51.8 12.9,55.0 23.0,44.0 12.9,33.0 27.5,36.2" fill="#ff6b00"/>
 <circle cx="32" cy="44" r="5" fill="#ffffff"/>

--- a/public/mahjong-tiles/flower-2.svg
+++ b/public/mahjong-tiles/flower-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<polygon points="32.0,22.0 36.5,36.2 51.1,33.0 41.0,44.0 51.1,55.0 36.5,51.8 32.0,66.0 27.5,51.8 12.9,55.0 23.0,44.0 12.9,33.0 27.5,36.2" fill="#ff6b00"/>
+<circle cx="32" cy="44" r="5" fill="#ffffff"/>
+</svg>

--- a/public/mahjong-tiles/wind-east.svg
+++ b/public/mahjong-tiles/wind-east.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
 <text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">E</text>

--- a/public/mahjong-tiles/wind-east.svg
+++ b/public/mahjong-tiles/wind-east.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
+<text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">E</text>
+</svg>

--- a/public/mahjong-tiles/wind-north.svg
+++ b/public/mahjong-tiles/wind-north.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
+<text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">N</text>
+</svg>

--- a/public/mahjong-tiles/wind-north.svg
+++ b/public/mahjong-tiles/wind-north.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
 <text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">N</text>

--- a/public/mahjong-tiles/wind-south.svg
+++ b/public/mahjong-tiles/wind-south.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
+<text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">S</text>
+</svg>

--- a/public/mahjong-tiles/wind-south.svg
+++ b/public/mahjong-tiles/wind-south.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
 <text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">S</text>

--- a/public/mahjong-tiles/wind-west.svg
+++ b/public/mahjong-tiles/wind-west.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88" width="64" height="88">
 <rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
 <rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
 <text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">W</text>

--- a/public/mahjong-tiles/wind-west.svg
+++ b/public/mahjong-tiles/wind-west.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 88">
+<rect x="1" y="1" width="62" height="86" rx="4" fill="#f5f0e0" stroke="#a0907a" stroke-width="2"/>
+<rect x="8" y="8" width="48" height="72" fill="none" stroke="#1a3a6e" stroke-width="1.5"/>
+<text x="32" y="46" font-family="Georgia, serif" font-weight="bold" font-size="40" fill="#1a3a6e" text-anchor="middle" dominant-baseline="middle">W</text>
+</svg>

--- a/specs/mahjong-solitaire.md
+++ b/specs/mahjong-solitaire.md
@@ -1,0 +1,167 @@
+# Mahjong Solitaire — Current State
+
+## Related
+
+- [`spec.md`](spec.md)
+
+## Overview
+
+A Taipei/Shisen-Sho-style "turtle" Mahjong Solitaire. 144 tiles, drawn from a
+traditional 36-design set, are stacked in a layered turtle-shaped layout.
+Click two free tiles with matching faces to remove them. Clear all 144 tiles
+to win. The board is always solvable from its initial deal — if no matching
+free pairs remain, Shuffle reassigns the faces on the remaining tiles without
+changing their positions.
+
+## Routes
+
+`/mahjong-solitaire` — standalone route wrapped in `StandaloneWindow`.
+Also embedded as a window inside NS Doors 97 (Start → Games → Mahjong
+Solitaire, or via `C:\Programs\Games\Mahjong Solitaire\Mahjong Solitaire.exe`).
+
+## Source layout
+
+- `src/experiences/MahjongSolitaire/tiles.ts` — `TileSuit`, `TileDesign`, the
+  36-entry `TILE_DESIGNS` registry, `TILE_DESIGNS_BY_ID` lookup, and
+  `buildTileDeck()` (144 unshuffled tile ids).
+- `src/experiences/MahjongSolitaire/layout.ts` — half-cell coordinate system
+  (`HALF_W`, `HALF_H`, `Z_OFFSET`), `generateTurtleLayout()` (144 `BoardSlot`s
+  across 4 layers), `getBoardPixelSize()` and `getBoardOrigin()` for sizing
+  and positioning the board container.
+- `src/experiences/MahjongSolitaire/board.ts` — framework-free game logic:
+  `isFree()`, `getFreeTiles()`, `getMatchablePairs()`,
+  `generateSolvableBoard()`, `shuffleBoard()`, and the shared
+  `assignSolvableIds()` helper.
+- `src/experiences/MahjongSolitaire/mahjongAssets.ts` — `getTileAssetUrl()`,
+  the FS asset-override resolver for tile faces.
+- `src/experiences/MahjongSolitaire/MahjongSolitaire.tsx` + `.css` — the game
+  component and Win95-styled HUD/board chrome.
+- `public/mahjong-tiles/*.svg` — 36 bundled tile-face SVGs.
+- `src/pages/MahjongSolitairePage.tsx` — `StandaloneWindow` wrapper for the
+  `/mahjong-solitaire` route.
+
+## Board & layout
+
+The board uses a half-cell `(x, y, z)` coordinate system. Each tile occupies
+a 2×2 half-unit footprint. The turtle layout is built from pre-computed
+rectangles across 4 layers, totaling exactly 144 slots:
+
+- **Layer 0** (z=0) — the main 12×8 body (96 slots) plus a 1×2 head
+  protrusion on the left and a 1×2 tail protrusion on the right (2 slots
+  each) = 100 slots.
+- **Layer 1** (z=1) — an 8×4 block centered over the body = 32 slots.
+- **Layer 2** (z=2) — a 4×2 block = 8 slots.
+- **Layer 3** (z=3) — a 2×2 block at the peak = 4 slots.
+
+Higher layers are rendered with a per-layer pixel offset (`Z_OFFSET`, applied
+to both x and y) to create the visual stepped/layered look. `getBoardPixelSize()`
+and `getBoardOrigin()` compute the bounding box of the whole layout so the
+board container is sized and tiles are positioned relative to a common origin.
+
+## Tile set
+
+36 tile designs, each appearing 4 times in the 144-tile deck:
+
+- **Dots 1–9** — pip-style circle layouts (blue ring, white fill, red center dot).
+- **Bamboo 1–9** — green stalk-with-joint layouts; Bamboo 1 is a stylized bird
+  glyph per tradition.
+- **Characters 1–9** — a large black numeral with a small red abstract glyph
+  beneath it.
+- **Winds** — East, South, West, North: bold compass letters in a thin frame.
+- **Dragons** — Red and Green dragons render as filled seal/stamp glyphs;
+  White Dragon is a blank tile with a double-rectangle blue frame.
+- **Flowers** — two filler designs (a purple 5-petal flower and an orange
+  6-pointed star) used to round out the 36-design set.
+
+## Free-tile rule
+
+A tile is **free** (clickable) when:
+
+1. **Nothing sits on top of it** — no non-removed tile occupies the layer
+   directly above (`z + 1`) with an overlapping `(x, y)` footprint.
+2. **At least one side is open** — its left side, its right side, or both,
+   has no non-removed tile at the same layer or higher occupying the
+   adjacent 2-half-unit-wide column.
+
+Locked tiles (covered from above, or boxed in on both sides) are dimmed and
+cannot be selected.
+
+## Generation & solvability
+
+A fresh board is built by **reverse construction**: starting from an empty
+board, the algorithm repeatedly finds all currently-"placeable" slots (those
+that would be free if filled in, given what's already placed), picks two at
+random, and assigns them a shared design id from a shuffled 72-pair deck
+(36 designs × 2 pairs = 144 tiles). Building backward this way guarantees at
+least one full solve order exists — the exact reverse of the construction
+order.
+
+Random or greedy play, however, can reach states with no matching free
+pairs even on a solvable board — this mirrors traditional Mahjong Solitaire
+and is expected. **Shuffle** is the escape hatch: it collects the
+currently-occupied slots and their design ids, then re-runs the same
+reverse-construction assignment restricted to that subset, replacing face
+assignments while leaving every tile's position and removed state unchanged.
+There is no hard-loss state — the game is always completable via Shuffle.
+
+## Controls
+
+- **Click a free tile** — selects it (highlighted with an orange outline and
+  a slight lift).
+- **Click the same tile again** — deselects it.
+- **Click a second free tile with the same face** — removes both tiles
+  (+10 score) and clears the selection.
+- **Click a free tile with a different face** — moves the selection to the
+  new tile.
+- **Hint** — highlights one currently-matchable free pair (pulsing yellow
+  glow) for ~1.5 seconds. If no matchable pairs exist, shows a "No moves
+  left — try Shuffle!" message instead.
+- **Shuffle** — reassigns faces on the remaining tiles (see above) and
+  clears any selection, hint, or message.
+- **New Game** — deals a fresh, solvable 144-tile board and resets score,
+  timer, and phase.
+
+## Scoring & timer
+
+- **+10 points** per matched pair removed.
+- A timer (mm:ss) runs while `phase === "playing"` and stops on a win.
+- On clearing all 144 tiles, a **time bonus** of `max(0, 1000 - elapsedSeconds * 2)`
+  is added to the running score to produce the final score, shown in a win
+  overlay.
+- If the final score beats the stored high score, it's saved and the overlay
+  shows "New High Score!".
+
+## High score persistence
+
+The high score is stored in `C:\Programs\Games\Mahjong Solitaire\SCORES.DAT`
+(stable FS id `MJ_SCORES_ID`) as a plain integer string — the same pattern as
+Typing Racer's `SCORES.DAT`. It's hackable: open the file in Notebook, edit
+the number, and save to change the stored high score. The component reads
+this file on mount via `fsStore.getFile(MJ_SCORES_ID)?.content` and writes a
+new value via `fsStore.writeFile(MJ_SCORES_ID, String(score))` whenever a
+win beats the previous high score.
+
+## Asset overrides
+
+Tile faces are resolved via `getTileAssetUrl(designId, defaultSvgPath)` in
+`mahjongAssets.ts`, mirroring the Hellzone `assetOverride.ts` pattern:
+
+- Checks `C:\Programs\Games\Mahjong Solitaire\TILES\{designId}.png` in the
+  virtual filesystem.
+- If that file exists with non-empty content (a data URL), it's used as the
+  tile face — letting users repaint tiles in NS Art and see the change in
+  game.
+- Otherwise, falls back to the bundled `/mahjong-tiles/{designId}.svg`.
+
+The `TILES\` folder is seeded with 36 empty `.png` stub files (one per
+design id, `appId: "nsart"`) so each tile face appears in the file browser
+and opens in NS Art for editing.
+
+## Menus (Game)
+
+| Item | Action |
+|---|---|
+| New Game | Deals a fresh, solvable board; resets score/timer |
+| Hint | Highlights a matchable free pair, or shows a "try Shuffle" message |
+| Shuffle | Reassigns faces on remaining tiles |
+| Exit | Closes the window (only present when `onQuit` is provided) |

--- a/specs/mahjong-solitaire.md
+++ b/specs/mahjong-solitaire.md
@@ -141,6 +141,27 @@ this file on mount via `fsStore.getFile(MJ_SCORES_ID)?.content` and writes a
 new value via `fsStore.writeFile(MJ_SCORES_ID, String(score))` whenever a
 win beats the previous high score.
 
+## In-progress game state persistence
+
+The board, score, and elapsed time are persisted to
+`C:\Programs\Games\Mahjong Solitaire\SAVE.DAT` (stable FS id `MJ_STATE_ID`) as
+JSON: `{ version, tiles: [{ slotId, designId, removed }], score, elapsedSec,
+savedAt }`. The component:
+
+- Loads and validates this file on mount (version and slot ids must match the
+  current layout); on success, rebuilds the board from `tiles` and restores
+  `score`, and recomputes `elapsedSec` by adding the wall-clock time since
+  `savedAt` to the saved value. If the file is missing or invalid, a fresh
+  board is generated as usual.
+- Writes a new save after every match, after Shuffle, after New Game, and once
+  on mount (so a rotation/refresh immediately after opening still resumes
+  correctly).
+- Clears the save (`fsStore.writeFile(MJ_STATE_ID, "")`) on a win, since a
+  finished game has nothing to resume.
+
+This means rotating the device, refreshing the page, or closing and reopening
+the window resumes the same board, score, and timer.
+
 ## Asset overrides
 
 Tile faces are resolved via `getTileAssetUrl(designId, defaultSvgPath)` in

--- a/specs/mahjong-solitaire.md
+++ b/specs/mahjong-solitaire.md
@@ -9,9 +9,8 @@
 A Taipei/Shisen-Sho-style "turtle" Mahjong Solitaire. 144 tiles, drawn from a
 traditional 36-design set, are stacked in a layered turtle-shaped layout.
 Click two free tiles with matching faces to remove them. Clear all 144 tiles
-to win. The board is always solvable from its initial deal — if no matching
-free pairs remain, Shuffle reassigns the faces on the remaining tiles without
-changing their positions.
+to win. The board is always dealt in a solvable order (see Generation &
+solvability below).
 
 ## Routes
 
@@ -30,8 +29,7 @@ Solitaire, or via `C:\Programs\Games\Mahjong Solitaire\Mahjong Solitaire.exe`).
   and positioning the board container.
 - `src/experiences/MahjongSolitaire/board.ts` — framework-free game logic:
   `isFree()`, `getFreeTiles()`, `getMatchablePairs()`,
-  `generateSolvableBoard()`, `shuffleBoard()`, and the shared
-  `assignSolvableIds()` helper.
+  `generateSolvableBoard()`, and the shared `assignSolvableIds()` helper.
 - `src/experiences/MahjongSolitaire/mahjongAssets.ts` — `getTileAssetUrl()`,
   the FS asset-override resolver for tile faces.
 - `src/experiences/MahjongSolitaire/MahjongSolitaire.tsx` + `.css` — the game
@@ -94,15 +92,15 @@ that would be free if filled in, given what's already placed), picks two at
 random, and assigns them a shared design id from a shuffled 72-pair deck
 (36 designs × 2 pairs = 144 tiles). Building backward this way guarantees at
 least one full solve order exists — the exact reverse of the construction
-order.
+order. If the reverse construction ever runs out of placeable candidates
+(shouldn't happen for this layout, but guarded against), `assignSolvableIds`
+falls back to pairing up any two remaining empty slots so every tile is
+always assigned a real design — no tile is ever left blank.
 
-Random or greedy play, however, can reach states with no matching free
-pairs even on a solvable board — this mirrors traditional Mahjong Solitaire
-and is expected. **Shuffle** is the escape hatch: it collects the
-currently-occupied slots and their design ids, then re-runs the same
-reverse-construction assignment restricted to that subset, replacing face
-assignments while leaving every tile's position and removed state unchanged.
-There is no hard-loss state — the game is always completable via Shuffle.
+Random or greedy play can still reach states with no matching free pairs
+even on a solvable board — this mirrors traditional Mahjong Solitaire and is
+expected. In that case, Hint reports there are no moves left and the player
+should start a New Game.
 
 ## Controls
 
@@ -115,9 +113,7 @@ There is no hard-loss state — the game is always completable via Shuffle.
   new tile.
 - **Hint** — highlights one currently-matchable free pair (pulsing yellow
   glow) for ~1.5 seconds. If no matchable pairs exist, shows a "No moves
-  left — try Shuffle!" message instead.
-- **Shuffle** — reassigns faces on the remaining tiles (see above) and
-  clears any selection, hint, or message.
+  left — try New Game!" message instead.
 - **New Game** — deals a fresh, solvable 144-tile board and resets score,
   timer, and phase.
 
@@ -153,9 +149,8 @@ savedAt }`. The component:
   `score`, and recomputes `elapsedSec` by adding the wall-clock time since
   `savedAt` to the saved value. If the file is missing or invalid, a fresh
   board is generated as usual.
-- Writes a new save after every match, after Shuffle, after New Game, and once
-  on mount (so a rotation/refresh immediately after opening still resumes
-  correctly).
+- Writes a new save after every match, after New Game, and once on mount (so
+  a rotation/refresh immediately after opening still resumes correctly).
 - Clears the save (`fsStore.writeFile(MJ_STATE_ID, "")`) on a win, since a
   finished game has nothing to resume.
 
@@ -183,6 +178,5 @@ and opens in NS Art for editing.
 | Item | Action |
 |---|---|
 | New Game | Deals a fresh, solvable board; resets score/timer |
-| Hint | Highlights a matchable free pair, or shows a "try Shuffle" message |
-| Shuffle | Reassigns faces on remaining tiles |
+| Hint | Highlights a matchable free pair, or shows a "no moves left" message |
 | Exit | Closes the window (only present when `onQuit` is provided) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import PegSolitairePage from "./pages/PegSolitairePage";
 import GooberDressupPage from "./pages/GooberDressupPage";
 import HellMapEditorPage from "./pages/HellMapEditorPage";
 import CheckersPage from "./pages/CheckersPage";
+import MahjongSolitairePage from "./pages/MahjongSolitairePage";
 
 export default function App() {
   return (
@@ -57,6 +58,7 @@ export default function App() {
         <Route path="/goober-dressup" element={<GooberDressupPage />} />
         <Route path="/hell-map-editor" element={<HellMapEditorPage />} />
         <Route path="/checkers" element={<CheckersPage />} />
+        <Route path="/mahjong-solitaire" element={<MahjongSolitairePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -175,4 +175,11 @@ export const experiences: Experience[] = [
     category: "toy",
     path: "/goober-dressup",
   },
+  {
+    id: "mahjong-solitaire",
+    title: "Mahjong Solitaire",
+    description: "Classic turtle-layout tile match. Clear all 144 tiles by matching free pairs — use Hint and Shuffle if you get stuck.",
+    category: "game",
+    path: "/mahjong-solitaire",
+  },
 ];

--- a/src/experiences/MahjongSolitaire/MahjongSolitaire.css
+++ b/src/experiences/MahjongSolitaire/MahjongSolitaire.css
@@ -1,0 +1,211 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Mahjong Solitaire — Win95-style HUD + layered turtle board
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.mj {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: #c0c0c0;
+  font-family: "Press Start 2P", monospace;
+  user-select: none;
+  min-height: 100%;
+}
+
+/* ── HUD bar ────────────────────────────────────────────────────────────── */
+
+.mj__hud {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  max-width: 660px;
+  padding: 6px 10px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+}
+
+.mj__hud-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.mj__hud-label {
+  font-size: 6px;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.mj__hud-value {
+  font-size: 9px;
+  color: #cc4400;
+}
+
+.mj__hud-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Win95 raised button ────────────────────────────────────────────────── */
+
+.mj__btn {
+  padding: 6px 10px;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  background: #c0c0c0;
+  color: #000;
+  font-family: "Press Start 2P", monospace;
+  font-size: 7px;
+  cursor: pointer;
+}
+
+.mj__btn:hover:not(:disabled) {
+  background: #cccccc;
+}
+
+.mj__btn:active:not(:disabled) {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.mj__btn:disabled {
+  color: #808080;
+  cursor: not-allowed;
+}
+
+.mj__btn--big {
+  font-size: 9px;
+  padding: 10px 18px;
+  margin-top: 12px;
+}
+
+/* ── Message strip ─────────────────────────────────────────────────────── */
+
+.mj__message {
+  width: 100%;
+  max-width: 660px;
+  padding: 5px 10px;
+  background: #ffffcc;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  color: #664400;
+  font-size: 7px;
+  text-align: center;
+}
+
+/* ── Board ──────────────────────────────────────────────────────────────── */
+
+.mj__board-wrap {
+  position: relative;
+  padding: 16px;
+  background: #2a4d2a;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.mj__board {
+  position: relative;
+}
+
+/* ── Tile ───────────────────────────────────────────────────────────────── */
+
+.mj-tile {
+  position: absolute;
+  width: 32px;
+  height: 44px;
+  border-radius: 3px;
+  background: #f5f0e0;
+  border: 1px solid #a0907a;
+  box-shadow:
+    1px 1px 0 #d8cdb0,
+    2px 2px 0 #c4b896,
+    3px 3px 0 #b0a37e,
+    0 0 4px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  transition: transform 0.08s ease;
+}
+
+.mj-tile img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.mj-tile--locked {
+  filter: brightness(0.82);
+  cursor: not-allowed;
+}
+
+.mj-tile--selected {
+  outline: 2px solid #ff6b00;
+  transform: translateY(-2px);
+}
+
+.mj-tile--hint {
+  animation: mj-hint-pulse 0.6s ease-in-out infinite alternate;
+}
+
+@keyframes mj-hint-pulse {
+  from {
+    box-shadow:
+      1px 1px 0 #d8cdb0,
+      2px 2px 0 #c4b896,
+      3px 3px 0 #b0a37e,
+      0 0 4px rgba(0, 0, 0, 0.4);
+  }
+  to {
+    box-shadow:
+      1px 1px 0 #d8cdb0,
+      2px 2px 0 #c4b896,
+      3px 3px 0 #b0a37e,
+      0 0 14px 4px rgba(255, 221, 0, 0.85);
+  }
+}
+
+/* ── Win overlay ────────────────────────────────────────────────────────── */
+
+.mj__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 10000;
+}
+
+.mj__overlay-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 32px;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  text-align: center;
+}
+
+.mj__overlay-title {
+  font-size: 12px;
+  color: #cc4400;
+  margin-bottom: 12px;
+}
+
+.mj__overlay-score {
+  font-size: 9px;
+  color: #000;
+  margin-bottom: 8px;
+}
+
+.mj__overlay-record {
+  font-size: 8px;
+  color: #228833;
+  margin-bottom: 8px;
+}

--- a/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
+++ b/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
@@ -17,7 +17,6 @@ import {
   generateSolvableBoard,
   getMatchablePairs,
   isFree,
-  shuffleBoard,
   type Board,
   type BoardTile,
 } from "./board";
@@ -182,7 +181,7 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
     if (phase !== "playing") return;
     const pairs = getMatchablePairs(board);
     if (pairs.length === 0) {
-      setMessage("No moves left — try Shuffle!");
+      setMessage("No moves left — try New Game!");
       return;
     }
     const pick = pairs[Math.floor(Math.random() * pairs.length)];
@@ -193,19 +192,6 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
       hintTimeoutRef.current = null;
     }, HINT_DURATION_MS);
   }, [board, phase]);
-
-  // ── Shuffle ────────────────────────────────────────────────────────────────
-  const shuffle = useCallback(() => {
-    if (phase !== "playing") return;
-    setBoard((prev) => {
-      const nextBoard = shuffleBoard(prev);
-      persist(nextBoard, score, elapsedSec);
-      return nextBoard;
-    });
-    setSelectedSlotId(null);
-    setHintPair(null);
-    setMessage(null);
-  }, [elapsedSec, persist, phase, score]);
 
   // ── Tile click ─────────────────────────────────────────────────────────────
   const handleTileClick = useCallback(
@@ -276,12 +262,11 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
           { label: "New Game", onClick: newGame },
           { separator: true },
           { label: "Hint", onClick: showHint },
-          { label: "Shuffle", onClick: shuffle },
           ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
         ],
       },
     ],
-    [newGame, onQuit, shuffle]
+    [newGame, onQuit, showHint]
   );
   useWindowMenus(menus);
 
@@ -308,9 +293,6 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
           </button>
           <button type="button" className="mj__btn" onClick={showHint} disabled={phase !== "playing"}>
             Hint
-          </button>
-          <button type="button" className="mj__btn" onClick={shuffle} disabled={phase !== "playing"}>
-            Shuffle
           </button>
         </div>
       </div>

--- a/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
+++ b/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useWindowMenus } from "../../components/Window/useWindowMenus";
 import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
 import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
-import { MJ_SCORES_ID } from "../NsDoors97/filesystem/types";
+import { MJ_SCORES_ID, MJ_STATE_ID } from "../NsDoors97/filesystem/types";
 import { TILE_DESIGNS_BY_ID } from "./tiles";
 import {
   generateTurtleLayout,
@@ -27,6 +27,21 @@ import "./MahjongSolitaire.css";
 type Phase = "playing" | "won";
 
 const HINT_DURATION_MS = 1500;
+const SAVE_VERSION = 1;
+
+interface SavedTile {
+  slotId: string;
+  designId: string;
+  removed: boolean;
+}
+
+interface SavedState {
+  version: number;
+  tiles: SavedTile[];
+  score: number;
+  elapsedSec: number;
+  savedAt: number;
+}
 
 function formatTime(totalSeconds: number): string {
   const minutes = Math.floor(totalSeconds / 60);
@@ -34,16 +49,55 @@ function formatTime(totalSeconds: number): string {
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
+function loadSavedState(slots: BoardSlot[]): SavedState | null {
+  const content = fsStore.getFile(MJ_STATE_ID)?.content;
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content) as SavedState;
+    if (parsed.version !== SAVE_VERSION || !Array.isArray(parsed.tiles)) return null;
+    if (parsed.tiles.length !== slots.length) return null;
+    const slotIds = new Set(slots.map((s) => s.id));
+    for (const tile of parsed.tiles) {
+      if (!slotIds.has(tile.slotId)) return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function buildBoardFromSave(slots: BoardSlot[], saved: SavedState): Board {
+  const bySlotId = new Map<string, SavedTile>();
+  for (const tile of saved.tiles) bySlotId.set(tile.slotId, tile);
+  return slots.map((slot) => {
+    const savedTile = bySlotId.get(slot.id);
+    return {
+      slotId: slot.id,
+      pos: slot.pos,
+      designId: savedTile?.designId ?? "",
+      removed: savedTile?.removed ?? false,
+    };
+  });
+}
+
 export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {}) {
   const slots = useState<BoardSlot[]>(() => generateTurtleLayout())[0];
   const boardSize = useMemo(() => getBoardPixelSize(slots), [slots]);
   const boardOrigin = useMemo(() => getBoardOrigin(slots), [slots]);
 
-  const [board, setBoard] = useState<Board>(() => generateSolvableBoard(slots));
+  const initialSave = useState(() => loadSavedState(slots))[0];
+
+  const [board, setBoard] = useState<Board>(() =>
+    initialSave ? buildBoardFromSave(slots, initialSave) : generateSolvableBoard(slots)
+  );
   const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
   const [hintPair, setHintPair] = useState<[string, string] | null>(null);
-  const [score, setScore] = useState(0);
-  const [elapsedSec, setElapsedSec] = useState(0);
+  const [score, setScore] = useState(() => initialSave?.score ?? 0);
+  const [elapsedSec, setElapsedSec] = useState(() => {
+    if (!initialSave) return 0;
+    const idleSec = Math.max(0, Math.floor((Date.now() - initialSave.savedAt) / 1000));
+    return initialSave.elapsedSec + idleSec;
+  });
   const [phase, setPhase] = useState<Phase>("playing");
   const [message, setMessage] = useState<string | null>(null);
   const [isNewRecord, setIsNewRecord] = useState(false);
@@ -56,6 +110,37 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
   });
 
   const hintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Persistence ────────────────────────────────────────────────────────────
+  const persist = useCallback((nextBoard: Board, nextScore: number, nextElapsed: number) => {
+    const saved: SavedState = {
+      version: SAVE_VERSION,
+      tiles: nextBoard.map((t) => ({ slotId: t.slotId, designId: t.designId, removed: t.removed })),
+      score: nextScore,
+      elapsedSec: nextElapsed,
+      savedAt: Date.now(),
+    };
+    try {
+      fsStore.writeFile(MJ_STATE_ID, JSON.stringify(saved));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const clearSave = useCallback(() => {
+    try {
+      fsStore.writeFile(MJ_STATE_ID, "");
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Persist the restored (or freshly generated) state immediately, so a
+  // rotation/refresh right after opening the game doesn't lose progress.
+  useEffect(() => {
+    persist(board, score, elapsedSec);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ── Timer ──────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -79,7 +164,8 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
       clearTimeout(hintTimeoutRef.current);
       hintTimeoutRef.current = null;
     }
-    setBoard(generateSolvableBoard(slots));
+    const nextBoard = generateSolvableBoard(slots);
+    setBoard(nextBoard);
     setSelectedSlotId(null);
     setHintPair(null);
     setScore(0);
@@ -88,7 +174,8 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
     setMessage(null);
     setIsNewRecord(false);
     setFinalScore(0);
-  }, [slots]);
+    persist(nextBoard, 0, 0);
+  }, [persist, slots]);
 
   // ── Hint ───────────────────────────────────────────────────────────────────
   const showHint = useCallback(() => {
@@ -110,11 +197,15 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
   // ── Shuffle ────────────────────────────────────────────────────────────────
   const shuffle = useCallback(() => {
     if (phase !== "playing") return;
-    setBoard((prev) => shuffleBoard(prev));
+    setBoard((prev) => {
+      const nextBoard = shuffleBoard(prev);
+      persist(nextBoard, score, elapsedSec);
+      return nextBoard;
+    });
     setSelectedSlotId(null);
     setHintPair(null);
     setMessage(null);
-  }, [phase]);
+  }, [elapsedSec, persist, phase, score]);
 
   // ── Tile click ─────────────────────────────────────────────────────────────
   const handleTileClick = useCallback(
@@ -163,6 +254,9 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
             setHighScore(won);
             setIsNewRecord(true);
           }
+          clearSave();
+        } else {
+          persist(nextBoard, nextScore, elapsedSec);
         }
         return;
       }
@@ -170,7 +264,7 @@ export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {
       // Different design — move selection to the new tile.
       setSelectedSlotId(tile.slotId);
     },
-    [board, elapsedSec, highScore, phase, selectedSlotId]
+    [board, clearSave, elapsedSec, highScore, persist, phase, score, selectedSlotId]
   );
 
   // ── Menus ──────────────────────────────────────────────────────────────────

--- a/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
+++ b/src/experiences/MahjongSolitaire/MahjongSolitaire.tsx
@@ -1,0 +1,282 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useWindowMenus } from "../../components/Window/useWindowMenus";
+import type { MenuBarMenu } from "../../components/MenuBar/MenuBar";
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+import { MJ_SCORES_ID } from "../NsDoors97/filesystem/types";
+import { TILE_DESIGNS_BY_ID } from "./tiles";
+import {
+  generateTurtleLayout,
+  getBoardPixelSize,
+  getBoardOrigin,
+  HALF_W,
+  HALF_H,
+  Z_OFFSET,
+  type BoardSlot,
+} from "./layout";
+import {
+  generateSolvableBoard,
+  getMatchablePairs,
+  isFree,
+  shuffleBoard,
+  type Board,
+  type BoardTile,
+} from "./board";
+import { getTileAssetUrl } from "./mahjongAssets";
+import "./MahjongSolitaire.css";
+
+type Phase = "playing" | "won";
+
+const HINT_DURATION_MS = 1500;
+
+function formatTime(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export default function MahjongSolitaire({ onQuit }: { onQuit?: () => void } = {}) {
+  const slots = useState<BoardSlot[]>(() => generateTurtleLayout())[0];
+  const boardSize = useMemo(() => getBoardPixelSize(slots), [slots]);
+  const boardOrigin = useMemo(() => getBoardOrigin(slots), [slots]);
+
+  const [board, setBoard] = useState<Board>(() => generateSolvableBoard(slots));
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const [hintPair, setHintPair] = useState<[string, string] | null>(null);
+  const [score, setScore] = useState(0);
+  const [elapsedSec, setElapsedSec] = useState(0);
+  const [phase, setPhase] = useState<Phase>("playing");
+  const [message, setMessage] = useState<string | null>(null);
+  const [isNewRecord, setIsNewRecord] = useState(false);
+  const [finalScore, setFinalScore] = useState(0);
+
+  const [highScore, setHighScore] = useState<number>(() => {
+    const fsContent = fsStore.getFile(MJ_SCORES_ID)?.content;
+    if (fsContent) return parseInt(fsContent, 10) || 0;
+    return 0;
+  });
+
+  const hintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Timer ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (phase !== "playing") return;
+    const interval = setInterval(() => {
+      setElapsedSec((s) => s + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase]);
+
+  // ── Cleanup hint timeout on unmount ───────────────────────────────────────
+  useEffect(() => {
+    return () => {
+      if (hintTimeoutRef.current) clearTimeout(hintTimeoutRef.current);
+    };
+  }, []);
+
+  // ── New game ───────────────────────────────────────────────────────────────
+  const newGame = useCallback(() => {
+    if (hintTimeoutRef.current) {
+      clearTimeout(hintTimeoutRef.current);
+      hintTimeoutRef.current = null;
+    }
+    setBoard(generateSolvableBoard(slots));
+    setSelectedSlotId(null);
+    setHintPair(null);
+    setScore(0);
+    setElapsedSec(0);
+    setPhase("playing");
+    setMessage(null);
+    setIsNewRecord(false);
+    setFinalScore(0);
+  }, [slots]);
+
+  // ── Hint ───────────────────────────────────────────────────────────────────
+  const showHint = useCallback(() => {
+    if (phase !== "playing") return;
+    const pairs = getMatchablePairs(board);
+    if (pairs.length === 0) {
+      setMessage("No moves left — try Shuffle!");
+      return;
+    }
+    const pick = pairs[Math.floor(Math.random() * pairs.length)];
+    if (hintTimeoutRef.current) clearTimeout(hintTimeoutRef.current);
+    setHintPair([pick[0].slotId, pick[1].slotId]);
+    hintTimeoutRef.current = setTimeout(() => {
+      setHintPair(null);
+      hintTimeoutRef.current = null;
+    }, HINT_DURATION_MS);
+  }, [board, phase]);
+
+  // ── Shuffle ────────────────────────────────────────────────────────────────
+  const shuffle = useCallback(() => {
+    if (phase !== "playing") return;
+    setBoard((prev) => shuffleBoard(prev));
+    setSelectedSlotId(null);
+    setHintPair(null);
+    setMessage(null);
+  }, [phase]);
+
+  // ── Tile click ─────────────────────────────────────────────────────────────
+  const handleTileClick = useCallback(
+    (tile: BoardTile) => {
+      if (phase !== "playing") return;
+      if (!isFree(board, tile)) return;
+
+      if (selectedSlotId === null) {
+        setSelectedSlotId(tile.slotId);
+        return;
+      }
+
+      if (selectedSlotId === tile.slotId) {
+        setSelectedSlotId(null);
+        return;
+      }
+
+      const selectedTile = board.find((t) => t.slotId === selectedSlotId);
+      if (!selectedTile) {
+        setSelectedSlotId(tile.slotId);
+        return;
+      }
+
+      if (selectedTile.designId === tile.designId) {
+        // Match! Remove both.
+        const removedSlotIds = new Set<string>([selectedTile.slotId, tile.slotId]);
+        const nextBoard = board.map((t) =>
+          removedSlotIds.has(t.slotId) ? { ...t, removed: true } : t
+        );
+        const nextScore = score + 10;
+        setBoard(nextBoard);
+        setSelectedSlotId(null);
+        setMessage(null);
+        setScore(nextScore);
+
+        if (nextBoard.every((t) => t.removed)) {
+          setPhase("won");
+          const won = nextScore + Math.max(0, 1000 - elapsedSec * 2);
+          setFinalScore(won);
+          if (won > highScore) {
+            try {
+              fsStore.writeFile(MJ_SCORES_ID, String(won));
+            } catch {
+              /* ignore */
+            }
+            setHighScore(won);
+            setIsNewRecord(true);
+          }
+        }
+        return;
+      }
+
+      // Different design — move selection to the new tile.
+      setSelectedSlotId(tile.slotId);
+    },
+    [board, elapsedSec, highScore, phase, selectedSlotId]
+  );
+
+  // ── Menus ──────────────────────────────────────────────────────────────────
+  const menus = useMemo<MenuBarMenu[]>(
+    () => [
+      {
+        label: "Game",
+        items: [
+          { label: "New Game", onClick: newGame },
+          { separator: true },
+          { label: "Hint", onClick: showHint },
+          { label: "Shuffle", onClick: shuffle },
+          ...(onQuit ? [{ separator: true as const }, { label: "Exit", onClick: onQuit }] : []),
+        ],
+      },
+    ],
+    [newGame, onQuit, shuffle]
+  );
+  useWindowMenus(menus);
+
+  const visibleTiles = board.filter((t) => !t.removed);
+
+  return (
+    <div className="mj">
+      <div className="mj__hud">
+        <div className="mj__hud-stat">
+          <span className="mj__hud-label">Score</span>
+          <span className="mj__hud-value">{score}</span>
+        </div>
+        <div className="mj__hud-stat">
+          <span className="mj__hud-label">Time</span>
+          <span className="mj__hud-value">{formatTime(elapsedSec)}</span>
+        </div>
+        <div className="mj__hud-stat">
+          <span className="mj__hud-label">High Score</span>
+          <span className="mj__hud-value">{highScore}</span>
+        </div>
+        <div className="mj__hud-buttons">
+          <button type="button" className="mj__btn" onClick={newGame}>
+            New Game
+          </button>
+          <button type="button" className="mj__btn" onClick={showHint} disabled={phase !== "playing"}>
+            Hint
+          </button>
+          <button type="button" className="mj__btn" onClick={shuffle} disabled={phase !== "playing"}>
+            Shuffle
+          </button>
+        </div>
+      </div>
+
+      {message && <div className="mj__message">{message}</div>}
+
+      <div className="mj__board-wrap">
+        <div
+          className="mj__board"
+          style={{ width: boardSize.width, height: boardSize.height }}
+        >
+          {visibleTiles.map((tile) => {
+            const design = TILE_DESIGNS_BY_ID[tile.designId];
+            const free = isFree(board, tile);
+            const isSelected = tile.slotId === selectedSlotId;
+            const isHint = hintPair?.includes(tile.slotId) ?? false;
+
+            const left = tile.pos.x * HALF_W + tile.pos.z * Z_OFFSET - boardOrigin.left;
+            const top = tile.pos.y * HALF_H - tile.pos.z * Z_OFFSET - boardOrigin.top;
+            const zIndex = tile.pos.z * 1000 + tile.pos.y;
+
+            return (
+              <div
+                key={tile.slotId}
+                className={[
+                  "mj-tile",
+                  free ? "mj-tile--free" : "mj-tile--locked",
+                  isSelected ? "mj-tile--selected" : "",
+                  isHint ? "mj-tile--hint" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={{ left, top, zIndex }}
+                onClick={() => handleTileClick(tile)}
+              >
+                {design && (
+                  <img
+                    src={getTileAssetUrl(design.id, design.asset)}
+                    alt={design.label}
+                    draggable={false}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {phase === "won" && (
+          <div className="mj__overlay">
+            <div className="mj__overlay-panel">
+              <div className="mj__overlay-title">Board Cleared!</div>
+              <div className="mj__overlay-score">Final Score: {finalScore}</div>
+              {isNewRecord && <div className="mj__overlay-record">New High Score!</div>}
+              <button type="button" className="mj__btn mj__btn--big" onClick={newGame}>
+                New Game
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/experiences/MahjongSolitaire/board.test.ts
+++ b/src/experiences/MahjongSolitaire/board.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { generateTurtleLayout } from "./layout";
+import { generateSolvableBoard } from "./board";
+
+describe("generateSolvableBoard", () => {
+  it("assigns a real design to every slot, across many seeds", () => {
+    const slots = generateTurtleLayout();
+    for (let i = 0; i < 50; i++) {
+      const board = generateSolvableBoard(slots);
+      expect(board.length).toBe(144);
+      for (const tile of board) {
+        expect(tile.designId).not.toBe("");
+      }
+    }
+  });
+});

--- a/src/experiences/MahjongSolitaire/board.ts
+++ b/src/experiences/MahjongSolitaire/board.ts
@@ -112,13 +112,21 @@ export function assignSolvableIds(slots: BoardSlot[], pairDeckIds: string[]): Ma
       if (free) candidates.push(tile);
     }
 
-    if (candidates.length < 2) {
-      // Should not happen for a valid layout, but guard against infinite loop.
-      break;
+    let first: BoardTile;
+    let second: BoardTile;
+    if (candidates.length >= 2) {
+      const shuffledCandidates = shuffle(candidates);
+      [first, second] = shuffledCandidates;
+    } else {
+      // Fallback: shouldn't happen for a well-formed layout, but guarantees
+      // every slot gets a tile (never blank) even if the reverse-construction
+      // ran out of free candidates early.
+      const stillRemoved = working.filter((tile) => tile.removed);
+      if (stillRemoved.length < 2) break;
+      const shuffledRemaining = shuffle(stillRemoved);
+      [first, second] = shuffledRemaining;
     }
 
-    const shuffledCandidates = shuffle(candidates);
-    const [first, second] = shuffledCandidates;
     const designId = deck.pop();
     if (designId === undefined) break;
 
@@ -152,24 +160,4 @@ export function generateSolvableBoard(slots: BoardSlot[]): Board {
     designId: assignments.get(slot.id) ?? "",
     removed: false,
   }));
-}
-
-/**
- * Reassigns design ids on the currently-occupied tiles of `board`, keeping
- * positions/removed flags unchanged. If fewer than 2 tiles remain, returns
- * the board unchanged.
- */
-export function shuffleBoard(board: Board): Board {
-  const occupied = board.filter((tile) => !tile.removed);
-  if (occupied.length < 2) return board;
-
-  const occupiedSlots: BoardSlot[] = occupied.map((tile) => ({ id: tile.slotId, pos: tile.pos }));
-  const pairDeck = shuffle(occupied.map((tile) => tile.designId));
-  const assignments = assignSolvableIds(occupiedSlots, pairDeck);
-
-  return board.map((tile) => {
-    if (tile.removed) return tile;
-    const designId = assignments.get(tile.slotId);
-    return designId !== undefined ? { ...tile, designId } : tile;
-  });
 }

--- a/src/experiences/MahjongSolitaire/board.ts
+++ b/src/experiences/MahjongSolitaire/board.ts
@@ -1,0 +1,175 @@
+import type { BoardSlot, TilePosition } from "./layout";
+import { TILE_DESIGNS } from "./tiles";
+
+export interface BoardTile {
+  slotId: string;
+  pos: TilePosition;
+  designId: string;
+  removed: boolean;
+}
+
+export type Board = BoardTile[];
+
+/** True rectangle overlap; tile footprint is [x, x+2) x [y, y+2) in half-units. */
+export function overlaps(a: TilePosition, b: TilePosition): boolean {
+  return Math.abs(a.x - b.x) < 2 && Math.abs(a.y - b.y) < 2;
+}
+
+/**
+ * A tile is free if nothing sits on top of it (z+1 layer overlapping it),
+ * and at least one of its left/right sides is unobstructed at the same or
+ * higher layer.
+ */
+export function isFree(board: Board, tile: BoardTile): boolean {
+  let coveredFromAbove = false;
+  let leftBlocked = false;
+  let rightBlocked = false;
+
+  for (const t of board) {
+    if (t.removed) continue;
+    if (t === tile) continue;
+
+    if (t.pos.z === tile.pos.z + 1 && overlaps(t.pos, tile.pos)) {
+      coveredFromAbove = true;
+    }
+
+    if (t.pos.z >= tile.pos.z && Math.abs(t.pos.y - tile.pos.y) < 2) {
+      if (t.pos.x > tile.pos.x - 4 && t.pos.x < tile.pos.x) {
+        leftBlocked = true;
+      }
+      if (t.pos.x < tile.pos.x + 4 && t.pos.x > tile.pos.x) {
+        rightBlocked = true;
+      }
+    }
+  }
+
+  return !coveredFromAbove && (!leftBlocked || !rightBlocked);
+}
+
+export function getFreeTiles(board: Board): BoardTile[] {
+  return board.filter((tile) => !tile.removed && isFree(board, tile));
+}
+
+export function getMatchablePairs(board: Board): Array<[BoardTile, BoardTile]> {
+  const free = getFreeTiles(board);
+  const pairs: Array<[BoardTile, BoardTile]> = [];
+  for (let i = 0; i < free.length; i++) {
+    for (let j = i + 1; j < free.length; j++) {
+      if (free[i].designId === free[j].designId) {
+        pairs.push([free[i], free[j]]);
+      }
+    }
+  }
+  return pairs;
+}
+
+/** Pure Fisher-Yates shuffle; returns a new array. */
+export function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * Assigns design ids from `pairDeckIds` (consumed 2-at-a-time, in pairs) to
+ * the given `slots`, working backward: at each step, find slots that are
+ * still unassigned but would be `isFree` if the only "present" tiles were
+ * the already-assigned ones plus this candidate (everything else stays
+ * transparent/removed). Returns a map of slotId -> designId covering every
+ * slot in `slots`.
+ *
+ * `pairDeckIds` must have exactly `slots.length` entries, structured as
+ * consecutive pairs (each id appears an even number of times overall).
+ */
+export function assignSolvableIds(slots: BoardSlot[], pairDeckIds: string[]): Map<string, string> {
+  const deck = shuffle(pairDeckIds);
+
+  // Working board over just these slots; everything starts removed/blank.
+  const working: Board = slots.map((slot) => ({
+    slotId: slot.id,
+    pos: slot.pos,
+    designId: "",
+    removed: true,
+  }));
+
+  const bySlotId = new Map<string, BoardTile>();
+  for (const tile of working) bySlotId.set(tile.slotId, tile);
+
+  const remaining = slots.length;
+  for (let step = 0; step < remaining / 2; step++) {
+    // Find candidate slots: still removed, but would be free if placed now.
+    const candidates: BoardTile[] = [];
+    for (const tile of working) {
+      if (!tile.removed) continue;
+      // Temporarily mark as present and test isFree against the working board
+      // (all other still-removed tiles stay removed/transparent).
+      tile.removed = false;
+      const free = isFree(working, tile);
+      tile.removed = true;
+      if (free) candidates.push(tile);
+    }
+
+    if (candidates.length < 2) {
+      // Should not happen for a valid layout, but guard against infinite loop.
+      break;
+    }
+
+    const shuffledCandidates = shuffle(candidates);
+    const [first, second] = shuffledCandidates;
+    const designId = deck.pop();
+    if (designId === undefined) break;
+
+    first.designId = designId;
+    first.removed = false;
+    second.designId = designId;
+    second.removed = false;
+  }
+
+  const result = new Map<string, string>();
+  for (const tile of working) result.set(tile.slotId, tile.designId);
+  return result;
+}
+
+function buildPairDeck(): string[] {
+  const deck: string[] = [];
+  for (const design of TILE_DESIGNS) {
+    deck.push(design.id, design.id);
+  }
+  return shuffle(deck);
+}
+
+/** Builds a freshly-shuffled, guaranteed-solvable board for the given layout slots. */
+export function generateSolvableBoard(slots: BoardSlot[]): Board {
+  const pairDeck = buildPairDeck();
+  const assignments = assignSolvableIds(slots, pairDeck);
+
+  return slots.map((slot) => ({
+    slotId: slot.id,
+    pos: slot.pos,
+    designId: assignments.get(slot.id) ?? "",
+    removed: false,
+  }));
+}
+
+/**
+ * Reassigns design ids on the currently-occupied tiles of `board`, keeping
+ * positions/removed flags unchanged. If fewer than 2 tiles remain, returns
+ * the board unchanged.
+ */
+export function shuffleBoard(board: Board): Board {
+  const occupied = board.filter((tile) => !tile.removed);
+  if (occupied.length < 2) return board;
+
+  const occupiedSlots: BoardSlot[] = occupied.map((tile) => ({ id: tile.slotId, pos: tile.pos }));
+  const pairDeck = shuffle(occupied.map((tile) => tile.designId));
+  const assignments = assignSolvableIds(occupiedSlots, pairDeck);
+
+  return board.map((tile) => {
+    if (tile.removed) return tile;
+    const designId = assignments.get(tile.slotId);
+    return designId !== undefined ? { ...tile, designId } : tile;
+  });
+}

--- a/src/experiences/MahjongSolitaire/board.ts
+++ b/src/experiences/MahjongSolitaire/board.ts
@@ -74,15 +74,16 @@ export function shuffle<T>(arr: T[]): T[] {
 }
 
 /**
- * Assigns design ids from `pairDeckIds` (consumed 2-at-a-time, in pairs) to
- * the given `slots`, working backward: at each step, find slots that are
+ * Assigns design ids from `pairDeckIds` (each id consumed once and applied
+ * to a pair of slots) to the given `slots`, working backward: at each step,
+ * find slots that are
  * still unassigned but would be `isFree` if the only "present" tiles were
  * the already-assigned ones plus this candidate (everything else stays
  * transparent/removed). Returns a map of slotId -> designId covering every
  * slot in `slots`.
  *
- * `pairDeckIds` must have exactly `slots.length` entries, structured as
- * consecutive pairs (each id appears an even number of times overall).
+ * `pairDeckIds` must have exactly `slots.length / 2` entries — one id per
+ * pair, each consumed once and assigned to two slots.
  */
 export function assignSolvableIds(slots: BoardSlot[], pairDeckIds: string[]): Map<string, string> {
   const deck = shuffle(pairDeckIds);
@@ -94,9 +95,6 @@ export function assignSolvableIds(slots: BoardSlot[], pairDeckIds: string[]): Ma
     designId: "",
     removed: true,
   }));
-
-  const bySlotId = new Map<string, BoardTile>();
-  for (const tile of working) bySlotId.set(tile.slotId, tile);
 
   const remaining = slots.length;
   for (let step = 0; step < remaining / 2; step++) {

--- a/src/experiences/MahjongSolitaire/layout.ts
+++ b/src/experiences/MahjongSolitaire/layout.ts
@@ -1,0 +1,106 @@
+export interface TilePosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface BoardSlot {
+  id: string; // `${z},${x},${y}`
+  pos: TilePosition;
+}
+
+/** Half-cell size in pixels. A tile footprint is 2x2 half-units. */
+export const HALF_W = 16;
+export const HALF_H = 22;
+/** Pixel offset applied per layer (both x and y) to create the layered look. */
+export const Z_OFFSET = 4;
+
+/** Tile footprint, in half-cell units. */
+const TILE_SIZE = 2;
+
+interface RectSpec {
+  xStart: number;
+  xCount: number;
+  yStart: number;
+  yCount: number;
+}
+
+// Pre-computed turtle-shaped layout rectangles. Each rect expands to
+// xCount * yCount slots at x = xStart + 2*i, y = yStart + 2*j.
+// Verified to total exactly 144 slots across 4 layers.
+const LAYERS: RectSpec[][] = [
+  // Layer 0 (z=0) — main body + head/tail protrusions = 100 slots
+  [
+    { xStart: 0, xCount: 12, yStart: 0, yCount: 8 }, // 96
+    { xStart: -2, xCount: 1, yStart: 6, yCount: 2 }, // 2 (head)
+    { xStart: 24, xCount: 1, yStart: 6, yCount: 2 }, // 2 (tail)
+  ],
+  // Layer 1 (z=1) = 32 slots
+  [{ xStart: 3, xCount: 8, yStart: 2, yCount: 4 }],
+  // Layer 2 (z=2) = 8 slots
+  [{ xStart: 5, xCount: 4, yStart: 4, yCount: 2 }],
+  // Layer 3 (z=3) = 4 slots
+  [{ xStart: 7, xCount: 2, yStart: 5, yCount: 2 }],
+];
+
+export function generateTurtleLayout(): BoardSlot[] {
+  const slots: BoardSlot[] = [];
+  LAYERS.forEach((rects, z) => {
+    for (const rect of rects) {
+      for (let i = 0; i < rect.xCount; i++) {
+        for (let j = 0; j < rect.yCount; j++) {
+          const x = rect.xStart + 2 * i;
+          const y = rect.yStart + 2 * j;
+          slots.push({ id: `${z},${x},${y}`, pos: { x, y, z } });
+        }
+      }
+    }
+  });
+  return slots;
+}
+
+/**
+ * Pixel bounding box of the whole layout, accounting for tile size and the
+ * per-layer Z_OFFSET, so the component can size its container dynamically.
+ */
+export function getBoardPixelSize(slots: BoardSlot[]): { width: number; height: number } {
+  const { minLeft, maxRight, minTop, maxBottom } = getBoardBounds(slots);
+  return { width: maxRight - minLeft, height: maxBottom - minTop };
+}
+
+/**
+ * Top-left origin (in pixels) of the layout's bounding box. Subtract this
+ * from a tile's computed left/top to position everything within a
+ * container sized by getBoardPixelSize.
+ */
+export function getBoardOrigin(slots: BoardSlot[]): { left: number; top: number } {
+  const { minLeft, minTop } = getBoardBounds(slots);
+  return { left: minLeft, top: minTop };
+}
+
+function getBoardBounds(slots: BoardSlot[]): {
+  minLeft: number;
+  maxRight: number;
+  minTop: number;
+  maxBottom: number;
+} {
+  let minLeft = Infinity;
+  let maxRight = -Infinity;
+  let minTop = Infinity;
+  let maxBottom = -Infinity;
+
+  for (const slot of slots) {
+    const { x, y, z } = slot.pos;
+    const left = x * HALF_W + z * Z_OFFSET;
+    const right = (x + TILE_SIZE) * HALF_W + z * Z_OFFSET;
+    const top = y * HALF_H - z * Z_OFFSET;
+    const bottom = (y + TILE_SIZE) * HALF_H - z * Z_OFFSET;
+
+    if (left < minLeft) minLeft = left;
+    if (right > maxRight) maxRight = right;
+    if (top < minTop) minTop = top;
+    if (bottom > maxBottom) maxBottom = bottom;
+  }
+
+  return { minLeft, maxRight, minTop, maxBottom };
+}

--- a/src/experiences/MahjongSolitaire/mahjongAssets.ts
+++ b/src/experiences/MahjongSolitaire/mahjongAssets.ts
@@ -1,0 +1,20 @@
+import { fsStore } from "../NsDoors97/filesystem/FileSystemStore";
+
+/**
+ * Resolves a Mahjong tile face to either the user's custom version (painted
+ * in NS Art and stored in the virtual FS) or the original bundled SVG.
+ *
+ * Mirrors the Hellzone `assetOverride.ts` pattern: checks
+ * `C:\Programs\Games\Mahjong Solitaire\TILES\{designId}.png` in the FS for
+ * non-empty content. The FS file content is expected to be a data URL
+ * (e.g. "data:image/png;base64,..."). If the FS file doesn't exist or has
+ * empty content, the bundled `defaultSvgPath` is used.
+ */
+const TILES_FS_DIR = "C:\\Programs\\Games\\Mahjong Solitaire\\TILES\\";
+
+export function getTileAssetUrl(designId: string, defaultSvgPath: string): string {
+  const fsPath = TILES_FS_DIR + designId + ".png";
+  const node = fsStore.getNodeByPath(fsPath);
+  if (node?.kind === "file" && node.content) return node.content;
+  return defaultSvgPath;
+}

--- a/src/experiences/MahjongSolitaire/tiles.ts
+++ b/src/experiences/MahjongSolitaire/tiles.ts
@@ -1,0 +1,54 @@
+export type TileSuit = "dots" | "bamboo" | "characters" | "wind" | "dragon" | "flower";
+
+export interface TileDesign {
+  id: string;
+  suit: TileSuit;
+  rank?: number;
+  label: string;
+  asset: string; // `/mahjong-tiles/{id}.svg`
+}
+
+function numberedTiles(suit: TileSuit, prefix: string, labelFor: (rank: number) => string): TileDesign[] {
+  return Array.from({ length: 9 }, (_, i) => {
+    const rank = i + 1;
+    return {
+      id: `${prefix}-${rank}`,
+      suit,
+      rank,
+      label: labelFor(rank),
+      asset: `/mahjong-tiles/${prefix}-${rank}.svg`,
+    };
+  });
+}
+
+export const TILE_DESIGNS: TileDesign[] = [
+  ...numberedTiles("dots", "dots", (rank) => `${rank} Dot${rank === 1 ? "" : "s"}`),
+  ...numberedTiles("bamboo", "bamboo", (rank) => `${rank} Bamboo`),
+  ...numberedTiles("characters", "chars", (rank) => `${rank} Character`),
+  { id: "wind-east", suit: "wind", label: "East Wind", asset: "/mahjong-tiles/wind-east.svg" },
+  { id: "wind-south", suit: "wind", label: "South Wind", asset: "/mahjong-tiles/wind-south.svg" },
+  { id: "wind-west", suit: "wind", label: "West Wind", asset: "/mahjong-tiles/wind-west.svg" },
+  { id: "wind-north", suit: "wind", label: "North Wind", asset: "/mahjong-tiles/wind-north.svg" },
+  { id: "dragon-red", suit: "dragon", label: "Red Dragon", asset: "/mahjong-tiles/dragon-red.svg" },
+  { id: "dragon-green", suit: "dragon", label: "Green Dragon", asset: "/mahjong-tiles/dragon-green.svg" },
+  { id: "dragon-white", suit: "dragon", label: "White Dragon", asset: "/mahjong-tiles/dragon-white.svg" },
+  { id: "flower-1", suit: "flower", label: "Flower 1", asset: "/mahjong-tiles/flower-1.svg" },
+  { id: "flower-2", suit: "flower", label: "Flower 2", asset: "/mahjong-tiles/flower-2.svg" },
+];
+
+export const TILE_DESIGNS_BY_ID: Record<string, TileDesign> = Object.fromEntries(
+  TILE_DESIGNS.map((design) => [design.id, design])
+);
+
+/**
+ * Returns 144 tile ids: each of the 36 design ids repeated 4 times, in
+ * design-order (NOT shuffled). Callers are responsible for arranging/
+ * assigning these to board slots.
+ */
+export function buildTileDeck(): string[] {
+  const deck: string[] = [];
+  for (const design of TILE_DESIGNS) {
+    for (let i = 0; i < 4; i++) deck.push(design.id);
+  }
+  return deck;
+}

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -597,11 +597,16 @@ export default function NsDoors97() {
         return;
       }
       // .png sprite files with appId "nsart" open in NS Art
-      // EGO sprites have a bundled public fallback; Goober sprites do not
+      // EGO sprites and Mahjong tile faces have a bundled public fallback; Goober sprites do not
       if (file.fileType === "png" && file.appId === "nsart") {
         const winId = `nsart:${file.id}`;
         const filePath = fsStore.getPath(file.id);
-        const isEgoSprite = filePath.toUpperCase().startsWith("C:\\EGO\\");
+        const upperPath = filePath.toUpperCase();
+        const isEgoSprite = upperPath.startsWith("C:\\EGO\\");
+        const isMahjongTile = upperPath.startsWith("C:\\PROGRAMS\\GAMES\\MAHJONG SOLITAIRE\\TILES\\");
+        const mahjongTileUrl = isMahjongTile
+          ? `/mahjong-tiles/${file.name.replace(/\.png$/i, ".svg")}`
+          : undefined;
         setOpenWindows((prev) => {
           if (prev.some((w) => w.id === winId)) {
             maxZ++;
@@ -620,6 +625,7 @@ export default function NsDoors97() {
               type: "nsart" as const,
               fileId: file.id,
               ...(isEgoSprite ? { fileUrl: `/sprites/${file.name}` } : {}),
+              ...(mahjongTileUrl ? { fileUrl: mahjongTileUrl } : {}),
             },
             zIndex: maxZ,
             defaultPosition: { x: 80 + offset, y: 48 + offset },

--- a/src/experiences/NsDoors97/NsDoors97.tsx
+++ b/src/experiences/NsDoors97/NsDoors97.tsx
@@ -32,6 +32,7 @@ import MidiEditor from "../MidiEditor/MidiEditor";
 import ChainReaction from "../ChainReaction/ChainReaction";
 import PegSolitaire from "../PegSolitaire/PegSolitaire";
 import GooberDressup from "../GooberDressup/GooberDressup";
+import MahjongSolitaire from "../MahjongSolitaire/MahjongSolitaire";
 import Checkers from "../Checkers/Checkers";
 import BombFinder, { type Difficulty as BfDifficulty } from "../BombFinder/BombFinder";
 import CardsLauncher from "../Cards/CardsLauncher";
@@ -87,7 +88,8 @@ type AppAction =
   | "chain-reaction"
   | "peg-solitaire"
   | "goober-dressup"
-  | "checkers";
+  | "checkers"
+  | "mahjong-solitaire";
 
 interface AppDef {
   title: string;
@@ -120,6 +122,7 @@ const APP_REGISTRY: Record<string, AppDef> = {
   "peg-solitaire":   { title: "Peg Solitaire",     icon: "🔴", action: "peg-solitaire"   },
   "goober-dressup":  { title: "Goober Dress-Up",   icon: "🐱", action: "goober-dressup"  },
   "checkers":        { title: "Checkers",           icon: "⚫", action: "checkers"        },
+  "mahjong-solitaire": { title: "Mahjong Solitaire", icon: "🀄", action: "mahjong-solitaire" },
 };
 
 // ── Desktop icon helpers ───────────────────────────────────────────────────────
@@ -176,7 +179,8 @@ type WindowContent =
   | { type: "chain-reaction" }
   | { type: "peg-solitaire" }
   | { type: "goober-dressup"; fileId?: string }
-  | { type: "checkers" };
+  | { type: "checkers" }
+  | { type: "mahjong-solitaire" };
 
 interface OpenWindow {
   id: string;
@@ -506,6 +510,7 @@ export default function NsDoors97() {
         case "peg-solitaire":   content = { type: "peg-solitaire" as const };   width = 580; break;
         case "goober-dressup":  content = { type: "goober-dressup" as const };  width = 500; break;
         case "checkers":        content = { type: "checkers" as const };         width = 420; break;
+        case "mahjong-solitaire": content = { type: "mahjong-solitaire" as const }; width = 660; break;
         case "experience": {
           const experience = experiences.find((e) => e.id === id)!;
           content = { type: "app-launcher", experience };
@@ -1046,6 +1051,9 @@ export default function NsDoors97() {
           )}
           {win.content.type === "peg-solitaire" && (
             <PegSolitaire onQuit={() => closeWindow(win.id)} />
+          )}
+          {win.content.type === "mahjong-solitaire" && (
+            <MahjongSolitaire onQuit={() => closeWindow(win.id)} />
           )}
           {win.content.type === "goober-dressup" && (
             <GooberDressup

--- a/src/experiences/NsDoors97/Taskbar.css
+++ b/src/experiences/NsDoors97/Taskbar.css
@@ -131,6 +131,10 @@
   overflow-x: hidden;
 }
 
+.ns-start-submenu--nested {
+  position: fixed;
+}
+
 .ns-start-menu__divider {
   height: 0;
   border-top: 1px solid #330000;

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -152,7 +152,11 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
   useLayoutEffect(() => {
     if (openGamesSubmenu === "word-games" && wordGamesWrapperRef.current) {
       const rect = wordGamesWrapperRef.current.getBoundingClientRect();
-      setWordGamesFlyoutPos({ left: rect.right, top: Math.max(0, rect.bottom - 150) });
+      const flyoutWidth = 150;
+      const left = rect.right + flyoutWidth > window.innerWidth
+        ? Math.max(0, rect.left - flyoutWidth)
+        : rect.right;
+      setWordGamesFlyoutPos({ left, top: Math.max(0, rect.bottom - 150) });
     } else {
       setWordGamesFlyoutPos(null);
     }

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -112,6 +112,7 @@ const GAMES_ITEMS = [
   { id: "chain-reaction",  icon: "🔗", label: "Chain Reaction"   },
   { id: "peg-solitaire",   icon: "🔴", label: "Peg Solitaire"    },
   { id: "goober-dressup",  icon: "🐱", label: "Goober Dress-Up"  },
+  { id: "mahjong-solitaire", icon: "🀄", label: "Mahjong Solitaire" },
 ] as const;
 
 const TOOLS_ITEMS = [

--- a/src/experiences/NsDoors97/Taskbar.tsx
+++ b/src/experiences/NsDoors97/Taskbar.tsx
@@ -99,22 +99,25 @@ function FullscreenButton() {
 // ── Menu item data ────────────────────────────────────────────────────────────
 
 const GAMES_ITEMS = [
+  { id: "pool",           icon: "🎱", label: "8-Ball Pool"      },
+  { id: "bomb-finder",    icon: "💣", label: "Bomb Finder"      },
+  { id: "brick-breaker",  icon: "🧱", label: "Brick Breaker"    },
   { id: "cards",          icon: "🃏", label: "Cards"            },
   { id: "checkers",       icon: "⚫", label: "Checkers"         },
+  { id: "duck-hunt",      icon: "🎯", label: "Duck & Learn"     },
+  { id: "goober-dressup",  icon: "🐱", label: "Goober Dress-Up"  },
+  { id: "jazzball",        icon: "🟧", label: "Jazzball"         },
+  { id: "mahjong-solitaire", icon: "🀄", label: "Mahjong Solitaire" },
+  { id: "number-muncher", icon: "🔢", label: "Nom Nom Numerals" },
+  { id: "peg-solitaire",   icon: "🔴", label: "Peg Solitaire"    },
   { id: "tic-tac-toe",    icon: "✖️",  label: "Tic-Tac-Toe"     },
-  { id: "pool",           icon: "🎱", label: "8-Ball Pool"      },
+] as const;
+
+const WORD_GAMES_ITEMS = [
+  { id: "chain-reaction",  icon: "🔗", label: "Chain Reaction"   },
+  { id: "typing-racer",   icon: "⌨️", label: "Type 'Em Up"      },
   { id: "word-whirlwind", icon: "🌪️", label: "Word Whirlwind"  },
   { id: "words",          icon: "🔤", label: "WORDS"            },
-  { id: "bomb-finder",    icon: "💣", label: "Bomb Finder"      },
-  { id: "duck-hunt",      icon: "🎯", label: "Duck & Learn"     },
-  { id: "number-muncher", icon: "🔢", label: "Nom Nom Numerals" },
-  { id: "typing-racer",   icon: "⌨️", label: "Type 'Em Up"      },
-  { id: "chain-reaction",  icon: "🔗", label: "Chain Reaction"   },
-  { id: "peg-solitaire",   icon: "🔴", label: "Peg Solitaire"    },
-  { id: "goober-dressup",  icon: "🐱", label: "Goober Dress-Up"  },
-  { id: "mahjong-solitaire", icon: "🀄", label: "Mahjong Solitaire" },
-  { id: "jazzball",        icon: "🟧", label: "Jazzball"         },
-  { id: "brick-breaker",  icon: "🧱", label: "Brick Breaker"    },
 ] as const;
 
 const TOOLS_ITEMS = [
@@ -125,14 +128,18 @@ const TOOLS_ITEMS = [
 ] as const;
 
 type OpenSubmenu = "games" | "tools" | "settings" | null;
+type OpenGamesSubmenu = "word-games" | null;
 
 // ── Taskbar ───────────────────────────────────────────────────────────────────
 
 export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRestart, onOpenSettings, onOpenAbout, onExitToTos, onOpenApp }: TaskbarProps) {
   const [startOpen, setStartOpen] = useState(false);
   const [openSubmenu, setOpenSubmenu] = useState<OpenSubmenu>(null);
+  const [openGamesSubmenu, setOpenGamesSubmenu] = useState<OpenGamesSubmenu>(null);
   const startAreaRef = useRef<HTMLDivElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
+  const wordGamesWrapperRef = useRef<HTMLDivElement>(null);
+  const [wordGamesFlyoutPos, setWordGamesFlyoutPos] = useState<{ left: number; top: number } | null>(null);
 
   useLayoutEffect(() => {
     if (openSubmenu !== null && submenuRef.current) {
@@ -141,6 +148,15 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
       submenuRef.current.style.maxHeight = `${Math.max(120, available)}px`;
     }
   }, [openSubmenu]);
+
+  useLayoutEffect(() => {
+    if (openGamesSubmenu === "word-games" && wordGamesWrapperRef.current) {
+      const rect = wordGamesWrapperRef.current.getBoundingClientRect();
+      setWordGamesFlyoutPos({ left: rect.right, top: Math.max(0, rect.bottom - 150) });
+    } else {
+      setWordGamesFlyoutPos(null);
+    }
+  }, [openGamesSubmenu]);
 
   // Close on outside click
   useEffect(() => {
@@ -158,6 +174,7 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
   const close = useCallback(() => {
     setStartOpen(false);
     setOpenSubmenu(null);
+    setOpenGamesSubmenu(null);
   }, []);
 
   const handleOpenAbout = useCallback(() => {
@@ -205,7 +222,10 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
               <div
                 className="ns-start-menu__item-wrapper"
                 onMouseEnter={() => setOpenSubmenu("games")}
-                onMouseLeave={() => setOpenSubmenu(null)}
+                onMouseLeave={() => {
+                  setOpenSubmenu(null);
+                  setOpenGamesSubmenu(null);
+                }}
               >
                 <button className="ns-start-menu__item">
                   <span className="ns-start-menu__item-icon">🎮</span>
@@ -219,11 +239,42 @@ export default function Taskbar({ windows, activeWindowId, onWindowFocus, onRest
                         key={item.id}
                         className="ns-start-menu__item"
                         onClick={() => handleOpenApp(item.id)}
+                        onMouseEnter={() => setOpenGamesSubmenu(null)}
                       >
                         <span className="ns-start-menu__item-icon">{item.icon}</span>
                         <span className="ns-start-menu__item-label">{item.label}</span>
                       </button>
                     ))}
+
+                    {/* Word Games */}
+                    <div
+                      className="ns-start-menu__item-wrapper"
+                      ref={wordGamesWrapperRef}
+                      onMouseEnter={() => setOpenGamesSubmenu("word-games")}
+                    >
+                      <button className="ns-start-menu__item">
+                        <span className="ns-start-menu__item-icon">🔤</span>
+                        <span className="ns-start-menu__item-label">Word Games</span>
+                        <span className="ns-start-menu__item-arrow">▶</span>
+                      </button>
+                      {openGamesSubmenu === "word-games" && wordGamesFlyoutPos && (
+                        <div
+                          className="ns-start-submenu ns-start-submenu--nested"
+                          style={{ left: wordGamesFlyoutPos.left, top: wordGamesFlyoutPos.top }}
+                        >
+                          {WORD_GAMES_ITEMS.map((item) => (
+                            <button
+                              key={item.id}
+                              className="ns-start-menu__item"
+                              onClick={() => handleOpenApp(item.id)}
+                            >
+                              <span className="ns-start-menu__item-icon">{item.icon}</span>
+                              <span className="ns-start-menu__item-label">{item.label}</span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -2,7 +2,7 @@ import {
   type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
   ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
   GOOBER_FOLDER_ID, GOOBER_SPRITES_ID, CK_SCORES_ID,
-  MJ_SCORES_ID, MJ_TILES_FOLDER_ID,
+  MJ_SCORES_ID, MJ_TILES_FOLDER_ID, MJ_STATE_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -405,6 +405,20 @@ export class FileSystemStore {
       if (mjDir?.kind === "folder") {
         this.nodes.set(MJ_SCORES_ID, {
           id: MJ_SCORES_ID, kind: "file", name: "SCORES.DAT",
+          parentId: mjDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          fileType: "dat", content: "", mimeType: "text/plain",
+          system: false, readonly: false,
+        } as FSFile);
+        changed = true;
+      }
+    }
+
+    // Ensure Mahjong SAVE.DAT (in-progress game state) exists
+    if (!this.nodes.has(MJ_STATE_ID)) {
+      mjDir = mjDir ?? this.getNodeByPath("C:\\Programs\\Games\\Mahjong Solitaire");
+      if (mjDir?.kind === "folder") {
+        this.nodes.set(MJ_STATE_ID, {
+          id: MJ_STATE_ID, kind: "file", name: "SAVE.DAT",
           parentId: mjDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
           fileType: "dat", content: "", mimeType: "text/plain",
           system: false, readonly: false,

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -2,6 +2,7 @@ import {
   type FSNode, type FSFile, type FSFolder, type FSShortcut, type FSFileType,
   ROOT_ID, DUMPSTER_ID, NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
   GOOBER_FOLDER_ID, GOOBER_SPRITES_ID, CK_SCORES_ID,
+  MJ_SCORES_ID, MJ_TILES_FOLDER_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -376,6 +377,70 @@ export class FileSystemStore {
           fileType: "dat", content: "", mimeType: "text/plain",
           system: false, readonly: false,
         } as FSFile);
+        changed = true;
+      }
+    }
+
+    // Ensure Mahjong Solitaire folder + SCORES.DAT exist
+    let mjDir = this.getNodeByPath("C:\\Programs\\Games\\Mahjong Solitaire");
+    if (!this.nodes.has(MJ_SCORES_ID)) {
+      if (!mjDir) {
+        const gamesDir = this.getNodeByPath("C:\\Programs\\Games");
+        if (gamesDir?.kind === "folder") {
+          const folder: FSFolder = {
+            id: "fs:games-mj", kind: "folder", name: "Mahjong Solitaire",
+            parentId: gamesDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            system: false,
+          };
+          this.nodes.set(folder.id, folder);
+          this.nodes.set("fs:games-mj-exe", {
+            id: "fs:games-mj-exe", kind: "file", name: "Mahjong Solitaire.exe",
+            parentId: folder.id, createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "exe", content: "", mimeType: "application/octet-stream",
+            system: false, readonly: false, appId: "mahjong-solitaire",
+          } as FSFile);
+          mjDir = folder;
+        }
+      }
+      if (mjDir?.kind === "folder") {
+        this.nodes.set(MJ_SCORES_ID, {
+          id: MJ_SCORES_ID, kind: "file", name: "SCORES.DAT",
+          parentId: mjDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          fileType: "dat", content: "", mimeType: "text/plain",
+          system: false, readonly: false,
+        } as FSFile);
+        changed = true;
+      }
+    }
+
+    // Ensure Mahjong TILES subfolder + tile face stubs exist
+    if (!this.nodes.has(MJ_TILES_FOLDER_ID)) {
+      mjDir = mjDir ?? this.getNodeByPath("C:\\Programs\\Games\\Mahjong Solitaire");
+      if (mjDir?.kind === "folder") {
+        this.nodes.set(MJ_TILES_FOLDER_ID, {
+          id: MJ_TILES_FOLDER_ID, kind: "folder", name: "TILES",
+          parentId: mjDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          system: false,
+        } as FSFolder);
+
+        const MJ_TILE_IDS = [
+          "dots-1", "dots-2", "dots-3", "dots-4", "dots-5", "dots-6", "dots-7", "dots-8", "dots-9",
+          "bamboo-1", "bamboo-2", "bamboo-3", "bamboo-4", "bamboo-5", "bamboo-6", "bamboo-7", "bamboo-8", "bamboo-9",
+          "chars-1", "chars-2", "chars-3", "chars-4", "chars-5", "chars-6", "chars-7", "chars-8", "chars-9",
+          "wind-east", "wind-south", "wind-west", "wind-north",
+          "dragon-red", "dragon-green", "dragon-white",
+          "flower-1", "flower-2",
+        ];
+        for (const tileId of MJ_TILE_IDS) {
+          const id = `fs:mj-tile-${tileId}`;
+          this.nodes.set(id, {
+            id, kind: "file", name: `${tileId}.png`,
+            parentId: MJ_TILES_FOLDER_ID,
+            createdAt: Date.now(), modifiedAt: Date.now(),
+            fileType: "png", content: "", mimeType: "image/png",
+            system: false, readonly: false, appId: "nsart",
+          } as FSFile);
+        }
         changed = true;
       }
     }

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -4,7 +4,7 @@ import {
   PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
   NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
   GOOBER_FOLDER_ID, GOOBER_SPRITES_ID, CK_SCORES_ID,
-  MJ_SCORES_ID, MJ_TILES_FOLDER_ID,
+  MJ_SCORES_ID, MJ_TILES_FOLDER_ID, MJ_STATE_ID,
 } from "./types";
 
 // ── Text content (preserved from original fileSystem.ts) ─────────────────────
@@ -436,6 +436,7 @@ export function seedFileSystem(store: FileSystemStore): void {
   const mjDir = store.createFolder(GAMES_ID, "Mahjong Solitaire");
   store.createFile(mjDir.id, "Mahjong Solitaire.exe", { fileType: "exe", appId: "mahjong-solitaire" });
   store.createFile(mjDir.id, "SCORES.DAT",            { fileType: "dat", content: "", id: MJ_SCORES_ID });
+  store.createFile(mjDir.id, "SAVE.DAT",              { fileType: "dat", content: "", id: MJ_STATE_ID });
 
   const mjTilesDir = store.createFolder(mjDir.id, "TILES", { id: MJ_TILES_FOLDER_ID });
   for (const tileId of MJ_TILE_IDS) {

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -4,6 +4,7 @@ import {
   PROGRAMS_ID, GAMES_ID, ACC_ID, SYSTEM_ID, DOWNLOADS_ID, EGO_ID,
   NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
   GOOBER_FOLDER_ID, GOOBER_SPRITES_ID, CK_SCORES_ID,
+  MJ_SCORES_ID, MJ_TILES_FOLDER_ID,
 } from "./types";
 
 // ── Text content (preserved from original fileSystem.ts) ─────────────────────
@@ -331,6 +332,16 @@ const GOOBER_SPRITE_FRAMES: Record<string, number> = {
   necklace: 5, hat: 6, heldItem: 5,
 };
 
+// Tile design ids (must match MahjongSolitaire/tiles.ts TILE_DESIGNS)
+const MJ_TILE_IDS = [
+  "dots-1", "dots-2", "dots-3", "dots-4", "dots-5", "dots-6", "dots-7", "dots-8", "dots-9",
+  "bamboo-1", "bamboo-2", "bamboo-3", "bamboo-4", "bamboo-5", "bamboo-6", "bamboo-7", "bamboo-8", "bamboo-9",
+  "chars-1", "chars-2", "chars-3", "chars-4", "chars-5", "chars-6", "chars-7", "chars-8", "chars-9",
+  "wind-east", "wind-south", "wind-west", "wind-north",
+  "dragon-red", "dragon-green", "dragon-white",
+  "flower-1", "flower-2",
+];
+
 // ── Seed function ─────────────────────────────────────────────────────────────
 
 export function seedFileSystem(store: FileSystemStore): void {
@@ -421,6 +432,17 @@ export function seedFileSystem(store: FileSystemStore): void {
   const trDir = store.createFolder(GAMES_ID, "Typing Racer");
   store.createFile(trDir.id, "Typing Racer.exe", { fileType: "exe", appId: "typing-racer" });
   store.createFile(trDir.id, "SCORES.DAT",       { fileType: "dat", content: "", id: TR_SCORES_ID });
+
+  const mjDir = store.createFolder(GAMES_ID, "Mahjong Solitaire");
+  store.createFile(mjDir.id, "Mahjong Solitaire.exe", { fileType: "exe", appId: "mahjong-solitaire" });
+  store.createFile(mjDir.id, "SCORES.DAT",            { fileType: "dat", content: "", id: MJ_SCORES_ID });
+
+  const mjTilesDir = store.createFolder(mjDir.id, "TILES", { id: MJ_TILES_FOLDER_ID });
+  for (const tileId of MJ_TILE_IDS) {
+    store.createFile(mjTilesDir.id, `${tileId}.png`, {
+      fileType: "png", appId: "nsart", content: "", id: `fs:mj-tile-${tileId}`,
+    });
+  }
 
   // Stub / unimplemented games (no appId — opens "not a valid NS Doors application")
   store.createFile(GAMES_ID, "Solitaire.exe",   { fileType: "exe" });

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -17,6 +17,8 @@ export const SYSTEM_INI_ID     = "fs:system-ini";
 export const GOOBER_FOLDER_ID  = "fs:goober-dressup";
 export const GOOBER_SPRITES_ID = "fs:goober-sprites";
 export const CK_SCORES_ID      = "fs:scores-ck";
+export const MJ_SCORES_ID      = "fs:scores-mj";
+export const MJ_TILES_FOLDER_ID = "fs:mj-tiles";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -19,6 +19,7 @@ export const GOOBER_SPRITES_ID = "fs:goober-sprites";
 export const CK_SCORES_ID      = "fs:scores-ck";
 export const MJ_SCORES_ID      = "fs:scores-mj";
 export const MJ_TILES_FOLDER_ID = "fs:mj-tiles";
+export const MJ_STATE_ID        = "fs:mj-state";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"

--- a/src/pages/MahjongSolitairePage.tsx
+++ b/src/pages/MahjongSolitairePage.tsx
@@ -18,14 +18,10 @@ export default function MahjongSolitairePage() {
             </li>
             <li>
               A tile is <strong>free</strong> when nothing sits on top of it and at
-              least one of its left or right side is open
+              least one of its left or right sides is open
             </li>
             <li>
               <strong>Hint</strong> highlights a matching pair you can clear right now
-            </li>
-            <li>
-              <strong>Shuffle</strong> reassigns the faces on the remaining tiles if
-              you get stuck — the board is always solvable
             </li>
             <li>
               <strong>New Game</strong> deals a fresh, solvable layout

--- a/src/pages/MahjongSolitairePage.tsx
+++ b/src/pages/MahjongSolitairePage.tsx
@@ -1,0 +1,46 @@
+import MahjongSolitaire from "../experiences/MahjongSolitaire/MahjongSolitaire";
+import StandaloneWindow from "../components/StandaloneWindow/StandaloneWindow";
+
+export default function MahjongSolitairePage() {
+  return (
+    <StandaloneWindow
+      title="Mahjong Solitaire"
+      icon="🀄"
+      helpContent={
+        <>
+          <ul>
+            <li>
+              <strong>Click a free tile</strong> to select it (it glows orange)
+            </li>
+            <li>
+              <strong>Click a second free tile</strong> with the same face to remove
+              both — that&apos;s a match!
+            </li>
+            <li>
+              A tile is <strong>free</strong> when nothing sits on top of it and at
+              least one of its left or right side is open
+            </li>
+            <li>
+              <strong>Hint</strong> highlights a matching pair you can clear right now
+            </li>
+            <li>
+              <strong>Shuffle</strong> reassigns the faces on the remaining tiles if
+              you get stuck — the board is always solvable
+            </li>
+            <li>
+              <strong>New Game</strong> deals a fresh, solvable layout
+            </li>
+          </ul>
+          <hr />
+          <ul>
+            <li>+10 points per match</li>
+            <li>Time bonus on a clear: faster is better</li>
+            <li>Goal: clear all 144 tiles!</li>
+          </ul>
+        </>
+      }
+    >
+      <MahjongSolitaire />
+    </StandaloneWindow>
+  );
+}


### PR DESCRIPTION
A Taipei/Shisen-Sho-style match-2 game with a 144-tile turtle layout (36
designs x 4), guaranteed-solvable board generation, Hint/Shuffle/Timer/Score,
and FS-backed high scores. Tile faces are bundled SVGs with the Hellzone-style
asset-override pattern, so players can repaint them in NS Art via
C:\Programs\Games\Mahjong Solitaire\TILES\*.png.