### PR TITLE
Shmup F2: content & copy registry layer

### DIFF
--- a/games/shmup/src/content/README.md
+++ b/games/shmup/src/content/README.md
@@ -1,25 +1,43 @@
 # SHMUP Content — Authoring Guide
 
-This directory is the single home for every player-facing string in SHMUP.
-**Editing a line here is a one-file change — zero systems code.** Nothing
-in `scenes/` or `systems/` should ever have an inline string; it calls into
-this layer instead.
+This directory is the intended single home for every player-facing string
+in SHMUP. **Editing a line here is a one-file change — zero systems code.**
+New code should always call into this layer instead of inlining a string.
 
-Every lookup function here is safe: a missing key or id returns a visible
-placeholder (`[missing: foo]`) instead of throwing, so a bad reference is
-obvious in-game without crashing anything.
+(Note on current state: the existing scaffold scenes — `BootScene.ts`,
+`PlayScene.ts` — still have a few placeholder inline UI strings left over
+from the early prototype slice. Those haven't been migrated yet; this guide
+describes where things are headed, not a claim that every string already
+routes through here.)
 
-## Files
+## Content vs. logic
 
-| File | What it holds |
+Files are split so content stays edit-only and logic stays in one place:
+
+| File | What it holds | Kind |
+|---|---|---|
+| `copy.ts` | The flat string table — titles, flavor text, node text, weapon/item/chassis/enemy names+descriptions. | content |
+| `ratings.ts` | The Ratings tier ladder (Nobody → … → Kevin Bacon), each with a `threshold` score. | content |
+| `brands.ts` | Sponsor brand names, taglines, and personalities. | content |
+| `tags.ts` | The flat, typed tag vocabulary used by the crowd-comment pool. | content (types) |
+| `crowdComments.ts` | The crowd-comment pool — each line is just a list of tags + a string. | content |
+| `accessors.ts` | Every lookup/picking function (`copy`, `ratingsTierName`, `brand`, `pickCrowdComment`, …). | logic |
+| `interpolate.ts` | The `{token}` substitution helper shared by several accessors. | logic |
+| `index.ts` | Public exports. Everything outside this directory imports from `../content` (or `./content`), never from an individual file. | barrel |
+
+The content files are intentionally close to plain JSON — just exported
+array/object literals, occasionally typed against a union from `tags.ts` so
+typos are caught at compile time. **Never add a function to a content
+file** — if you need new behavior, add it to `accessors.ts`.
+
+## Safe fallbacks (each accessor degrades differently — none ever throw)
+
+| Accessor | On a missing key/id |
 |---|---|
-| `copy.ts` | The flat string table — titles, flavor text, node text, weapon/item/enemy names+descriptions. |
-| `ratings.ts` | The Ratings tier ladder (Nobody → … → Kevin Bacon) — ordered, names, rank lookup. |
-| `brands.ts` | Sponsor brand names, taglines, and personalities. |
-| `tags.ts` | The typed tag vocabulary (event, stage timing, damage source, trend, crowd size, tier). |
-| `crowdComments.ts` | The crowd-comment pool + the tag-matching weighted picker. |
-| `interpolate.ts` | The `{token}` substitution helper shared by `copy()` and the crowd-comment picker. |
-| `index.ts` | Public exports. Everything outside this directory imports from `../content` (or `./content`), never from an individual file. |
+| `copy(key)` | Returns the literal string `[missing: key]`. |
+| `ratingsTierName(id)` | Returns the literal string `[missing tier: id]`. |
+| `brand(id)` | Returns a stub `SponsorBrand` whose `name` is `[missing brand: id]` and `tagline`/`personality` are empty strings. |
+| `pickCrowdComment(ctx)` | Returns `undefined` if no line in the pool matches the context — the caller decides the fallback (typically: say nothing). |
 
 ## Adding/editing flat copy (`copy.ts`)
 
@@ -51,9 +69,15 @@ rather than throwing.
 
 ## Editing the Ratings ladder (`ratings.ts`)
 
-`RATINGS_LADDER` is an ordered array, low tier to high. Rename a tier or
-reorder the array directly — `ratingsTierName()` and `ratingsTierRank()`
-read from this array, so there's nothing else to keep in sync.
+Each tier has an `id`, a display `name`, and a `threshold` — the cumulative
+Ratings score needed to reach that tier. The `threshold` is what gives the
+ladder its ordering (not array position), so you can reorder entries in the
+file for readability without affecting rank or tier lookups. Rename a tier,
+adjust a threshold, or insert a new tier directly; `ratingsTierName()`,
+`ratingsTierRank()`, and `ratingsTierForScore()` (in `accessors.ts`) all
+read from this array, so there's nothing else to keep in sync. Thresholds
+here are placeholders — the real balance numbers are TBD per
+`hype-and-ratings.spec.todo.md`.
 
 ## Editing sponsor brands (`brands.ts`)
 
@@ -61,42 +85,41 @@ Add an entry to `BRANDS` keyed by a short id. `personality` should read as
 a build archetype (what kind of build owning this brand's items signals),
 since that's the text players actually see on item synergy hints.
 
-## Adding a tag *value* (`tags.ts`)
+## Adding a tag (`tags.ts`)
 
-Each tag dimension is a string-literal union, e.g.:
+`CrowdTag` is one flat string-literal union — not separate named fields per
+category. Add a new value to the union and it's immediately usable on any
+line or context, with autocomplete and a compile error on typos. There's no
+separate "dimension" concept to wire up: tags for *when* something happened,
+*what* happened, *how big* the crowd is, etc. all live in the same union and
+are matched the same way.
 
-```ts
-export type CrowdEventTag = "death" | "hit" | "graze" | "clear" | "levelStart" | "bossIntro" | "scoreGain";
-```
-
-Add a new value to the union it belongs to. Every line/context that
-references that union gets autocomplete and a compile error on typos —
-this is what "tags are a single typed source of truth" means in practice.
-
-Adding a whole new *dimension* (rare) means adding a new union here, then a
-matching optional field to both `CrowdCommentLine` and `CrowdCommentContext`
-in `crowdComments.ts`, plus a branch in that file's `matches()`/`weight()`.
+Numeric facts (like a graze streak count) aren't tags by themselves —
+whoever builds the context decides which bucket tag(s) apply (e.g. a streak
+of 12 includes both `grazeStreak5` and `grazeStreak10`) and includes them in
+the `tags` array passed to `pickCrowdComment`.
 
 ## Adding a crowd-comment line (`crowdComments.ts`)
 
-Append an object to `CROWD_COMMENTS`. Every field but `says` is optional;
-an omitted field is a **wildcard** — the line is eligible regardless of
-that part of the context. The exception is `minStreak`, a numeric floor
-(the line is eligible once `context.streak >= minStreak`).
+Append an object to `CROWD_COMMENTS`. Each line is just `{ tags, says }`:
 
 ```ts
-{ when: "death", at: "early", says: "That's it?! These seats cost me $5000!!" }
-{ when: "death", tier: "has-been", trend: "falling", says: "Oh, how the mighty have fallen." }
-{ when: "graze", minStreak: 5, says: "DUUUUDE!!" }
-{ says: "We love you {playerName}!!" }   // no tags = generic filler, still eligible for everything
+{ tags: ["death", "earlyGame"], says: "That's it?! These seats cost me $5000!!" }
+{ tags: ["death", "has-been", "falling"], says: "Oh, how the mighty have fallen." }
+{ tags: ["graze", "grazeStreak5"], says: "DUUUUDE!!" }
+{ tags: [], says: "We love you {playerName}!!" }   // no tags = generic filler, still eligible for everything
 ```
 
-**Weighting:** among lines eligible for a given context, pick weight is
-`1 + (number of tags the line specifies)`. So a line with three matching
-tags is far more likely to be picked than a zero-tag filler line whenever
-both apply — specific zingers win when they're relevant, but generic filler
-keeps the pool from going silent when nothing specific fits. You don't
-manage weights by hand; just add tags to make a line more specific.
+A line is eligible when **every** tag it lists is present in the current
+context's tag list. An empty `tags` array is eligible for any context.
 
-Call `pickCrowdComment(context)` to get a string (already token-interpolated)
-or `undefined` if nothing in the pool matches the context.
+**Weighting:** among eligible lines, pick weight is `1 + (number of tags on
+the line)`. So a line with three tags is far more likely to be picked than
+a zero-tag filler line whenever both apply — specific zingers win when
+they're relevant, but generic filler keeps the pool from going silent when
+nothing specific fits. You don't manage weights by hand; just add tags to
+make a line more specific.
+
+Call `pickCrowdComment({ tags: [...active tags...], tokens })` to get a
+string (already token-interpolated) or `undefined` if nothing in the pool
+matches.

--- a/games/shmup/src/content/README.md
+++ b/games/shmup/src/content/README.md
@@ -1,0 +1,102 @@
+# SHMUP Content — Authoring Guide
+
+This directory is the single home for every player-facing string in SHMUP.
+**Editing a line here is a one-file change — zero systems code.** Nothing
+in `scenes/` or `systems/` should ever have an inline string; it calls into
+this layer instead.
+
+Every lookup function here is safe: a missing key or id returns a visible
+placeholder (`[missing: foo]`) instead of throwing, so a bad reference is
+obvious in-game without crashing anything.
+
+## Files
+
+| File | What it holds |
+|---|---|
+| `copy.ts` | The flat string table — titles, flavor text, node text, weapon/item/enemy names+descriptions. |
+| `ratings.ts` | The Ratings tier ladder (Nobody → … → Kevin Bacon) — ordered, names, rank lookup. |
+| `brands.ts` | Sponsor brand names, taglines, and personalities. |
+| `tags.ts` | The typed tag vocabulary (event, stage timing, damage source, trend, crowd size, tier). |
+| `crowdComments.ts` | The crowd-comment pool + the tag-matching weighted picker. |
+| `interpolate.ts` | The `{token}` substitution helper shared by `copy()` and the crowd-comment picker. |
+| `index.ts` | Public exports. Everything outside this directory imports from `../content` (or `./content`), never from an individual file. |
+
+## Adding/editing flat copy (`copy.ts`)
+
+Add a new dotted key in the right section of the `COPY` object, or edit an
+existing line's value in place — that's it. Keys are grouped by namespace
+in comments; put new keys in the matching group rather than starting a new
+one. For weapon/item/chassis/enemy text, follow the existing convention:
+
+```ts
+"weapon.<id>.name": "...",
+"weapon.<id>.description": "...",
+```
+
+(same shape for `item.`, `chassis.`, `enemy.`). Code looks it up with
+`copy("weapon.laser.name")`.
+
+Strings can contain `{token}` placeholders, filled at call time:
+
+```ts
+"cancelled.flavor": "The execs pulled the plug, {playerName}. Better luck next career.",
+```
+
+```ts
+copy("cancelled.flavor", { playerName: "Noah" });
+```
+
+A placeholder with no matching token is left as literal text (`{playerName}`)
+rather than throwing.
+
+## Editing the Ratings ladder (`ratings.ts`)
+
+`RATINGS_LADDER` is an ordered array, low tier to high. Rename a tier or
+reorder the array directly — `ratingsTierName()` and `ratingsTierRank()`
+read from this array, so there's nothing else to keep in sync.
+
+## Editing sponsor brands (`brands.ts`)
+
+Add an entry to `BRANDS` keyed by a short id. `personality` should read as
+a build archetype (what kind of build owning this brand's items signals),
+since that's the text players actually see on item synergy hints.
+
+## Adding a tag *value* (`tags.ts`)
+
+Each tag dimension is a string-literal union, e.g.:
+
+```ts
+export type CrowdEventTag = "death" | "hit" | "graze" | "clear" | "levelStart" | "bossIntro" | "scoreGain";
+```
+
+Add a new value to the union it belongs to. Every line/context that
+references that union gets autocomplete and a compile error on typos —
+this is what "tags are a single typed source of truth" means in practice.
+
+Adding a whole new *dimension* (rare) means adding a new union here, then a
+matching optional field to both `CrowdCommentLine` and `CrowdCommentContext`
+in `crowdComments.ts`, plus a branch in that file's `matches()`/`weight()`.
+
+## Adding a crowd-comment line (`crowdComments.ts`)
+
+Append an object to `CROWD_COMMENTS`. Every field but `says` is optional;
+an omitted field is a **wildcard** — the line is eligible regardless of
+that part of the context. The exception is `minStreak`, a numeric floor
+(the line is eligible once `context.streak >= minStreak`).
+
+```ts
+{ when: "death", at: "early", says: "That's it?! These seats cost me $5000!!" }
+{ when: "death", tier: "has-been", trend: "falling", says: "Oh, how the mighty have fallen." }
+{ when: "graze", minStreak: 5, says: "DUUUUDE!!" }
+{ says: "We love you {playerName}!!" }   // no tags = generic filler, still eligible for everything
+```
+
+**Weighting:** among lines eligible for a given context, pick weight is
+`1 + (number of tags the line specifies)`. So a line with three matching
+tags is far more likely to be picked than a zero-tag filler line whenever
+both apply — specific zingers win when they're relevant, but generic filler
+keeps the pool from going silent when nothing specific fits. You don't
+manage weights by hand; just add tags to make a line more specific.
+
+Call `pickCrowdComment(context)` to get a string (already token-interpolated)
+or `undefined` if nothing in the pool matches the context.

--- a/games/shmup/src/content/accessors.ts
+++ b/games/shmup/src/content/accessors.ts
@@ -1,0 +1,93 @@
+/**
+ * All lookup/picking logic for the content registry lives here. The data
+ * files (copy.ts, ratings.ts, brands.ts, crowdComments.ts, tags.ts) are
+ * pure content — exported literals and types, no functions — so an
+ * authoring change to those files is never a code change. This file is the
+ * one place behavior is allowed to live.
+ */
+import { COPY } from "./copy";
+import { RATINGS_LADDER, type RatingsTierId } from "./ratings";
+import { BRANDS, type BrandId, type SponsorBrand } from "./brands";
+import { CROWD_COMMENTS, type CrowdCommentLine } from "./crowdComments";
+import type { CrowdTag } from "./tags";
+import { interpolate } from "./interpolate";
+
+export type CopyKey = keyof typeof COPY;
+
+/**
+ * Look up a line by key; never throws. A missing key returns a visible
+ * `[missing: key]` fallback so a bad reference is obvious without crashing
+ * the game. Optional `tokens` interpolate `{name}`-style placeholders.
+ */
+export function copy(key: CopyKey | string, tokens?: Record<string, string | number>): string {
+  const template = (COPY as Record<string, string>)[key];
+  if (template === undefined) return `[missing: ${key}]`;
+  return interpolate(template, tokens);
+}
+
+/** Display name for a Ratings tier; never throws on an unknown id — returns `[missing tier: id]`. */
+export function ratingsTierName(id: RatingsTierId | string): string {
+  return RATINGS_LADDER.find((t) => t.id === id)?.name ?? `[missing tier: ${id}]`;
+}
+
+/** Rank in the ladder ordered by threshold (low → high); -1 if the id isn't found. */
+export function ratingsTierRank(id: RatingsTierId | string): number {
+  return [...RATINGS_LADDER].sort((a, b) => a.threshold - b.threshold).findIndex((t) => t.id === id);
+}
+
+/** Which tier a given cumulative Ratings score currently falls in. */
+export function ratingsTierForScore(score: number): RatingsTierId {
+  const eligible = RATINGS_LADDER.filter((t) => score >= t.threshold);
+  if (eligible.length === 0) return RATINGS_LADDER[0].id;
+  return eligible.reduce((best, t) => (t.threshold > best.threshold ? t : best)).id;
+}
+
+/** Look up a sponsor brand by id; never throws on an unknown id — returns a `[missing brand: id]` stub. */
+export function brand(id: BrandId | string): SponsorBrand {
+  return (
+    (BRANDS as Record<string, SponsorBrand>)[id] ?? {
+      name: `[missing brand: ${id}]`,
+      tagline: "",
+      personality: "",
+    }
+  );
+}
+
+/** What the audience service knows about the moment it's reacting to. */
+export interface CrowdCommentContext {
+  /** Every tag that's true right now — event + situational state, all flattened. */
+  tags: readonly CrowdTag[];
+  /** Values for `{token}` interpolation, e.g. `{ playerName: "Noah" }`. */
+  tokens?: Record<string, string | number>;
+}
+
+function isEligible(line: CrowdCommentLine, activeTags: readonly CrowdTag[]): boolean {
+  return line.tags.every((tag) => activeTags.includes(tag));
+}
+
+/** More tags on a line = more specific = higher weight; untagged filler still gets a baseline weight of 1. */
+function commentWeight(line: CrowdCommentLine): number {
+  return 1 + line.tags.length;
+}
+
+/**
+ * Filter the pool to lines whose tags are all present in the context, then
+ * draw a weighted random pick favoring the most specific matches. Returns
+ * undefined if nothing in the pool applies — the caller decides the
+ * fallback (typically: stay silent rather than show a broken line).
+ */
+export function pickCrowdComment(
+  ctx: CrowdCommentContext,
+  rng: () => number = Math.random
+): string | undefined {
+  const eligible = CROWD_COMMENTS.filter((line) => isEligible(line, ctx.tags));
+  if (eligible.length === 0) return undefined;
+
+  const total = eligible.reduce((sum, line) => sum + commentWeight(line), 0);
+  let roll = rng() * total;
+  for (const line of eligible) {
+    roll -= commentWeight(line);
+    if (roll <= 0) return interpolate(line.says, ctx.tokens);
+  }
+  return interpolate(eligible[eligible.length - 1].says, ctx.tokens);
+}

--- a/games/shmup/src/content/brands.ts
+++ b/games/shmup/src/content/brands.ts
@@ -4,8 +4,9 @@
  * archetype (Grease Monkey Oil → dodge/speed) so players can recognize a
  * brand's identity from its decal alone, before reading a single tooltip.
  *
- * Keyed by a short brand id; weapons/items reference brands by this id
- * elsewhere (not here — this file only owns the copy).
+ * Pure content — keyed by a short brand id; weapons/items reference brands
+ * by this id elsewhere (not here — this file only owns the copy). Lookup
+ * logic (the `brand()` accessor) lives in ./accessors.ts, not here.
  */
 export interface SponsorBrand {
   name: string;
@@ -27,14 +28,3 @@ export const BRANDS = {
 } as const satisfies Record<string, SponsorBrand>;
 
 export type BrandId = keyof typeof BRANDS;
-
-/** Look up a brand by id; never throws on an unknown id. */
-export function brand(id: BrandId | string): SponsorBrand {
-  return (
-    (BRANDS as Record<string, SponsorBrand>)[id] ?? {
-      name: `[missing brand: ${id}]`,
-      tagline: "",
-      personality: "",
-    }
-  );
-}

--- a/games/shmup/src/content/brands.ts
+++ b/games/shmup/src/content/brands.ts
@@ -1,0 +1,40 @@
+/**
+ * Sponsor brands (specs/items-and-brands.spec.todo.md) — names, taglines,
+ * and personalities. A brand's personality should read as a build
+ * archetype (Grease Monkey Oil → dodge/speed) so players can recognize a
+ * brand's identity from its decal alone, before reading a single tooltip.
+ *
+ * Keyed by a short brand id; weapons/items reference brands by this id
+ * elsewhere (not here — this file only owns the copy).
+ */
+export interface SponsorBrand {
+  name: string;
+  tagline: string;
+  personality: string;
+}
+
+export const BRANDS = {
+  "grease-monkey": {
+    name: "Grease Monkey Oil",
+    tagline: "Slicker than the competition.",
+    personality: "Dodge & speed — rewards an evasion-leaning build.",
+  },
+  masochist: {
+    name: "Masochist Energy Drink",
+    tagline: "Pain is just progress with a kick.",
+    personality: "Hype-on-damage — thrives on taking hits, not avoiding them.",
+  },
+} as const satisfies Record<string, SponsorBrand>;
+
+export type BrandId = keyof typeof BRANDS;
+
+/** Look up a brand by id; never throws on an unknown id. */
+export function brand(id: BrandId | string): SponsorBrand {
+  return (
+    (BRANDS as Record<string, SponsorBrand>)[id] ?? {
+      name: `[missing brand: ${id}]`,
+      tagline: "",
+      personality: "",
+    }
+  );
+}

--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -1,0 +1,40 @@
+/**
+ * The flat copy table — every short player-facing string that doesn't need
+ * its own structured shape (those live in ratings.ts, brands.ts,
+ * crowdComments.ts instead). Keys are dotted strings grouped by namespace
+ * below; add new keys in the matching section rather than inventing a new
+ * one. See ./README.md for the full authoring guide.
+ */
+export const COPY = {
+  // ---- Title / intro ----
+  "game.title": "SHMUP",
+  "intro.presents": "Noahsoft presents:",
+  "intro.sticker": "Works on Doors 97!",
+
+  // ---- Season / Finale / Syndication flavor (run-structure.spec.todo.md) ----
+  "season.finale.title": "SEASON FINALE",
+  "season.finale.flavor": "The network's watching. Don't blow it.",
+  "series.finale.title": "SERIES FINALE",
+  "series.finale.flavor": "Five seasons. One shot at legend status.",
+  "syndication.title": "SYNDICATION",
+  "syndication.flavor": "The show goes on. Forever, if you're good enough.",
+  "cancelled.title": "CANCELLED",
+  "cancelled.flavor": "The execs pulled the plug, {playerName}. Better luck next career.",
+
+  // ---- Event nodes (run-structure.spec.todo.md node types) ----
+  "node.standard.flavor": "Another contract. Another paycheck.",
+  "node.elite.flavor": "Somebody important is watching this one.",
+  "node.shop.flavor": "The pit crew's got a deal for you.",
+  "node.event.flavor": "Something's not on the call sheet.",
+  "node.treasure.flavor": "Craft services left the good stuff out.",
+  "node.bossFinale.flavor": "This is the one the trailer's built around.",
+
+  // ---- Weapon/item/chassis/enemy copy ----
+  // Convention: "weapon.<id>.name" / "weapon.<id>.description", and the
+  // same shape for "item.", "chassis.", "enemy.". F3/F4 own the systems
+  // that assign real ids; these two are placeholders proving the shape.
+  "weapon.placeholder.name": "Stock Blaster",
+  "weapon.placeholder.description": "Standard-issue. Gets the job done.",
+  "enemy.placeholder.name": "Drone",
+  "enemy.placeholder.description": "Cheap, expendable, everywhere.",
+} as const;

--- a/games/shmup/src/content/crowdComments.ts
+++ b/games/shmup/src/content/crowdComments.ts
@@ -2,136 +2,55 @@
  * The crowd-comment pool — the showcase for "copy is an asset"
  * (specs/audience-and-score.spec.todo.md, specs/content-and-assets.spec.todo.md).
  *
- * The studio audience reacts with tagged one-liners. A reaction carries a
- * *context* (what happened + facts); a line is eligible only if every tag
- * it specifies matches the context — an unspecified field is a wildcard.
- * Among eligible lines, **more matching tags = higher pick weight**, so
- * generic filler and hyper-specific zingers can live in the same pool and
- * the specific line wins when it applies.
+ * Pure content: each line is just a list of tags (see ./tags.ts) plus the
+ * line itself. A line is eligible when every one of its tags is present in
+ * the active context; an empty `tags` array means generic filler that's
+ * always eligible. Matching and weighted picking is logic, not content, so
+ * it lives in ./accessors.ts (`pickCrowdComment`) instead of here.
  *
  * Adding or editing a line is a one-file change to CROWD_COMMENTS below.
  * See ./README.md for the authoring guide.
  */
-import type {
-  CrowdEventTag,
-  StageTimingTag,
-  DamageSourceTag,
-  TrendTag,
-  CrowdSizeTag,
-  RatingsTierId,
-} from "./tags";
-import { interpolate } from "./interpolate";
+import type { CrowdTag } from "./tags";
 
-/**
- * One line in the pool. Every field but `says` is an optional tag; leaving
- * a field out makes the line a wildcard on that dimension.
- */
 export interface CrowdCommentLine {
+  /** Tags that must ALL be active for this line to be eligible. */
+  tags: readonly CrowdTag[];
   says: string;
-  when?: CrowdEventTag;
-  at?: StageTimingTag;
-  damageSource?: DamageSourceTag;
-  tier?: RatingsTierId;
-  trend?: TrendTag;
-  crowdSize?: CrowdSizeTag;
-  /** Eligible only when the context's streak is at least this high. */
-  minStreak?: number;
 }
 
-/** What the audience service knows about the moment it's reacting to. */
-export interface CrowdCommentContext {
-  event: CrowdEventTag;
-  stageTiming?: StageTimingTag;
-  damageSource?: DamageSourceTag;
-  tier?: RatingsTierId;
-  trend?: TrendTag;
-  crowdSize?: CrowdSizeTag;
-  streak?: number;
-  /** Values for `{token}` interpolation, e.g. `{ playerName: "Noah" }`. */
-  tokens?: Record<string, string | number>;
-}
-
-const TAG_FIELDS: readonly (keyof CrowdCommentLine)[] = [
-  "when",
-  "at",
-  "damageSource",
-  "tier",
-  "trend",
-  "crowdSize",
-  "minStreak",
-];
-
-function matches(line: CrowdCommentLine, ctx: CrowdCommentContext): boolean {
-  if (line.when !== undefined && line.when !== ctx.event) return false;
-  if (line.at !== undefined && line.at !== ctx.stageTiming) return false;
-  if (line.damageSource !== undefined && line.damageSource !== ctx.damageSource) return false;
-  if (line.tier !== undefined && line.tier !== ctx.tier) return false;
-  if (line.trend !== undefined && line.trend !== ctx.trend) return false;
-  if (line.crowdSize !== undefined && line.crowdSize !== ctx.crowdSize) return false;
-  if (line.minStreak !== undefined && (ctx.streak ?? 0) < line.minStreak) return false;
-  return true;
-}
-
-/** Pick weight: a baseline of 1 (so wildcard filler is never zero) plus one per specified tag. */
-function weight(line: CrowdCommentLine): number {
-  const specified = TAG_FIELDS.filter((field) => line[field] !== undefined).length;
-  return 1 + specified;
-}
-
-// Author format (illustrative, from #130): unspecified fields are wildcards.
 // Keep specific zingers and generic filler side by side — specificity is
-// handled entirely by the weighting in pickCrowdComment, not by file order.
+// handled entirely by the weighting in pickCrowdComment (accessors.ts),
+// not by file order.
 export const CROWD_COMMENTS: readonly CrowdCommentLine[] = [
-  // Generic filler — always eligible, lowest weight.
-  { says: "We love you {playerName}!!" },
-  { says: "Let's go!!" },
-  { says: "Come on, let's see something good!" },
+  // Generic filler — always eligible (no tags), lowest weight.
+  { tags: [], says: "We love you {playerName}!!" },
+  { tags: [], says: "Let's go!!" },
+  { tags: [], says: "Come on, let's see something good!" },
 
   // Hits / death.
-  { when: "hit", says: "Booooo!" },
-  { when: "death", says: "Aw, come on!" },
-  { when: "death", at: "early", says: "That's it?! These seats cost me $5000!!" },
-  { when: "death", tier: "has-been", trend: "falling", says: "Oh, how the mighty have fallen." },
-  { when: "death", at: "boss", says: "SO CLOSE! SO CLOSE!" },
+  { tags: ["hit"], says: "Booooo!" },
+  { tags: ["death"], says: "Aw, come on!" },
+  { tags: ["death", "earlyGame"], says: "That's it?! These seats cost me $5000!!" },
+  { tags: ["death", "has-been", "falling"], says: "Oh, how the mighty have fallen." },
+  { tags: ["death", "bossFight"], says: "SO CLOSE! SO CLOSE!" },
 
   // Grazing.
-  { when: "graze", says: "Whoooaaa!" },
-  { when: "graze", minStreak: 5, says: "DUUUUDE!!" },
-  { when: "graze", minStreak: 10, crowdSize: "packed", says: "THIS PLACE IS LOSING IT!!" },
+  { tags: ["graze"], says: "Whoooaaa!" },
+  { tags: ["graze", "grazeStreak5"], says: "DUUUUDE!!" },
+  { tags: ["graze", "grazeStreak10", "packedCrowd"], says: "THIS PLACE IS LOSING IT!!" },
 
   // Clears / comebacks.
-  { when: "clear", says: "And the crowd goes wild!" },
-  { when: "clear", trend: "comeback", says: "HE'S STILL GOT IT!" },
-  { when: "clear", tier: "kevin-bacon", says: "Of course he cleared it. He's Kevin Bacon." },
+  { tags: ["clear"], says: "And the crowd goes wild!" },
+  { tags: ["clear", "comeback"], says: "HE'S STILL GOT IT!" },
+  { tags: ["clear", "kevin-bacon"], says: "Of course he cleared it. He's Kevin Bacon." },
 
   // Episode/boss framing.
-  { when: "levelStart", says: "Here we go, here we go!" },
-  { when: "bossIntro", says: "Ooooooh, here we go!" },
-  { when: "bossIntro", crowdSize: "large", says: "EVERYBODY ON YOUR FEET!" },
+  { tags: ["levelStart"], says: "Here we go, here we go!" },
+  { tags: ["bossIntro"], says: "Ooooooh, here we go!" },
+  { tags: ["bossIntro", "largeCrowd"], says: "EVERYBODY ON YOUR FEET!" },
 
   // Score.
-  { when: "scoreGain", says: "Ka-ching!" },
-  { when: "scoreGain", crowdSize: "packed", says: "THE WHOLE PLACE IS GOING NUTS!" },
+  { tags: ["scoreGain"], says: "Ka-ching!" },
+  { tags: ["scoreGain", "packedCrowd"], says: "THE WHOLE PLACE IS GOING NUTS!" },
 ] as const;
-
-/**
- * Filter the pool to lines whose tags all match the context, then draw a
- * weighted random pick favoring the most specific matches. Returns
- * undefined if nothing in the pool applies — the caller decides the
- * fallback (typically: stay silent rather than show a broken line).
- */
-export function pickCrowdComment(
-  ctx: CrowdCommentContext,
-  rng: () => number = Math.random
-): string | undefined {
-  const eligible = CROWD_COMMENTS.filter((line) => matches(line, ctx));
-  if (eligible.length === 0) return undefined;
-
-  const total = eligible.reduce((sum, line) => sum + weight(line), 0);
-  let roll = rng() * total;
-  for (const line of eligible) {
-    roll -= weight(line);
-    if (roll <= 0) return interpolate(line.says, ctx.tokens);
-  }
-  return interpolate(eligible[eligible.length - 1].says, ctx.tokens);
-}

--- a/games/shmup/src/content/crowdComments.ts
+++ b/games/shmup/src/content/crowdComments.ts
@@ -1,0 +1,137 @@
+/**
+ * The crowd-comment pool — the showcase for "copy is an asset"
+ * (specs/audience-and-score.spec.todo.md, specs/content-and-assets.spec.todo.md).
+ *
+ * The studio audience reacts with tagged one-liners. A reaction carries a
+ * *context* (what happened + facts); a line is eligible only if every tag
+ * it specifies matches the context — an unspecified field is a wildcard.
+ * Among eligible lines, **more matching tags = higher pick weight**, so
+ * generic filler and hyper-specific zingers can live in the same pool and
+ * the specific line wins when it applies.
+ *
+ * Adding or editing a line is a one-file change to CROWD_COMMENTS below.
+ * See ./README.md for the authoring guide.
+ */
+import type {
+  CrowdEventTag,
+  StageTimingTag,
+  DamageSourceTag,
+  TrendTag,
+  CrowdSizeTag,
+  RatingsTierId,
+} from "./tags";
+import { interpolate } from "./interpolate";
+
+/**
+ * One line in the pool. Every field but `says` is an optional tag; leaving
+ * a field out makes the line a wildcard on that dimension.
+ */
+export interface CrowdCommentLine {
+  says: string;
+  when?: CrowdEventTag;
+  at?: StageTimingTag;
+  damageSource?: DamageSourceTag;
+  tier?: RatingsTierId;
+  trend?: TrendTag;
+  crowdSize?: CrowdSizeTag;
+  /** Eligible only when the context's streak is at least this high. */
+  minStreak?: number;
+}
+
+/** What the audience service knows about the moment it's reacting to. */
+export interface CrowdCommentContext {
+  event: CrowdEventTag;
+  stageTiming?: StageTimingTag;
+  damageSource?: DamageSourceTag;
+  tier?: RatingsTierId;
+  trend?: TrendTag;
+  crowdSize?: CrowdSizeTag;
+  streak?: number;
+  /** Values for `{token}` interpolation, e.g. `{ playerName: "Noah" }`. */
+  tokens?: Record<string, string | number>;
+}
+
+const TAG_FIELDS: readonly (keyof CrowdCommentLine)[] = [
+  "when",
+  "at",
+  "damageSource",
+  "tier",
+  "trend",
+  "crowdSize",
+  "minStreak",
+];
+
+function matches(line: CrowdCommentLine, ctx: CrowdCommentContext): boolean {
+  if (line.when !== undefined && line.when !== ctx.event) return false;
+  if (line.at !== undefined && line.at !== ctx.stageTiming) return false;
+  if (line.damageSource !== undefined && line.damageSource !== ctx.damageSource) return false;
+  if (line.tier !== undefined && line.tier !== ctx.tier) return false;
+  if (line.trend !== undefined && line.trend !== ctx.trend) return false;
+  if (line.crowdSize !== undefined && line.crowdSize !== ctx.crowdSize) return false;
+  if (line.minStreak !== undefined && (ctx.streak ?? 0) < line.minStreak) return false;
+  return true;
+}
+
+/** Pick weight: a baseline of 1 (so wildcard filler is never zero) plus one per specified tag. */
+function weight(line: CrowdCommentLine): number {
+  const specified = TAG_FIELDS.filter((field) => line[field] !== undefined).length;
+  return 1 + specified;
+}
+
+// Author format (illustrative, from #130): unspecified fields are wildcards.
+// Keep specific zingers and generic filler side by side — specificity is
+// handled entirely by the weighting in pickCrowdComment, not by file order.
+export const CROWD_COMMENTS: readonly CrowdCommentLine[] = [
+  // Generic filler — always eligible, lowest weight.
+  { says: "We love you {playerName}!!" },
+  { says: "Let's go!!" },
+  { says: "Come on, let's see something good!" },
+
+  // Hits / death.
+  { when: "hit", says: "Booooo!" },
+  { when: "death", says: "Aw, come on!" },
+  { when: "death", at: "early", says: "That's it?! These seats cost me $5000!!" },
+  { when: "death", tier: "has-been", trend: "falling", says: "Oh, how the mighty have fallen." },
+  { when: "death", at: "boss", says: "SO CLOSE! SO CLOSE!" },
+
+  // Grazing.
+  { when: "graze", says: "Whoooaaa!" },
+  { when: "graze", minStreak: 5, says: "DUUUUDE!!" },
+  { when: "graze", minStreak: 10, crowdSize: "packed", says: "THIS PLACE IS LOSING IT!!" },
+
+  // Clears / comebacks.
+  { when: "clear", says: "And the crowd goes wild!" },
+  { when: "clear", trend: "comeback", says: "HE'S STILL GOT IT!" },
+  { when: "clear", tier: "kevin-bacon", says: "Of course he cleared it. He's Kevin Bacon." },
+
+  // Episode/boss framing.
+  { when: "levelStart", says: "Here we go, here we go!" },
+  { when: "bossIntro", says: "Ooooooh, here we go!" },
+  { when: "bossIntro", crowdSize: "large", says: "EVERYBODY ON YOUR FEET!" },
+
+  // Score.
+  { when: "scoreGain", says: "Ka-ching!" },
+  { when: "scoreGain", crowdSize: "packed", says: "THE WHOLE PLACE IS GOING NUTS!" },
+] as const;
+
+/**
+ * Filter the pool to lines whose tags all match the context, then draw a
+ * weighted random pick favoring the most specific matches. Returns
+ * undefined if nothing in the pool applies — the caller decides the
+ * fallback (typically: stay silent rather than show a broken line).
+ */
+export function pickCrowdComment(
+  ctx: CrowdCommentContext,
+  rng: () => number = Math.random
+): string | undefined {
+  const eligible = CROWD_COMMENTS.filter((line) => matches(line, ctx));
+  if (eligible.length === 0) return undefined;
+
+  const total = eligible.reduce((sum, line) => sum + weight(line), 0);
+  let roll = rng() * total;
+  for (const line of eligible) {
+    roll -= weight(line);
+    if (roll <= 0) return interpolate(line.says, ctx.tokens);
+  }
+  return interpolate(eligible[eligible.length - 1].says, ctx.tokens);
+}

--- a/games/shmup/src/content/index.ts
+++ b/games/shmup/src/content/index.ts
@@ -1,22 +1,37 @@
 /**
- * Content / copy registry — "copy is an asset" (specs/content-and-assets.spec.md).
+ * Content / copy registry — "copy is an asset" (specs/content-and-assets.spec.todo.md).
  *
- * All player-facing text lives here as data, referenced by key. Noah edits this;
- * systems never inline strings. Missing keys degrade gracefully (never throw).
+ * All player-facing text lives in this directory as data, referenced by
+ * key. Noah edits these files; systems code never inlines strings. Missing
+ * keys/ids degrade gracefully (never throw). See ./README.md for the full
+ * authoring guide.
  *
- * This is a minimal stub for the scaffold; F2 (#130) builds the full registry,
- * typed crowd-comment tags, token interpolation, and per-domain files.
+ * Public surface:
+ * - `copy(key, tokens?)` — the flat string table (./copy.ts), with `{token}` interpolation.
+ * - `ratingsTierName` / `ratingsTierRank` / `RATINGS_LADDER` — the fame ladder (./ratings.ts).
+ * - `brand(id)` / `BRANDS` — sponsor brand names/taglines/personalities (./brands.ts).
+ * - `pickCrowdComment(context)` — the tag-matched, weighted crowd-comment pool (./crowdComments.ts).
+ * - The tag dimension types (./tags.ts) used to build a `CrowdCommentContext`.
  */
-
-export const COPY = {
-  "game.title": "SHMUP",
-  "intro.presents": "Noahsoft presents:",
-  "intro.sticker": "Works on Doors 97!",
-} as const;
+import { COPY } from "./copy";
+import { interpolate } from "./interpolate";
 
 export type CopyKey = keyof typeof COPY;
 
-/** Look up a line by key; returns a visible fallback rather than throwing. */
-export function copy(key: CopyKey | string): string {
-  return (COPY as Record<string, string>)[key] ?? `[missing: ${key}]`;
+/**
+ * Look up a line by key; never throws. A missing key returns a visible
+ * `[missing: key]` fallback so a bad reference is obvious without crashing
+ * the game. Optional `tokens` interpolate `{name}`-style placeholders.
+ */
+export function copy(key: CopyKey | string, tokens?: Record<string, string | number>): string {
+  const template = (COPY as Record<string, string>)[key];
+  if (template === undefined) return `[missing: ${key}]`;
+  return interpolate(template, tokens);
 }
+
+export { COPY };
+export { interpolate };
+export * from "./tags";
+export * from "./ratings";
+export * from "./brands";
+export * from "./crowdComments";

--- a/games/shmup/src/content/index.ts
+++ b/games/shmup/src/content/index.ts
@@ -1,37 +1,37 @@
 /**
  * Content / copy registry — "copy is an asset" (specs/content-and-assets.spec.todo.md).
  *
- * All player-facing text lives in this directory as data, referenced by
- * key. Noah edits these files; systems code never inlines strings. Missing
- * keys/ids degrade gracefully (never throw). See ./README.md for the full
- * authoring guide.
+ * The intent is for every player-facing string and tagged content pool to
+ * live in this directory as data, referenced by key/tag, so nothing in
+ * `scenes/`/`systems/` ever inlines a string. New code should always go
+ * through this layer. (Note: the existing scaffold scenes — BootScene,
+ * PlayScene — still have some placeholder inline UI text left over from
+ * the early prototype slice and haven't been migrated yet.)
  *
- * Public surface:
- * - `copy(key, tokens?)` — the flat string table (./copy.ts), with `{token}` interpolation.
- * - `ratingsTierName` / `ratingsTierRank` / `RATINGS_LADDER` — the fame ladder (./ratings.ts).
- * - `brand(id)` / `BRANDS` — sponsor brand names/taglines/personalities (./brands.ts).
- * - `pickCrowdComment(context)` — the tag-matched, weighted crowd-comment pool (./crowdComments.ts).
- * - The tag dimension types (./tags.ts) used to build a `CrowdCommentContext`.
+ * Content vs. logic split:
+ * - copy.ts / ratings.ts / brands.ts / crowdComments.ts / tags.ts are pure
+ *   content — exported literals and types only, no functions. Noah edits
+ *   these; an authoring change never touches code with behavior.
+ * - accessors.ts holds every lookup/picking function.
+ * - interpolate.ts is the small shared `{token}` substitution helper.
+ *
+ * Public surface (everything below is what consumers outside content/ should import):
  */
-import { COPY } from "./copy";
-import { interpolate } from "./interpolate";
-
-export type CopyKey = keyof typeof COPY;
-
-/**
- * Look up a line by key; never throws. A missing key returns a visible
- * `[missing: key]` fallback so a bad reference is obvious without crashing
- * the game. Optional `tokens` interpolate `{name}`-style placeholders.
- */
-export function copy(key: CopyKey | string, tokens?: Record<string, string | number>): string {
-  const template = (COPY as Record<string, string>)[key];
-  if (template === undefined) return `[missing: ${key}]`;
-  return interpolate(template, tokens);
-}
-
-export { COPY };
-export { interpolate };
-export * from "./tags";
-export * from "./ratings";
-export * from "./brands";
-export * from "./crowdComments";
+export { COPY } from "./copy";
+export { RATINGS_LADDER } from "./ratings";
+export type { RatingsTierId } from "./ratings";
+export { BRANDS } from "./brands";
+export type { SponsorBrand, BrandId } from "./brands";
+export { CROWD_COMMENTS } from "./crowdComments";
+export type { CrowdCommentLine } from "./crowdComments";
+export type { CrowdTag } from "./tags";
+export { interpolate } from "./interpolate";
+export {
+  copy,
+  ratingsTierName,
+  ratingsTierRank,
+  ratingsTierForScore,
+  brand,
+  pickCrowdComment,
+} from "./accessors";
+export type { CopyKey, CrowdCommentContext } from "./accessors";

--- a/games/shmup/src/content/interpolate.ts
+++ b/games/shmup/src/content/interpolate.ts
@@ -1,0 +1,16 @@
+/**
+ * Token interpolation — fills `{playerName}`-style placeholders at runtime.
+ * Missing tokens are left as the literal `{token}` text rather than
+ * throwing, matching the "missing key never throws" rule for the rest of
+ * the content layer.
+ */
+export function interpolate(
+  template: string,
+  tokens?: Record<string, string | number>
+): string {
+  if (!tokens) return template;
+  return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = tokens[name];
+    return value === undefined ? match : String(value);
+  });
+}

--- a/games/shmup/src/content/ratings.ts
+++ b/games/shmup/src/content/ratings.ts
@@ -2,28 +2,21 @@
  * Ratings tier ladder (specs/hype-and-ratings.spec.todo.md) — the 90s fame
  * progression Ratings converts into. "The tier name IS the progress bar."
  *
- * This is the single source of truth for tier ids, names, and rank order.
- * Noah edits names/order here; nothing elsewhere hard-codes a tier name.
+ * Pure content: id, display name, and `threshold` — the cumulative Ratings
+ * score needed to reach that tier, which is what gives the ladder its
+ * inherent ordering (not file position). Thresholds here are placeholders;
+ * hype-and-ratings.spec.todo.md calls out the real constants as TBD for the
+ * balance pass. Lookup/accessor logic lives in ./accessors.ts, not here.
  */
 export const RATINGS_LADDER = [
-  { id: "nobody", name: "Nobody" },
-  { id: "has-been", name: "Has-Been" },
-  { id: "cult-following", name: "Cult Following" },
-  { id: "local-legend", name: "Local Legend" },
-  { id: "up-and-comer", name: "Up-and-Comer" },
-  { id: "household-name", name: "Household Name" },
-  { id: "radical", name: "Radical 🤙" },
-  { id: "kevin-bacon", name: "Kevin Bacon" },
+  { id: "nobody", name: "Nobody", threshold: 0 },
+  { id: "has-been", name: "Has-Been", threshold: 100 },
+  { id: "cult-following", name: "Cult Following", threshold: 500 },
+  { id: "local-legend", name: "Local Legend", threshold: 1500 },
+  { id: "up-and-comer", name: "Up-and-Comer", threshold: 4000 },
+  { id: "household-name", name: "Household Name", threshold: 10000 },
+  { id: "radical", name: "Radical 🤙", threshold: 25000 },
+  { id: "kevin-bacon", name: "Kevin Bacon", threshold: 60000 },
 ] as const;
 
 export type RatingsTierId = (typeof RATINGS_LADDER)[number]["id"];
-
-/** Display name for a tier; never throws on an unknown id. */
-export function ratingsTierName(id: RatingsTierId | string): string {
-  return RATINGS_LADDER.find((t) => t.id === id)?.name ?? `[missing tier: ${id}]`;
-}
-
-/** 0-indexed rank in the ladder (low → high); -1 if the id isn't found. */
-export function ratingsTierRank(id: RatingsTierId | string): number {
-  return RATINGS_LADDER.findIndex((t) => t.id === id);
-}

--- a/games/shmup/src/content/ratings.ts
+++ b/games/shmup/src/content/ratings.ts
@@ -1,0 +1,29 @@
+/**
+ * Ratings tier ladder (specs/hype-and-ratings.spec.todo.md) — the 90s fame
+ * progression Ratings converts into. "The tier name IS the progress bar."
+ *
+ * This is the single source of truth for tier ids, names, and rank order.
+ * Noah edits names/order here; nothing elsewhere hard-codes a tier name.
+ */
+export const RATINGS_LADDER = [
+  { id: "nobody", name: "Nobody" },
+  { id: "has-been", name: "Has-Been" },
+  { id: "cult-following", name: "Cult Following" },
+  { id: "local-legend", name: "Local Legend" },
+  { id: "up-and-comer", name: "Up-and-Comer" },
+  { id: "household-name", name: "Household Name" },
+  { id: "radical", name: "Radical 🤙" },
+  { id: "kevin-bacon", name: "Kevin Bacon" },
+] as const;
+
+export type RatingsTierId = (typeof RATINGS_LADDER)[number]["id"];
+
+/** Display name for a tier; never throws on an unknown id. */
+export function ratingsTierName(id: RatingsTierId | string): string {
+  return RATINGS_LADDER.find((t) => t.id === id)?.name ?? `[missing tier: ${id}]`;
+}
+
+/** 0-indexed rank in the ladder (low → high); -1 if the id isn't found. */
+export function ratingsTierRank(id: RatingsTierId | string): number {
+  return RATINGS_LADDER.findIndex((t) => t.id === id);
+}

--- a/games/shmup/src/content/tags.ts
+++ b/games/shmup/src/content/tags.ts
@@ -1,35 +1,50 @@
 /**
- * The tag vocabulary — single typed source of truth (specs/content-and-
- * assets.spec.todo.md, F2 #130). Crowd-comment lines and the contexts that
- * match against them both reference these unions, never raw strings, so a
- * typo is a compile error instead of a silently-dead line.
+ * The crowd-comment tag vocabulary — single typed source of truth
+ * (specs/content-and-assets.spec.todo.md, F2 #130). One flat pool of tags,
+ * not named dimensions: a "context" is just the list of tags that are true
+ * right now, and a line is eligible if every tag it carries is in that
+ * list. Lines and contexts both reference this union, never raw strings,
+ * so a typo is a compile error instead of a silently-dead line.
  *
- * Add a new tag *value* by extending the relevant union below. Add a new
- * tag *dimension* by adding a union here, then a matching optional field on
- * both `CrowdCommentLine` and `CrowdCommentContext` in ./crowdComments.ts.
+ * Add a new tag by adding a value to the union below — nothing else needs
+ * to change. (Numeric facts like a graze streak count aren't tags
+ * themselves; whoever builds the context decides which bucket tags like
+ * `grazeStreak5` apply and includes them.)
  */
 import type { RatingsTierId } from "./ratings";
 
 export type { RatingsTierId };
 
-/** What happened — the event the audience is reacting to. */
-export type CrowdEventTag =
+export type CrowdTag =
+  // what happened
   | "death"
   | "hit"
   | "graze"
   | "clear"
   | "levelStart"
   | "bossIntro"
-  | "scoreGain";
-
-/** Where in the episode it happened. */
-export type StageTimingTag = "early" | "mid" | "late" | "boss";
-
-/** What dealt the damage, for hit/death reactions. */
-export type DamageSourceTag = "contact" | "projectile" | "boss" | "hazard";
-
-/** Career trajectory — current tier vs. the player's peak. */
-export type TrendTag = "rising" | "falling" | "comeback";
-
-/** How big (and how rowdy) the studio audience currently is. */
-export type CrowdSizeTag = "small" | "medium" | "large" | "packed";
+  | "scoreGain"
+  // when in the episode
+  | "earlyGame"
+  | "midGame"
+  | "lateGame"
+  | "bossFight"
+  // what dealt the damage (death/hit reactions)
+  | "damageContact"
+  | "damageProjectile"
+  | "damageBoss"
+  | "damageHazard"
+  // career trajectory
+  | "rising"
+  | "falling"
+  | "comeback"
+  // how big (and rowdy) the studio audience is right now
+  | "smallCrowd"
+  | "mediumCrowd"
+  | "largeCrowd"
+  | "packedCrowd"
+  // graze-streak buckets
+  | "grazeStreak5"
+  | "grazeStreak10"
+  // current Ratings tier — the tier ids double as tags
+  | RatingsTierId;

--- a/games/shmup/src/content/tags.ts
+++ b/games/shmup/src/content/tags.ts
@@ -1,0 +1,35 @@
+/**
+ * The tag vocabulary — single typed source of truth (specs/content-and-
+ * assets.spec.todo.md, F2 #130). Crowd-comment lines and the contexts that
+ * match against them both reference these unions, never raw strings, so a
+ * typo is a compile error instead of a silently-dead line.
+ *
+ * Add a new tag *value* by extending the relevant union below. Add a new
+ * tag *dimension* by adding a union here, then a matching optional field on
+ * both `CrowdCommentLine` and `CrowdCommentContext` in ./crowdComments.ts.
+ */
+import type { RatingsTierId } from "./ratings";
+
+export type { RatingsTierId };
+
+/** What happened — the event the audience is reacting to. */
+export type CrowdEventTag =
+  | "death"
+  | "hit"
+  | "graze"
+  | "clear"
+  | "levelStart"
+  | "bossIntro"
+  | "scoreGain";
+
+/** Where in the episode it happened. */
+export type StageTimingTag = "early" | "mid" | "late" | "boss";
+
+/** What dealt the damage, for hit/death reactions. */
+export type DamageSourceTag = "contact" | "projectile" | "boss" | "hazard";
+
+/** Career trajectory — current tier vs. the player's peak. */
+export type TrendTag = "rising" | "falling" | "comeback";
+
+/** How big (and how rowdy) the studio audience currently is. */
+export type CrowdSizeTag = "small" | "medium" | "large" | "packed";


### PR DESCRIPTION
Implements #130 (F2 — content & copy registry), part of Epic 1 (#126).

## Summary
Builds out `games/shmup/src/content/` from the existing stub into the full "copy is an asset" layer described in `specs/games/shmup/content-and-assets.spec.todo.md`:

- **`copy.ts`** — the flat dotted-key string table (title/intro, season/finale/syndication flavor, event-node text, weapon/item/enemy name+description convention).
- **`ratings.ts`** — the Ratings tier ladder (Nobody → Has-Been → … → Radical 🤙 → Kevin Bacon) as a single ordered source of truth, with `ratingsTierName`/`ratingsTierRank`.
- **`brands.ts`** — sponsor brand registry (name/tagline/personality), per the F9 brand system.
- **`tags.ts`** — the single typed tag vocabulary (event, stage timing, damage source, trend, crowd size) that crowd-comment lines and contexts both reference, so a typo is a compile error.
- **`crowdComments.ts`** — the flagship crowd-comment pool: tag-matching eligibility + weighted pick (more matching tags = higher weight), per the illustrative author format in the issue.
- **`interpolate.ts`** — shared `{token}` interpolation, used by both `copy()` and the crowd-comment picker.
- **`index.ts`** — public barrel; `copy()` now also accepts an optional tokens arg for interpolation.
- **`README.md`** — authoring guide for Noah, covering each file and the weighting rule.

This is pure data + accessors — no gameplay wiring, no changes to `PlayScene`/`main.ts`/Doors. Per the parallel-work split, I did not touch `games/shmup/src/systems/` or `games/shmup/src/tuning/` (owned by #131).

## Test plan
- [x] `npm run build -w @toybox/shmup` passes with no TS errors.
- [x] Root `npm run build` filtered per CLAUDE.md conventions — no new errors.
- [x] Smoke-tested `copy()` fallback/token behavior, `ratingsTierName`/`brand()` missing-id fallback, and `pickCrowdComment` weighting distribution via a throwaway script (confirms specific tags win proportionally to tag count, and generic filler keeps the pool non-empty).
- [x] Existing `BootScene.ts` import of `copy` from `../content` still resolves unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dz2ziEXmtL75FZ3dyD5Mg

---
_Generated by [Claude Code](https://claude.ai/code/session_016dz2ziEXmtL75FZ3dyD5Mg)_