### PR TITLE
[Shmup][F6] Core gameplay loop

### DIFF
--- a/games/shmup/src/config.ts
+++ b/games/shmup/src/config.ts
@@ -1,3 +1,5 @@
 // Base design resolution. Phaser scales to fit the fullscreen container.
-export const GAME_WIDTH = 1280;
-export const GAME_HEIGHT = 720;
+// Portrait (vertical-scroll shmup is a mobile-first genre): FIT mode then
+// fills nearly the whole screen on a phone instead of letterboxing top/bottom.
+export const GAME_WIDTH = 720;
+export const GAME_HEIGHT = 1280;

--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -40,7 +40,7 @@ export const COPY = {
 
   // ---- Core gameplay loop HUD/flow (F6 #134) ----
   "play.score": "SCORE {score}",
-  "play.hint": "Drag/Arrows/WASD to move · Hold Shift or tap-hold to Focus · auto-fire",
+  "play.hint": "Drag/Arrows/WASD to move · Hold Shift to Focus · auto-fire",
   "play.episodeOver.title": "EPISODE OVER",
   "play.episodeOver.score": "Final Score: {score}",
   "play.episodeOver.restartPrompt": "PRESS ANY KEY OR TAP TO TRY AGAIN",

--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -37,4 +37,11 @@ export const COPY = {
   "weapon.placeholder.description": "Standard-issue. Gets the job done.",
   "enemy.placeholder.name": "Drone",
   "enemy.placeholder.description": "Cheap, expendable, everywhere.",
+
+  // ---- Core gameplay loop HUD/flow (F6 #134) ----
+  "play.score": "SCORE {score}",
+  "play.hint": "Drag/Arrows/WASD to move · Hold Shift or tap-hold to Focus · auto-fire",
+  "play.episodeOver.title": "EPISODE OVER",
+  "play.episodeOver.score": "Final Score: {score}",
+  "play.episodeOver.restartPrompt": "PRESS ANY KEY OR TAP TO TRY AGAIN",
 } as const;

--- a/games/shmup/src/content/index.ts
+++ b/games/shmup/src/content/index.ts
@@ -22,6 +22,7 @@ export { RATINGS_LADDER } from "./ratings";
 export type { RatingsTierId } from "./ratings";
 export { BRANDS } from "./brands";
 export type { SponsorBrand, BrandId } from "./brands";
+export { PLACEHOLDER_WEAPON } from "./weapons";
 export { CROWD_COMMENTS } from "./crowdComments";
 export type { CrowdCommentLine } from "./crowdComments";
 export type { CrowdTag } from "./tags";

--- a/games/shmup/src/content/weapons.ts
+++ b/games/shmup/src/content/weapons.ts
@@ -1,0 +1,20 @@
+/**
+ * Placeholder starting weapon — C1 #140 owns the real base-weapon roster.
+ * This is pure data run through the same F4 effect-composition engine as any
+ * future weapon (weapons.spec.todo.md's acceptance reference: "a new weapon
+ * or modifier is purely a data addition"), proving the engine end-to-end for
+ * F6's core loop. Copy comes from the existing "weapon.placeholder.*" keys
+ * in copy.ts, which were already shaped for exactly this id.
+ */
+import { copy } from "./accessors";
+import type { WeaponDef } from "../systems/effects";
+
+export const PLACEHOLDER_WEAPON: WeaponDef = {
+  id: "placeholder",
+  name: copy("weapon.placeholder.name"),
+  firingArc: "forward",
+  targetType: "both",
+  projectileSpeed: 640,
+  scalesWith: ["damage", "attackSpeed", "pierce"],
+  mods: [{ base: { kind: "flat", stat: "damage", amount: 4, source: "placeholder" }, perLevel: 1 }],
+};

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -1,0 +1,152 @@
+import Phaser from "phaser";
+import { MAIN_STAT_IDS, EXOTIC_STAT_IDS, STAT_DEFS, formatStatValue } from "../systems/stats";
+import type { StatId } from "../systems/stats";
+import { TUNING } from "../tuning";
+import type { Player } from "../entities/Player";
+
+const STAT_ORDER: StatId[] = [...MAIN_STAT_IDS, ...EXOTIC_STAT_IDS];
+
+/**
+ * Per-stat nudge increment for the debug overlay (C12 #151's "preview a
+ * build's effective stats without a full run"). These are inspection-tool
+ * step sizes, not gameplay balance numbers — TUNING stays the home for
+ * levers the game itself reads; this is just what makes the overlay usable.
+ */
+const STAT_STEP: Record<StatId, number> = {
+  damage: 0.25,
+  attackSpeed: 0.25,
+  critChance: 0.1,
+  critDamage: 0.1,
+  maxHp: 10,
+  armor: 10,
+  evasion: 0.1,
+  maxShield: 20,
+  hpRegen: 2,
+  lifesteal: 0.1,
+  playerSpeed: 40,
+  reflexes: 0.25,
+  luck: 0.1,
+  creditScore: 0.1,
+  expGain: 0.25,
+  magnetRadius: 20,
+  pierce: 0.25,
+  blastRadius: 20,
+  homingStrength: 0.25,
+};
+
+/**
+ * Expected crit multiplier for *display only* — combat's real per-shot roll
+ * is rollCrit() (systems/combat/resolveHit.ts), which samples one concrete
+ * outcome. This is the closed-form expectation: numCrits = guaranteed +
+ * Bernoulli(frac), so E[(1+CD)^numCrits] = (1+CD)^guaranteed * E[(1+CD)^Bernoulli(frac)]
+ * = (1+CD)^guaranteed * (1 + frac*CD).
+ */
+function expectedCritFactor(critChance: number, critDamage: number): number {
+  const guaranteed = Math.floor(critChance);
+  const frac = critChance - guaranteed;
+  return Math.pow(1 + critDamage, guaranteed) * (1 + frac * critDamage);
+}
+
+/**
+ * C12 #151 ("Debug / balance instrumentation overlay") — a shell sized to
+ * F6's scope: live effective stats, a way to nudge them without a real
+ * level-up/item system to grant them yet, and the resulting weapon behavior
+ * (pierce decay / forks / blast) so a stat's effect is visible immediately
+ * instead of inferred from a balance spreadsheet. The fuller overlay #151
+ * calls for (graze/hype readouts, a real build simulator) is its own job
+ * once those systems (F7+) exist.
+ */
+export class DebugOverlay {
+  private readonly text: Phaser.GameObjects.Text;
+  private readonly toggleKey: Phaser.Input.Keyboard.Key;
+  private readonly prevKey: Phaser.Input.Keyboard.Key;
+  private readonly nextKey: Phaser.Input.Keyboard.Key;
+  private readonly decKey: Phaser.Input.Keyboard.Key;
+  private readonly incKey: Phaser.Input.Keyboard.Key;
+  private readonly resetOneKey: Phaser.Input.Keyboard.Key;
+  private readonly resetAllKey: Phaser.Input.Keyboard.Key;
+
+  private visible = false;
+  private selectedIndex = 0;
+
+  constructor(
+    scene: Phaser.Scene,
+    private readonly player: Player
+  ) {
+    const kb = scene.input.keyboard!;
+    this.toggleKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.BACKTICK);
+    this.prevKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.OPEN_BRACKET);
+    this.nextKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.CLOSED_BRACKET);
+    this.decKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.MINUS);
+    this.incKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.PLUS);
+    this.resetOneKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.ZERO);
+    this.resetAllKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.BACKSPACE);
+
+    this.text = scene.add
+      .text(scene.scale.width - 16, 14, "", {
+        fontFamily: "monospace",
+        fontSize: "12px",
+        color: "#00ff88",
+        backgroundColor: "#000000cc",
+        padding: { x: 8, y: 6 },
+        lineSpacing: 2,
+      })
+      .setOrigin(1, 0)
+      .setDepth(300)
+      .setVisible(false);
+  }
+
+  /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
+  update(): void {
+    if (Phaser.Input.Keyboard.JustDown(this.toggleKey)) {
+      this.visible = !this.visible;
+      this.text.setVisible(this.visible);
+    }
+    if (!this.visible) return;
+
+    const len = STAT_ORDER.length;
+    if (Phaser.Input.Keyboard.JustDown(this.prevKey)) this.selectedIndex = (this.selectedIndex - 1 + len) % len;
+    if (Phaser.Input.Keyboard.JustDown(this.nextKey)) this.selectedIndex = (this.selectedIndex + 1) % len;
+
+    const selected = STAT_ORDER[this.selectedIndex];
+    if (Phaser.Input.Keyboard.JustDown(this.decKey)) this.player.nudgeDebugStat(selected, -STAT_STEP[selected]);
+    if (Phaser.Input.Keyboard.JustDown(this.incKey)) this.player.nudgeDebugStat(selected, STAT_STEP[selected]);
+    if (Phaser.Input.Keyboard.JustDown(this.resetOneKey)) this.player.setDebugMod(selected, 0);
+    if (Phaser.Input.Keyboard.JustDown(this.resetAllKey)) this.player.clearDebugMods();
+
+    this.text.setText(this.render());
+  }
+
+  private render(): string {
+    const stats = this.player.stats;
+    const lines: string[] = ["-- DEBUG (` to close) --", ""];
+
+    STAT_ORDER.forEach((stat, i) => {
+      const def = STAT_DEFS[stat];
+      const cursor = i === this.selectedIndex ? "> " : "  ";
+      const mod = this.player.debugModAmount(stat);
+      const modTag = mod !== 0 ? ` (dbg ${mod > 0 ? "+" : ""}${mod})` : "";
+      lines.push(`${cursor}${def.display.padEnd(14)} ${formatStatValue(def, stats[stat])}${modTag}`);
+    });
+
+    lines.push("");
+    lines.push("[ ] select stat   - = adjust");
+    lines.push("0 reset stat   Backspace reset all");
+    lines.push("");
+    lines.push("-- weapon (placeholder) --");
+
+    const shotsPerSec = TUNING.weapons.baseFireRate * stats.attackSpeed;
+    const avgHit = stats.damage * expectedCritFactor(stats.critChance, stats.critDamage);
+    lines.push(`shots/s: ${shotsPerSec.toFixed(2)}   avg hit: ${avgHit.toFixed(1)}`);
+
+    const behavior = this.player.projectileBehaviors[0];
+    if (behavior) {
+      const fractions = behavior.tailHitFractions.map((f) => f.toFixed(2)).join(", ");
+      lines.push(`pierce line (${behavior.tailHitFractions.length} hits): [${fractions}]`);
+      lines.push(`forked full-dmg lines: ${behavior.flatLineCount}`);
+      lines.push(`blast: radius ${stats.blastRadius.toFixed(0)}px @ ${(behavior.blastDamageFraction * 100).toFixed(0)}%`);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -8,6 +8,18 @@ import { ShakeDetector } from "./ShakeDetector";
 const STAT_ORDER: StatId[] = [...MAIN_STAT_IDS, ...EXOTIC_STAT_IDS];
 
 /**
+ * Sentinel index, one past the last real stat — selects the debug-only
+ * "Firing Angle" row (C12 #151 follow-up). Not a StatId: there's no
+ * balance/upgrade/item source for it, it exists purely to fire the weapon
+ * off-axis for inspecting homing/fork/pierce behavior, so it lives on
+ * `Player.debugFiringAngleDeg` directly rather than in the StatBlock/
+ * debugMods pipeline the rest of this overlay drives.
+ */
+const FIRING_ANGLE_INDEX = STAT_ORDER.length;
+const SELECTABLE_COUNT = STAT_ORDER.length + 1;
+const FIRING_ANGLE_STEP_DEG = 5;
+
+/**
  * Per-stat nudge increment for the debug overlay (C12 #151's "preview a
  * build's effective stats without a full run"). These are inspection-tool
  * step sizes, not gameplay balance numbers — TUNING stays the home for
@@ -207,21 +219,29 @@ export class DebugOverlay {
   }
 
   private selectDelta(dir: number): void {
-    const len = STAT_ORDER.length;
-    this.selectedIndex = (this.selectedIndex + dir + len) % len;
+    this.selectedIndex = (this.selectedIndex + dir + SELECTABLE_COUNT) % SELECTABLE_COUNT;
   }
 
   private adjustSelected(dir: number): void {
+    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
+      this.player.debugFiringAngleDeg += dir * FIRING_ANGLE_STEP_DEG;
+      return;
+    }
     const stat = STAT_ORDER[this.selectedIndex];
     this.player.nudgeDebugStat(stat, dir * STAT_STEP[stat]);
   }
 
   private resetSelected(): void {
+    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
+      this.player.debugFiringAngleDeg = 0;
+      return;
+    }
     this.player.setDebugMod(STAT_ORDER[this.selectedIndex], 0);
   }
 
   private resetAll(): void {
     this.player.clearDebugMods();
+    this.player.debugFiringAngleDeg = 0;
   }
 
   /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
@@ -238,9 +258,13 @@ export class DebugOverlay {
 
     this.listText.setText(this.renderList());
 
-    const selected = STAT_ORDER[this.selectedIndex];
-    const def = STAT_DEFS[selected];
-    this.selectedText.setText(`${def.display}\n${formatStatValue(def, this.player.stats[selected])}`);
+    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
+      this.selectedText.setText(`Firing Angle\n${this.player.debugFiringAngleDeg.toFixed(0)}°`);
+    } else {
+      const selected = STAT_ORDER[this.selectedIndex];
+      const def = STAT_DEFS[selected];
+      this.selectedText.setText(`${def.display}\n${formatStatValue(def, this.player.stats[selected])}`);
+    }
 
     this.infoText.setText(this.renderInfo());
     this.panelBg.setSize(PANEL_WIDTH, this.infoText.y + this.infoText.height + 10 - this.panelBg.y);
@@ -258,6 +282,9 @@ export class DebugOverlay {
       const modTag = roundedMod !== 0 ? ` (dbg ${roundedMod > 0 ? "+" : ""}${roundedMod})` : "";
       lines.push(`${cursor}${def.display.padEnd(14)} ${formatStatValue(def, stats[stat])}${modTag}`);
     });
+
+    const angleCursor = this.selectedIndex === FIRING_ANGLE_INDEX ? "> " : "  ";
+    lines.push(`${angleCursor}${"Firing Angle".padEnd(14)} ${this.player.debugFiringAngleDeg.toFixed(0)}°`);
 
     return lines.join("\n");
   }

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -3,6 +3,7 @@ import { MAIN_STAT_IDS, EXOTIC_STAT_IDS, STAT_DEFS, formatStatValue } from "../s
 import type { StatId } from "../systems/stats";
 import { TUNING } from "../tuning";
 import type { Player } from "../entities/Player";
+import { ShakeDetector } from "./ShakeDetector";
 
 const STAT_ORDER: StatId[] = [...MAIN_STAT_IDS, ...EXOTIC_STAT_IDS];
 
@@ -54,7 +55,9 @@ function expectedCritFactor(critChance: number, critDamage: number): number {
  * (pierce decay / forks / blast) so a stat's effect is visible immediately
  * instead of inferred from a balance spreadsheet. The fuller overlay #151
  * calls for (graze/hype readouts, a real build simulator) is its own job
- * once those systems (F7+) exist.
+ * once those systems (F7+) exist. Toggle is backtick on a keyboard or a
+ * device shake on mobile (see ShakeDetector) — there's no keyboard to press
+ * on a phone, and the stat nudges are still desktop/keyboard-only for now.
  */
 export class DebugOverlay {
   private readonly text: Phaser.GameObjects.Text;
@@ -65,6 +68,7 @@ export class DebugOverlay {
   private readonly incKey: Phaser.Input.Keyboard.Key;
   private readonly resetOneKey: Phaser.Input.Keyboard.Key;
   private readonly resetAllKey: Phaser.Input.Keyboard.Key;
+  private readonly shake: ShakeDetector;
 
   private visible = false;
   private selectedIndex = 0;
@@ -74,6 +78,8 @@ export class DebugOverlay {
     private readonly player: Player
   ) {
     const kb = scene.input.keyboard!;
+    this.shake = new ShakeDetector(() => this.toggleVisible());
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.shake.destroy());
     this.toggleKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.BACKTICK);
     this.prevKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.OPEN_BRACKET);
     this.nextKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.CLOSED_BRACKET);
@@ -96,12 +102,14 @@ export class DebugOverlay {
       .setVisible(false);
   }
 
+  private toggleVisible(): void {
+    this.visible = !this.visible;
+    this.text.setVisible(this.visible);
+  }
+
   /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
   update(): void {
-    if (Phaser.Input.Keyboard.JustDown(this.toggleKey)) {
-      this.visible = !this.visible;
-      this.text.setVisible(this.visible);
-    }
+    if (Phaser.Input.Keyboard.JustDown(this.toggleKey)) this.toggleVisible();
     if (!this.visible) return;
 
     const len = STAT_ORDER.length;
@@ -119,7 +127,7 @@ export class DebugOverlay {
 
   private render(): string {
     const stats = this.player.stats;
-    const lines: string[] = ["-- DEBUG (` to close) --", ""];
+    const lines: string[] = ["-- DEBUG (` or shake to close) --", ""];
 
     STAT_ORDER.forEach((stat, i) => {
       const def = STAT_DEFS[stat];

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -48,6 +48,24 @@ function expectedCritFactor(critChance: number, critDamage: number): number {
   return Math.pow(1 + critDamage, guaranteed) * (1 + frac * critDamage);
 }
 
+// Panel/button geometry, in game-space px. Buttons are sized well above a
+// finger's worth of canvas pixels even after the FIT-mode downscale to a
+// real phone width (see ShakeDetector's mobile-input rationale) — this is
+// the touch-equivalent of the keyboard's bracket/minus/plus/zero/backspace.
+const PANEL_WIDTH = 360;
+const PANEL_MARGIN = 16;
+const ARROW_BTN = 64;
+const ADJUST_BTN_W = 130;
+const ADJUST_BTN_H = 80;
+const RESET_BTN_W = 165;
+const RESET_BTN_H = 56;
+const ROW_GAP = 14;
+
+interface Button {
+  rect: Phaser.GameObjects.Rectangle;
+  label: Phaser.GameObjects.Text;
+}
+
 /**
  * C12 #151 ("Debug / balance instrumentation overlay") — a shell sized to
  * F6's scope: live effective stats, a way to nudge them without a real
@@ -56,11 +74,21 @@ function expectedCritFactor(critChance: number, critDamage: number): number {
  * instead of inferred from a balance spreadsheet. The fuller overlay #151
  * calls for (graze/hype readouts, a real build simulator) is its own job
  * once those systems (F7+) exist. Toggle is backtick on a keyboard or a
- * device shake on mobile (see ShakeDetector) — there's no keyboard to press
- * on a phone, and the stat nudges are still desktop/keyboard-only for now.
+ * device shake on mobile (see ShakeDetector); stat selection/adjustment is
+ * mouse/touch buttons (work with both pointer types) plus keyboard shortcuts
+ * for desktop speed — there's no keyboard on a phone to drive the old
+ * keys-only version.
  */
 export class DebugOverlay {
-  private readonly text: Phaser.GameObjects.Text;
+  private readonly panelLeft: number;
+  private readonly panelRight: number;
+
+  private readonly panelBg: Phaser.GameObjects.Rectangle;
+  private readonly listText: Phaser.GameObjects.Text;
+  private readonly selectedText: Phaser.GameObjects.Text;
+  private readonly infoText: Phaser.GameObjects.Text;
+  private readonly buttons: Button[] = [];
+
   private readonly toggleKey: Phaser.Input.Keyboard.Key;
   private readonly prevKey: Phaser.Input.Keyboard.Key;
   private readonly nextKey: Phaser.Input.Keyboard.Key;
@@ -74,12 +102,13 @@ export class DebugOverlay {
   private selectedIndex = 0;
 
   constructor(
-    scene: Phaser.Scene,
+    private readonly scene: Phaser.Scene,
     private readonly player: Player
   ) {
+    this.panelRight = scene.scale.width - PANEL_MARGIN;
+    this.panelLeft = this.panelRight - PANEL_WIDTH;
+
     const kb = scene.input.keyboard!;
-    this.shake = new ShakeDetector(() => this.toggleVisible());
-    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.shake.destroy());
     this.toggleKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.BACKTICK);
     this.prevKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.OPEN_BRACKET);
     this.nextKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.CLOSED_BRACKET);
@@ -88,12 +117,58 @@ export class DebugOverlay {
     this.resetOneKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.ZERO);
     this.resetAllKey = kb.addKey(Phaser.Input.Keyboard.KeyCodes.BACKSPACE);
 
-    this.text = scene.add
-      .text(scene.scale.width - 16, 14, "", {
+    this.shake = new ShakeDetector(() => this.toggleVisible());
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.shake.destroy());
+
+    this.panelBg = scene.add
+      .rectangle(this.panelLeft, 14, PANEL_WIDTH, 10, 0x000000, 0.85)
+      .setOrigin(0, 0)
+      .setDepth(299)
+      .setVisible(false);
+
+    this.listText = scene.add
+      .text(this.panelRight, 14, "", {
         fontFamily: "monospace",
         fontSize: "12px",
         color: "#00ff88",
-        backgroundColor: "#000000cc",
+        padding: { x: 8, y: 6 },
+        lineSpacing: 2,
+      })
+      .setOrigin(1, 0)
+      .setDepth(300)
+      .setVisible(false);
+    // Line count (header + one per stat) never changes, so this height is
+    // stable — measure it once up front to lay out the controls below it.
+    this.listText.setText(this.renderList());
+    let y = 14 + this.listText.height + ROW_GAP;
+
+    this.addButton(this.panelLeft, y, ARROW_BTN, ARROW_BTN, "<", () => this.selectDelta(-1));
+    this.addButton(this.panelRight - ARROW_BTN, y, ARROW_BTN, ARROW_BTN, ">", () => this.selectDelta(1));
+    this.selectedText = scene.add
+      .text(this.panelLeft + PANEL_WIDTH / 2, y + ARROW_BTN / 2, "", {
+        fontFamily: "monospace",
+        fontSize: "14px",
+        color: "#ffffff",
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setDepth(300)
+      .setVisible(false);
+    y += ARROW_BTN + ROW_GAP;
+
+    this.addButton(this.panelLeft, y, ADJUST_BTN_W, ADJUST_BTN_H, "-", () => this.adjustSelected(-1));
+    this.addButton(this.panelRight - ADJUST_BTN_W, y, ADJUST_BTN_W, ADJUST_BTN_H, "+", () => this.adjustSelected(1));
+    y += ADJUST_BTN_H + ROW_GAP;
+
+    this.addButton(this.panelLeft, y, RESET_BTN_W, RESET_BTN_H, "RESET", () => this.resetSelected());
+    this.addButton(this.panelRight - RESET_BTN_W, y, RESET_BTN_W, RESET_BTN_H, "RESET ALL", () => this.resetAll());
+    y += RESET_BTN_H + ROW_GAP;
+
+    this.infoText = scene.add
+      .text(this.panelRight, y, "", {
+        fontFamily: "monospace",
+        fontSize: "12px",
+        color: "#00ff88",
         padding: { x: 8, y: 6 },
         lineSpacing: 2,
       })
@@ -102,9 +177,51 @@ export class DebugOverlay {
       .setVisible(false);
   }
 
+  private addButton(x: number, y: number, w: number, h: number, label: string, onTap: () => void): void {
+    const rect = this.scene.add
+      .rectangle(x, y, w, h, 0x103322, 0.95)
+      .setStrokeStyle(2, 0x00ff88)
+      .setOrigin(0, 0)
+      .setDepth(300)
+      .setVisible(false)
+      .setInteractive({ useHandCursor: true });
+    rect.on("pointerdown", onTap);
+    const text = this.scene.add
+      .text(x + w / 2, y + h / 2, label, { fontFamily: "monospace", fontSize: "22px", color: "#00ff88" })
+      .setOrigin(0.5)
+      .setDepth(301)
+      .setVisible(false);
+    this.buttons.push({ rect, label: text });
+  }
+
   private toggleVisible(): void {
     this.visible = !this.visible;
-    this.text.setVisible(this.visible);
+    this.panelBg.setVisible(this.visible);
+    this.listText.setVisible(this.visible);
+    this.selectedText.setVisible(this.visible);
+    this.infoText.setVisible(this.visible);
+    for (const b of this.buttons) {
+      b.rect.setVisible(this.visible);
+      b.label.setVisible(this.visible);
+    }
+  }
+
+  private selectDelta(dir: number): void {
+    const len = STAT_ORDER.length;
+    this.selectedIndex = (this.selectedIndex + dir + len) % len;
+  }
+
+  private adjustSelected(dir: number): void {
+    const stat = STAT_ORDER[this.selectedIndex];
+    this.player.nudgeDebugStat(stat, dir * STAT_STEP[stat]);
+  }
+
+  private resetSelected(): void {
+    this.player.setDebugMod(STAT_ORDER[this.selectedIndex], 0);
+  }
+
+  private resetAll(): void {
+    this.player.clearDebugMods();
   }
 
   /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
@@ -112,20 +229,24 @@ export class DebugOverlay {
     if (Phaser.Input.Keyboard.JustDown(this.toggleKey)) this.toggleVisible();
     if (!this.visible) return;
 
-    const len = STAT_ORDER.length;
-    if (Phaser.Input.Keyboard.JustDown(this.prevKey)) this.selectedIndex = (this.selectedIndex - 1 + len) % len;
-    if (Phaser.Input.Keyboard.JustDown(this.nextKey)) this.selectedIndex = (this.selectedIndex + 1) % len;
+    if (Phaser.Input.Keyboard.JustDown(this.prevKey)) this.selectDelta(-1);
+    if (Phaser.Input.Keyboard.JustDown(this.nextKey)) this.selectDelta(1);
+    if (Phaser.Input.Keyboard.JustDown(this.decKey)) this.adjustSelected(-1);
+    if (Phaser.Input.Keyboard.JustDown(this.incKey)) this.adjustSelected(1);
+    if (Phaser.Input.Keyboard.JustDown(this.resetOneKey)) this.resetSelected();
+    if (Phaser.Input.Keyboard.JustDown(this.resetAllKey)) this.resetAll();
+
+    this.listText.setText(this.renderList());
 
     const selected = STAT_ORDER[this.selectedIndex];
-    if (Phaser.Input.Keyboard.JustDown(this.decKey)) this.player.nudgeDebugStat(selected, -STAT_STEP[selected]);
-    if (Phaser.Input.Keyboard.JustDown(this.incKey)) this.player.nudgeDebugStat(selected, STAT_STEP[selected]);
-    if (Phaser.Input.Keyboard.JustDown(this.resetOneKey)) this.player.setDebugMod(selected, 0);
-    if (Phaser.Input.Keyboard.JustDown(this.resetAllKey)) this.player.clearDebugMods();
+    const def = STAT_DEFS[selected];
+    this.selectedText.setText(`${def.display}\n${formatStatValue(def, this.player.stats[selected])}`);
 
-    this.text.setText(this.render());
+    this.infoText.setText(this.renderInfo());
+    this.panelBg.setSize(PANEL_WIDTH, this.infoText.y + this.infoText.height + 10 - this.panelBg.y);
   }
 
-  private render(): string {
+  private renderList(): string {
     const stats = this.player.stats;
     const lines: string[] = ["-- DEBUG (` or shake to close) --", ""];
 
@@ -137,11 +258,12 @@ export class DebugOverlay {
       lines.push(`${cursor}${def.display.padEnd(14)} ${formatStatValue(def, stats[stat])}${modTag}`);
     });
 
-    lines.push("");
-    lines.push("[ ] select stat   - = adjust");
-    lines.push("0 reset stat   Backspace reset all");
-    lines.push("");
-    lines.push("-- weapon (placeholder) --");
+    return lines.join("\n");
+  }
+
+  private renderInfo(): string {
+    const stats = this.player.stats;
+    const lines: string[] = ["-- weapon (placeholder) --"];
 
     const shotsPerSec = TUNING.weapons.baseFireRate * stats.attackSpeed;
     const avgHit = stats.damage * expectedCritFactor(stats.critChance, stats.critDamage);

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -254,7 +254,8 @@ export class DebugOverlay {
       const def = STAT_DEFS[stat];
       const cursor = i === this.selectedIndex ? "> " : "  ";
       const mod = this.player.debugModAmount(stat);
-      const modTag = mod !== 0 ? ` (dbg ${mod > 0 ? "+" : ""}${mod})` : "";
+      const roundedMod = Math.round(mod * 100) / 100;
+      const modTag = roundedMod !== 0 ? ` (dbg ${roundedMod > 0 ? "+" : ""}${roundedMod})` : "";
       lines.push(`${cursor}${def.display.padEnd(14)} ${formatStatValue(def, stats[stat])}${modTag}`);
     });
 
@@ -271,9 +272,7 @@ export class DebugOverlay {
 
     const behavior = this.player.projectileBehaviors[0];
     if (behavior) {
-      const fractions = behavior.tailHitFractions.map((f) => f.toFixed(2)).join(", ");
-      lines.push(`pierce line (${behavior.tailHitFractions.length} hits): [${fractions}]`);
-      lines.push(`forked full-dmg lines: ${behavior.flatLineCount}`);
+      lines.push(`pierce tail hits: ${behavior.tailHitFractions.length}   forked lines: ${behavior.flatLineCount}`);
       lines.push(`blast: radius ${stats.blastRadius.toFixed(0)}px @ ${(behavior.blastDamageFraction * 100).toFixed(0)}%`);
     }
 

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -9,15 +9,17 @@ const STAT_ORDER: StatId[] = [...MAIN_STAT_IDS, ...EXOTIC_STAT_IDS];
 
 /**
  * Sentinel index, one past the last real stat — selects the debug-only
- * "Firing Angle" row (C12 #151 follow-up). Not a StatId: there's no
- * balance/upgrade/item source for it, it exists purely to fire the weapon
- * off-axis for inspecting homing/fork/pierce behavior, so it lives on
- * `Player.debugFiringAngleDeg` directly rather than in the StatBlock/
- * debugMods pipeline the rest of this overlay drives.
+ * "Firing Cone" row (C12 #151 follow-up). Not a StatId: there's no
+ * balance/upgrade/item source for it, it exists purely to spread the
+ * weapon's fire for inspecting homing/fork/pierce behavior off-axis, so it
+ * lives on `Player.debugFiringConeDeg` directly rather than in the
+ * StatBlock/debugMods pipeline the rest of this overlay drives. The value
+ * is the cone's full width — each shot's heading is drawn uniformly from
+ * within ±half of it around straight up, not a fixed offset.
  */
-const FIRING_ANGLE_INDEX = STAT_ORDER.length;
+const FIRING_CONE_INDEX = STAT_ORDER.length;
 const SELECTABLE_COUNT = STAT_ORDER.length + 1;
-const FIRING_ANGLE_STEP_DEG = 5;
+const FIRING_CONE_STEP_DEG = 5;
 
 /**
  * Per-stat nudge increment for the debug overlay (C12 #151's "preview a
@@ -223,8 +225,8 @@ export class DebugOverlay {
   }
 
   private adjustSelected(dir: number): void {
-    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
-      this.player.debugFiringAngleDeg += dir * FIRING_ANGLE_STEP_DEG;
+    if (this.selectedIndex === FIRING_CONE_INDEX) {
+      this.player.debugFiringConeDeg = Math.max(0, this.player.debugFiringConeDeg + dir * FIRING_CONE_STEP_DEG);
       return;
     }
     const stat = STAT_ORDER[this.selectedIndex];
@@ -232,8 +234,8 @@ export class DebugOverlay {
   }
 
   private resetSelected(): void {
-    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
-      this.player.debugFiringAngleDeg = 0;
+    if (this.selectedIndex === FIRING_CONE_INDEX) {
+      this.player.debugFiringConeDeg = 0;
       return;
     }
     this.player.setDebugMod(STAT_ORDER[this.selectedIndex], 0);
@@ -241,7 +243,7 @@ export class DebugOverlay {
 
   private resetAll(): void {
     this.player.clearDebugMods();
-    this.player.debugFiringAngleDeg = 0;
+    this.player.debugFiringConeDeg = 0;
   }
 
   /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
@@ -258,8 +260,8 @@ export class DebugOverlay {
 
     this.listText.setText(this.renderList());
 
-    if (this.selectedIndex === FIRING_ANGLE_INDEX) {
-      this.selectedText.setText(`Firing Angle\n${this.player.debugFiringAngleDeg.toFixed(0)}°`);
+    if (this.selectedIndex === FIRING_CONE_INDEX) {
+      this.selectedText.setText(`Firing Cone\n${this.player.debugFiringConeDeg.toFixed(0)}°`);
     } else {
       const selected = STAT_ORDER[this.selectedIndex];
       const def = STAT_DEFS[selected];
@@ -283,8 +285,8 @@ export class DebugOverlay {
       lines.push(`${cursor}${def.display.padEnd(14)} ${formatStatValue(def, stats[stat])}${modTag}`);
     });
 
-    const angleCursor = this.selectedIndex === FIRING_ANGLE_INDEX ? "> " : "  ";
-    lines.push(`${angleCursor}${"Firing Angle".padEnd(14)} ${this.player.debugFiringAngleDeg.toFixed(0)}°`);
+    const coneCursor = this.selectedIndex === FIRING_CONE_INDEX ? "> " : "  ";
+    lines.push(`${coneCursor}${"Firing Cone".padEnd(14)} ${this.player.debugFiringConeDeg.toFixed(0)}°`);
 
     return lines.join("\n");
   }

--- a/games/shmup/src/debug/DebugOverlay.ts
+++ b/games/shmup/src/debug/DebugOverlay.ts
@@ -18,8 +18,28 @@ const STAT_ORDER: StatId[] = [...MAIN_STAT_IDS, ...EXOTIC_STAT_IDS];
  * within ±half of it around straight up, not a fixed offset.
  */
 const FIRING_CONE_INDEX = STAT_ORDER.length;
-const SELECTABLE_COUNT = STAT_ORDER.length + 1;
+/**
+ * Sentinel index for the debug-only "Fork Cone" row — overrides
+ * `Player.debugForkConeOverrideDeg` (null = defer to the weapon's authored
+ * `forkConeDeg`/`TUNING.weapons.defaultForkConeDeg`). Full width, in degrees,
+ * of the cone a forked line's heading is drawn from around the forking
+ * bullet's own heading at the moment of impact.
+ */
+const FORK_CONE_INDEX = STAT_ORDER.length + 1;
+/**
+ * Sentinel index for the debug-only "Spawn Rate" row — overrides
+ * `Player.debugEnemySpawnIntervalMs` (null = defer to
+ * `TUNING.enemies.drone.spawnIntervalMs`). Lower is faster spawning.
+ */
+const SPAWN_RATE_INDEX = STAT_ORDER.length + 2;
+/** Sentinel index for the debug-only "Hitboxes" toggle row — flips `Player.debugShowHitboxes`, which drives Arcade Physics' built-in per-body debug draw. */
+const HITBOXES_INDEX = STAT_ORDER.length + 3;
+const SELECTABLE_COUNT = STAT_ORDER.length + 4;
 const FIRING_CONE_STEP_DEG = 5;
+const FORK_CONE_STEP_DEG = 5;
+const SPAWN_RATE_STEP_MS = 50;
+// Safety floor so the +/- buttons can't drive the spawn cooldown to (or past) zero.
+const SPAWN_RATE_MIN_MS = 100;
 
 /**
  * Per-stat nudge increment for the debug overlay (C12 #151's "preview a
@@ -199,7 +219,15 @@ export class DebugOverlay {
       .setDepth(300)
       .setVisible(false)
       .setInteractive({ useHandCursor: true });
-    rect.on("pointerdown", onTap);
+    // Without this, the tap also bubbles to PlayScene's scene-level
+    // "pointerdown" handler and starts dragging the ship toward the button.
+    rect.on(
+      "pointerdown",
+      (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: Phaser.Types.Input.EventData) => {
+        event.stopPropagation();
+        onTap();
+      }
+    );
     const text = this.scene.add
       .text(x + w / 2, y + h / 2, label, { fontFamily: "monospace", fontSize: "22px", color: "#00ff88" })
       .setOrigin(0.5)
@@ -229,6 +257,20 @@ export class DebugOverlay {
       this.player.debugFiringConeDeg = Math.max(0, this.player.debugFiringConeDeg + dir * FIRING_CONE_STEP_DEG);
       return;
     }
+    if (this.selectedIndex === FORK_CONE_INDEX) {
+      const current = this.player.effectiveForkConeDeg;
+      this.player.debugForkConeOverrideDeg = Math.max(0, current + dir * FORK_CONE_STEP_DEG);
+      return;
+    }
+    if (this.selectedIndex === SPAWN_RATE_INDEX) {
+      const current = this.player.effectiveEnemySpawnIntervalMs;
+      this.player.debugEnemySpawnIntervalMs = Math.max(SPAWN_RATE_MIN_MS, current + dir * SPAWN_RATE_STEP_MS);
+      return;
+    }
+    if (this.selectedIndex === HITBOXES_INDEX) {
+      this.player.debugShowHitboxes = !this.player.debugShowHitboxes;
+      return;
+    }
     const stat = STAT_ORDER[this.selectedIndex];
     this.player.nudgeDebugStat(stat, dir * STAT_STEP[stat]);
   }
@@ -238,12 +280,27 @@ export class DebugOverlay {
       this.player.debugFiringConeDeg = 0;
       return;
     }
+    if (this.selectedIndex === FORK_CONE_INDEX) {
+      this.player.debugForkConeOverrideDeg = null;
+      return;
+    }
+    if (this.selectedIndex === SPAWN_RATE_INDEX) {
+      this.player.debugEnemySpawnIntervalMs = null;
+      return;
+    }
+    if (this.selectedIndex === HITBOXES_INDEX) {
+      this.player.debugShowHitboxes = false;
+      return;
+    }
     this.player.setDebugMod(STAT_ORDER[this.selectedIndex], 0);
   }
 
   private resetAll(): void {
     this.player.clearDebugMods();
     this.player.debugFiringConeDeg = 0;
+    this.player.debugForkConeOverrideDeg = null;
+    this.player.debugEnemySpawnIntervalMs = null;
+    this.player.debugShowHitboxes = false;
   }
 
   /** Call once per frame regardless of game-over state — inspecting/nudging stats shouldn't require an active run. */
@@ -262,6 +319,12 @@ export class DebugOverlay {
 
     if (this.selectedIndex === FIRING_CONE_INDEX) {
       this.selectedText.setText(`Firing Cone\n${this.player.debugFiringConeDeg.toFixed(0)}°`);
+    } else if (this.selectedIndex === FORK_CONE_INDEX) {
+      this.selectedText.setText(`Fork Cone\n${this.player.effectiveForkConeDeg.toFixed(0)}°`);
+    } else if (this.selectedIndex === SPAWN_RATE_INDEX) {
+      this.selectedText.setText(`Spawn Rate\n${this.player.effectiveEnemySpawnIntervalMs.toFixed(0)}ms`);
+    } else if (this.selectedIndex === HITBOXES_INDEX) {
+      this.selectedText.setText(`Hitboxes\n${this.player.debugShowHitboxes ? "ON" : "OFF"}`);
     } else {
       const selected = STAT_ORDER[this.selectedIndex];
       const def = STAT_DEFS[selected];
@@ -287,6 +350,15 @@ export class DebugOverlay {
 
     const coneCursor = this.selectedIndex === FIRING_CONE_INDEX ? "> " : "  ";
     lines.push(`${coneCursor}${"Firing Cone".padEnd(14)} ${this.player.debugFiringConeDeg.toFixed(0)}°`);
+
+    const forkConeCursor = this.selectedIndex === FORK_CONE_INDEX ? "> " : "  ";
+    lines.push(`${forkConeCursor}${"Fork Cone".padEnd(14)} ${this.player.effectiveForkConeDeg.toFixed(0)}°`);
+
+    const spawnRateCursor = this.selectedIndex === SPAWN_RATE_INDEX ? "> " : "  ";
+    lines.push(`${spawnRateCursor}${"Spawn Rate".padEnd(14)} ${this.player.effectiveEnemySpawnIntervalMs.toFixed(0)}ms`);
+
+    const hitboxesCursor = this.selectedIndex === HITBOXES_INDEX ? "> " : "  ";
+    lines.push(`${hitboxesCursor}${"Hitboxes".padEnd(14)} ${this.player.debugShowHitboxes ? "ON" : "OFF"}`);
 
     return lines.join("\n");
   }

--- a/games/shmup/src/debug/ShakeDetector.ts
+++ b/games/shmup/src/debug/ShakeDetector.ts
@@ -1,0 +1,51 @@
+// Magnitude-delta shake detection (accelerationIncludingGravity, frame-to-frame
+// jolt) with a cooldown so one physical shake fires exactly one callback, not
+// a burst. Mobile's stand-in for the debug overlay's backtick key (C12 #151) —
+// there's no keyboard to press on a phone.
+const SHAKE_DELTA_THRESHOLD = 18; // m/s^2 of combined-axis jolt between readings
+const SHAKE_COOLDOWN_MS = 1000;
+
+export class ShakeDetector {
+  private lastX = 0;
+  private lastY = 0;
+  private lastZ = 0;
+  private lastShakeAt = 0;
+  private readonly handler = (e: DeviceMotionEvent) => this.onMotion(e);
+
+  constructor(private readonly onShake: () => void) {
+    window.addEventListener("devicemotion", this.handler);
+  }
+
+  private onMotion(e: DeviceMotionEvent): void {
+    const acc = e.accelerationIncludingGravity;
+    if (!acc || acc.x === null || acc.y === null || acc.z === null) return;
+
+    const delta = Math.abs(acc.x - this.lastX) + Math.abs(acc.y - this.lastY) + Math.abs(acc.z - this.lastZ);
+    this.lastX = acc.x;
+    this.lastY = acc.y;
+    this.lastZ = acc.z;
+
+    const now = Date.now();
+    if (delta > SHAKE_DELTA_THRESHOLD && now - this.lastShakeAt > SHAKE_COOLDOWN_MS) {
+      this.lastShakeAt = now;
+      this.onShake();
+    }
+  }
+
+  destroy(): void {
+    window.removeEventListener("devicemotion", this.handler);
+  }
+}
+
+/**
+ * iOS 13+ gates `devicemotion` behind a permission prompt that only resolves
+ * when requested from inside a user-gesture handler — call this directly from
+ * a tap/click handler, not after an async hop. No-op (and no prompt) on
+ * browsers without the gate (Android, desktop), so it's safe to call always.
+ */
+export async function requestMotionPermission(): Promise<void> {
+  const ctor = DeviceMotionEvent as unknown as { requestPermission?: () => Promise<"granted" | "denied"> };
+  if (typeof ctor.requestPermission === "function") {
+    await ctor.requestPermission().catch(() => {});
+  }
+}

--- a/games/shmup/src/entities/Enemy.ts
+++ b/games/shmup/src/entities/Enemy.ts
@@ -10,8 +10,12 @@ import type { ShmupPlayScene } from "./types";
  * armor/evasion/shield — enemies don't have an F3 stat pool yet.
  */
 export class Enemy extends Phaser.Physics.Arcade.Sprite {
+  private static nextSpawnId = 1;
+
   hp = 0;
   scoreValue = 0;
+  /** Identifies this enemy's current life, not the pooled object — bullets must track hits by this, not by object reference, since the underlying sprite is reused across spawns (Group.get() recycling). */
+  spawnId = 0;
   private fireCooldownMs = 0;
 
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
@@ -23,6 +27,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     this.hp = d.maxHp;
     this.scoreValue = d.scoreValue;
     this.fireCooldownMs = d.fireIntervalMs;
+    this.spawnId = Enemy.nextSpawnId++;
     this.setPosition(x, y);
     this.setActive(true);
     this.setVisible(true);

--- a/games/shmup/src/entities/Enemy.ts
+++ b/games/shmup/src/entities/Enemy.ts
@@ -29,6 +29,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.enable = true;
     body.setVelocity(0, this.moveSpeed());
+    body.debugBodyColor = TUNING.debug.hitboxColors.enemy;
+    body.debugShowVelocity = false;
   }
 
   recycle(): void {

--- a/games/shmup/src/entities/Enemy.ts
+++ b/games/shmup/src/entities/Enemy.ts
@@ -1,0 +1,64 @@
+import Phaser from "phaser";
+import { TUNING } from "../tuning";
+import { GAME_HEIGHT } from "../config";
+import { reflexMoveSpeedMult } from "../systems/combat";
+import type { ShmupPlayScene } from "./types";
+
+/**
+ * Pooled placeholder "drone" enemy (run-structure.spec.todo.md's Difficulty
+ * (D) scaling owns real enemy stat curves — F8 #136). Flat HP only, no
+ * armor/evasion/shield — enemies don't have an F3 stat pool yet.
+ */
+export class Enemy extends Phaser.Physics.Arcade.Sprite {
+  hp = 0;
+  scoreValue = 0;
+  private fireCooldownMs = 0;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
+    super(scene, x, y, texture);
+  }
+
+  spawn(x: number, y: number): void {
+    const d = TUNING.enemies.drone;
+    this.hp = d.maxHp;
+    this.scoreValue = d.scoreValue;
+    this.fireCooldownMs = d.fireIntervalMs;
+    this.setPosition(x, y);
+    this.setActive(true);
+    this.setVisible(true);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.enable = true;
+    body.setVelocity(0, this.moveSpeed());
+  }
+
+  recycle(): void {
+    this.setActive(false);
+    this.setVisible(false);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.stop();
+    body.enable = false;
+  }
+
+  /** True if this drone's fire cooldown elapsed this frame (and resets it). */
+  tryFire(dtMs: number): boolean {
+    this.fireCooldownMs -= dtMs;
+    if (this.fireCooldownMs <= 0) {
+      this.fireCooldownMs += TUNING.enemies.drone.fireIntervalMs;
+      return true;
+    }
+    return false;
+  }
+
+  private moveSpeed(): number {
+    const reflexes = (this.scene as ShmupPlayScene).player?.stats.reflexes ?? 0;
+    return TUNING.enemies.drone.speed * reflexMoveSpeedMult(reflexes);
+  }
+
+  preUpdate(time: number, delta: number): void {
+    super.preUpdate(time, delta);
+    if (!this.active) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setVelocityY(this.moveSpeed());
+    if (this.y > GAME_HEIGHT + 48) this.recycle();
+  }
+}

--- a/games/shmup/src/entities/EnemyBullet.ts
+++ b/games/shmup/src/entities/EnemyBullet.ts
@@ -1,0 +1,38 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+
+/** Pooled enemy bullet — fixed damage, no pierce/blast (those are player-weapon-only mechanics). */
+export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
+  damage = 0;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
+    super(scene, x, y, texture);
+  }
+
+  fire(x: number, y: number, vx: number, vy: number, damage: number): void {
+    this.damage = damage;
+    this.setPosition(x, y);
+    this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
+    this.setActive(true);
+    this.setVisible(true);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.enable = true;
+    body.setVelocity(vx, vy);
+  }
+
+  recycle(): void {
+    this.setActive(false);
+    this.setVisible(false);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.stop();
+    body.enable = false;
+  }
+
+  preUpdate(time: number, delta: number): void {
+    super.preUpdate(time, delta);
+    if (!this.active) return;
+    if (this.y < -32 || this.y > GAME_HEIGHT + 32 || this.x < -32 || this.x > GAME_WIDTH + 32) {
+      this.recycle();
+    }
+  }
+}

--- a/games/shmup/src/entities/EnemyBullet.ts
+++ b/games/shmup/src/entities/EnemyBullet.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { TUNING } from "../tuning";
 
 /** Pooled enemy bullet — fixed damage, no pierce/blast (those are player-weapon-only mechanics). */
 export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
@@ -18,6 +19,8 @@ export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.enable = true;
     body.setVelocity(vx, vy);
+    body.debugBodyColor = TUNING.debug.hitboxColors.enemyBullet;
+    body.debugShowVelocity = false;
   }
 
   recycle(): void {

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -2,7 +2,7 @@ import Phaser from "phaser";
 import { TUNING } from "../tuning";
 import { resolveLoadout } from "../systems/effects";
 import type { OwnedWeapon, ProjectileBehavior } from "../systems/effects";
-import type { StatBlock } from "../systems/stats";
+import type { StatBlock, StatId, StatModifier } from "../systems/stats";
 import type { Defender } from "../systems/combat";
 import { PLACEHOLDER_WEAPON } from "../content";
 
@@ -28,6 +28,10 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   focus = false;
   iFrameRemainingMs = 0;
   private fireCooldownMs: number[] = [];
+  // Transient mods from the debug overlay (C12 #151) — a stand-in for the
+  // real level-up/item mod sources that don't exist yet. Keyed by stat so
+  // the overlay can replace one stat's nudge without touching the others.
+  private debugMods = new Map<StatId, StatModifier>();
 
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
     super(scene, x, y, texture);
@@ -40,6 +44,39 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     this.defender = { hp: stats.maxHp, shield: stats.maxShield, shieldRegenDelayRemaining: 0 };
     this.fireCooldownMs = this.weapons.map(() => 0);
     this.applyHitboxRadius();
+  }
+
+  /** Nudges a stat by `delta` via a debug-sourced flat modifier; re-resolves the whole loadout so the change is visible immediately. */
+  nudgeDebugStat(stat: StatId, delta: number): void {
+    const current = this.debugMods.get(stat)?.amount ?? 0;
+    this.setDebugMod(stat, current + delta);
+  }
+
+  setDebugMod(stat: StatId, amount: number): void {
+    if (amount === 0) {
+      this.debugMods.delete(stat);
+    } else {
+      this.debugMods.set(stat, { kind: "flat", stat, amount, source: "debug" });
+    }
+    this.recompute();
+  }
+
+  clearDebugMods(): void {
+    this.debugMods.clear();
+    this.recompute();
+  }
+
+  debugModAmount(stat: StatId): number {
+    return this.debugMods.get(stat)?.amount ?? 0;
+  }
+
+  private recompute(): void {
+    const { stats, projectileBehaviors } = resolveLoadout({
+      weapons: this.weapons,
+      transientMods: [...this.debugMods.values()],
+    });
+    this.stats = stats;
+    this.projectileBehaviors = projectileBehaviors;
   }
 
   private applyHitboxRadius(): void {

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -29,6 +29,12 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   iFrameRemainingMs = 0;
   /** Debug-only (C12 #151): full width, in degrees, of a random cone around straight-up that each shot's heading is drawn from (0 = always straight up). Not a real StatId — there's no balance/upgrade source for it, it exists purely so the debug overlay can spread fire to inspect homing/fork/pierce behavior off-axis. */
   debugFiringConeDeg = 0;
+  /** Debug-only override (C12 #151 follow-up) for fork-cone width; null means "use the weapon's authored/default value" (see `effectiveForkConeDeg`). */
+  debugForkConeOverrideDeg: number | null = null;
+  /** Debug-only override (C12 #151 follow-up) for the enemy spawn interval (ms); null means "use TUNING.enemies.drone.spawnIntervalMs" (see `effectiveEnemySpawnIntervalMs`). */
+  debugEnemySpawnIntervalMs: number | null = null;
+  /** Debug-only (C12 #151 follow-up): renders collision hitbox outlines for player/enemies/projectiles when true. */
+  debugShowHitboxes = false;
   private fireCooldownMs: number[] = [];
   // Transient mods from the debug overlay (C12 #151) — a stand-in for the
   // real level-up/item mod sources that don't exist yet. Keyed by stat so
@@ -46,6 +52,24 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     this.defender = { hp: stats.maxHp, shield: stats.maxShield, shieldRegenDelayRemaining: 0 };
     this.fireCooldownMs = this.weapons.map(() => 0);
     this.applyHitboxRadius();
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.debugBodyColor = TUNING.debug.hitboxColors.player;
+    body.debugShowVelocity = false;
+  }
+
+  /** This player's first weapon's authored fork-cone width, or the tuning default if unset — the "real" production value before any debug override. */
+  get baseForkConeDeg(): number {
+    return this.weapons[0]?.weapon.forkConeDeg ?? TUNING.weapons.defaultForkConeDeg;
+  }
+
+  /** Effective fork-cone width: the debug override when set, else the production value above. */
+  get effectiveForkConeDeg(): number {
+    return this.debugForkConeOverrideDeg ?? this.baseForkConeDeg;
+  }
+
+  /** Effective enemy spawn interval (ms): the debug override when set, else TUNING's default. */
+  get effectiveEnemySpawnIntervalMs(): number {
+    return this.debugEnemySpawnIntervalMs ?? TUNING.enemies.drone.spawnIntervalMs;
   }
 
   /** Nudges a stat by `delta` via a debug-sourced flat modifier; re-resolves the whole loadout so the change is visible immediately. */

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -27,6 +27,8 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   defender: Defender;
   focus = false;
   iFrameRemainingMs = 0;
+  /** Debug-only (C12 #151): degrees added to the main weapon line's straight-up heading. Not a real StatId — there's no balance/upgrade source for it, it exists purely so the debug overlay can fire at an angle to inspect homing/fork/pierce behavior off-axis. */
+  debugFiringAngleDeg = 0;
   private fireCooldownMs: number[] = [];
   // Transient mods from the debug overlay (C12 #151) — a stand-in for the
   // real level-up/item mod sources that don't exist yet. Keyed by stat so

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -27,8 +27,8 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   defender: Defender;
   focus = false;
   iFrameRemainingMs = 0;
-  /** Debug-only (C12 #151): degrees added to the main weapon line's straight-up heading. Not a real StatId — there's no balance/upgrade source for it, it exists purely so the debug overlay can fire at an angle to inspect homing/fork/pierce behavior off-axis. */
-  debugFiringAngleDeg = 0;
+  /** Debug-only (C12 #151): full width, in degrees, of a random cone around straight-up that each shot's heading is drawn from (0 = always straight up). Not a real StatId — there's no balance/upgrade source for it, it exists purely so the debug overlay can spread fire to inspect homing/fork/pierce behavior off-axis. */
+  debugFiringConeDeg = 0;
   private fireCooldownMs: number[] = [];
   // Transient mods from the debug overlay (C12 #151) — a stand-in for the
   // real level-up/item mod sources that don't exist yet. Keyed by stat so

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -1,0 +1,93 @@
+import Phaser from "phaser";
+import { TUNING } from "../tuning";
+import { resolveLoadout } from "../systems/effects";
+import type { OwnedWeapon, ProjectileBehavior } from "../systems/effects";
+import type { StatBlock } from "../systems/stats";
+import type { Defender } from "../systems/combat";
+import { PLACEHOLDER_WEAPON } from "../content";
+
+/** One weapon ready to fire this frame, with everything its shot needs already resolved. */
+export interface PlayerFireRequest {
+  weaponIndex: number;
+  projectileSpeed: number;
+  behavior: ProjectileBehavior;
+}
+
+/**
+ * Single starting weapon for F6's vertical slice (C1 #140 owns the real
+ * base-weapon roster). `Player.weapons` is an array so a future roster is
+ * purely a data addition, per weapons.spec.todo.md's acceptance reference.
+ */
+const STARTING_WEAPONS: OwnedWeapon[] = [{ weapon: PLACEHOLDER_WEAPON, tier: 0 }];
+
+export class Player extends Phaser.Physics.Arcade.Sprite {
+  stats: StatBlock;
+  weapons: OwnedWeapon[] = STARTING_WEAPONS;
+  projectileBehaviors: ProjectileBehavior[] = [];
+  defender: Defender;
+  focus = false;
+  iFrameRemainingMs = 0;
+  private fireCooldownMs: number[] = [];
+
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
+    super(scene, x, y, texture);
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+
+    const { stats, projectileBehaviors } = resolveLoadout({ weapons: this.weapons });
+    this.stats = stats;
+    this.projectileBehaviors = projectileBehaviors;
+    this.defender = { hp: stats.maxHp, shield: stats.maxShield, shieldRegenDelayRemaining: 0 };
+    this.fireCooldownMs = this.weapons.map(() => 0);
+    this.applyHitboxRadius();
+  }
+
+  private applyHitboxRadius(): void {
+    const r = this.focus ? TUNING.combat.hitboxRadiusFocus : TUNING.combat.hitboxRadiusNormal;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setCircle(r, this.width / 2 - r, this.height / 2 - r);
+  }
+
+  setFocus(focus: boolean): void {
+    if (this.focus === focus) return;
+    this.focus = focus;
+    this.applyHitboxRadius();
+  }
+
+  /** Movement speed for this frame, in px/s — Focus is movement-slow-only per chassis.spec.todo.md. */
+  currentSpeed(): number {
+    return this.stats.playerSpeed * (this.focus ? TUNING.combat.focusSpeedMult : 1);
+  }
+
+  get invulnerable(): boolean {
+    return this.iFrameRemainingMs > 0;
+  }
+
+  triggerIFrame(): void {
+    this.iFrameRemainingMs = TUNING.combat.playerIFrameMs;
+  }
+
+  tickIFrame(dtMs: number): void {
+    if (this.iFrameRemainingMs > 0) {
+      this.iFrameRemainingMs = Math.max(0, this.iFrameRemainingMs - dtMs);
+    }
+  }
+
+  /** Decrements every weapon's cooldown; returns fire requests for whichever weapons came ready this frame. */
+  tryFire(dtMs: number): PlayerFireRequest[] {
+    const requests: PlayerFireRequest[] = [];
+    const cadenceMs = 1000 / (TUNING.weapons.baseFireRate * this.stats.attackSpeed);
+    this.weapons.forEach((owned, i) => {
+      this.fireCooldownMs[i] -= dtMs;
+      if (this.fireCooldownMs[i] <= 0) {
+        this.fireCooldownMs[i] += cadenceMs;
+        requests.push({
+          weaponIndex: i,
+          projectileSpeed: owned.weapon.projectileSpeed,
+          behavior: this.projectileBehaviors[i],
+        });
+      }
+    });
+    return requests;
+  }
+}

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -39,6 +39,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   blastDamageFraction = 0;
   /** Speed to give any forks spawned from this line's first impact (the firing weapon's projectileSpeed). Unused on forked bullets themselves — they don't re-fork. */
   forkProjectileSpeed = 0;
+  /** Cone width (degrees) any forks spawned from this line's first impact should spread their heading within, centered on this bullet's heading at that impact. Unused on forked bullets themselves — they don't re-fork. */
+  forkConeDeg = 0;
   private fractions: number[] = [];
   private fractionIndex = 0;
   private infinite = false;
@@ -67,7 +69,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     blastDamageFraction: number,
     homingStrength: number,
     forkCount: number,
-    forkProjectileSpeed: number
+    forkProjectileSpeed: number,
+    forkConeDeg: number
   ): void {
     this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = false;
@@ -75,6 +78,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     this.fractionIndex = 0;
     this.pendingForkCount = forkCount;
     this.forkProjectileSpeed = forkProjectileSpeed;
+    this.forkConeDeg = forkConeDeg;
   }
 
   fireForkedLine(
@@ -117,6 +121,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     this.hitSet.clear();
     this.pendingForkCount = 0;
     this.forkProjectileSpeed = 0;
+    this.forkConeDeg = 0;
     this.setPosition(x, y);
     this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
     this.setActive(true);
@@ -124,6 +129,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.enable = true;
     body.setVelocity(vx, vy);
+    body.debugBodyColor = TUNING.debug.hitboxColors.playerBullet;
+    body.debugShowVelocity = false;
   }
 
   /** True once this bullet has already damaged `enemy` — it should pass through without re-hitting it. */
@@ -230,7 +237,9 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     let best: Enemy | null = null;
     let bestDist = Infinity;
     for (const enemy of (this.scene as ShmupPlayScene).enemies.getChildren() as Enemy[]) {
-      if (!enemy.active) continue;
+      // Can't hit it again (it's already in this bullet's hit-list, same as
+      // collision exclusion), so it shouldn't be seekable either.
+      if (!enemy.active || this.hitSet.has(enemy)) continue;
       const dist = Phaser.Math.Distance.Between(centerX, centerY, enemy.x, enemy.y);
       if (dist <= radius && dist < bestDist) {
         best = enemy;

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -12,6 +12,14 @@ import type { ShmupPlayScene } from "./types";
  *   capped by `TUNING.weapons.maxHitsPerInfiniteBullet` rather than decaying
  *   (weapons.spec.todo.md's fork-overflow behavior).
  *
+ * Forks aren't spawned at the muzzle — weapons.spec.todo.md's "forked
+ * projectiles inherit the firing projectile's hit-list" only makes sense if
+ * a fork is born from an impact the line has already scored. A `fireLine`
+ * bullet carries `pendingForkCount` (the shot's whole fork allotment) and
+ * hands it to the scene via `takePendingForks()` on its first registered
+ * hit; the scene spawns that many `fireForkedLine` bullets from that impact
+ * point, each pre-seeded with the just-hit enemy so they can't re-hit it.
+ *
  * `baseHit` is the already-crit-resolved damage for this shot (crit is
  * rolled once per shot fired, never re-rolled per pierce impact/fork —
  * combat.spec.todo.md). Blast radius is a real spatial query the scene runs
@@ -29,6 +37,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   numCrits = 0;
   blastRadius = 0;
   blastDamageFraction = 0;
+  /** Speed to give any forks spawned from this line's first impact (the firing weapon's projectileSpeed). Unused on forked bullets themselves — they don't re-fork. */
+  forkProjectileSpeed = 0;
   private fractions: number[] = [];
   private fractionIndex = 0;
   private infinite = false;
@@ -38,6 +48,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   private baseHomingStrength = 0;
   private homingStrength = 0;
   private lockedTarget: Enemy | null = null;
+  /** This line's whole fork allotment, drained once (by `takePendingForks`) on the first hit it registers. Always 0 on a forked ("infinite") bullet — forks don't re-fork. */
+  private pendingForkCount = 0;
 
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
     super(scene, x, y, texture);
@@ -53,12 +65,16 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     fractions: number[],
     blastRadius: number,
     blastDamageFraction: number,
-    homingStrength: number
+    homingStrength: number,
+    forkCount: number,
+    forkProjectileSpeed: number
   ): void {
     this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = false;
     this.fractions = fractions;
     this.fractionIndex = 0;
+    this.pendingForkCount = forkCount;
+    this.forkProjectileSpeed = forkProjectileSpeed;
   }
 
   fireForkedLine(
@@ -71,11 +87,13 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     hitsAllowed: number,
     blastRadius: number,
     blastDamageFraction: number,
-    homingStrength: number
+    homingStrength: number,
+    inheritedHit?: Enemy
   ): void {
     this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = true;
     this.hitsRemaining = hitsAllowed;
+    if (inheritedHit) this.hitSet.add(inheritedHit);
   }
 
   private reset(
@@ -97,6 +115,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     this.homingStrength = homingStrength;
     this.lockedTarget = null;
     this.hitSet.clear();
+    this.pendingForkCount = 0;
+    this.forkProjectileSpeed = 0;
     this.setPosition(x, y);
     this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
     this.setActive(true);
@@ -109,6 +129,18 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   /** True once this bullet has already damaged `enemy` — it should pass through without re-hitting it. */
   hasHit(enemy: Enemy): boolean {
     return this.hitSet.has(enemy);
+  }
+
+  /** This shot's original Homing Strength, undecayed — what a fork spawned off this line should carry, since forked "infinite" lines never decay homing (same as they never decay damage). */
+  get shotHomingStrength(): number {
+    return this.baseHomingStrength;
+  }
+
+  /** Drains and returns this line's fork allotment — non-zero only the first time it's called, since `pendingForkCount` is only ever set on a fresh `fireLine`. The scene calls this after a successful `registerHit` to spawn forks from that impact. */
+  takePendingForks(): number {
+    const n = this.pendingForkCount;
+    this.pendingForkCount = 0;
+    return n;
   }
 
   /**

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -14,11 +14,16 @@ import type { ShmupPlayScene } from "./types";
  *
  * Forks aren't spawned at the muzzle — weapons.spec.todo.md's "forked
  * projectiles inherit the firing projectile's hit-list" only makes sense if
- * a fork is born from an impact the line has already scored. A `fireLine`
- * bullet carries `pendingForkCount` (the shot's whole fork allotment) and
+ * a fork is born from an impact the line has already scored. Either kind of
+ * bullet carries `pendingForkCount` (how many more chain links remain) and
  * hands it to the scene via `takePendingForks()` on its first registered
- * hit; the scene spawns that many `fireForkedLine` bullets from that impact
- * point, each pre-seeded with the just-hit enemy so they can't re-hit it.
+ * hit; the scene spawns exactly one `fireForkedLine` bullet from that impact
+ * point, pre-seeded with the just-hit enemy so it can't re-hit it, and
+ * carrying `pendingForkCount - 1` so the chain keeps recursing as long as
+ * each new fork keeps landing impacts of its own (weapons.spec.todo.md: "That
+ * forked projectile resolves the same rule recursively"). A chain link that
+ * never lands a hit ends the chain early — pierce above 100% only describes
+ * the *maximum* chain depth, not a guaranteed simultaneous spawn count.
  *
  * `baseHit` is the already-crit-resolved damage for this shot (crit is
  * rolled once per shot fired, never re-rolled per pierce impact/fork —
@@ -37,9 +42,9 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   numCrits = 0;
   blastRadius = 0;
   blastDamageFraction = 0;
-  /** Speed to give any forks spawned from this line's first impact (the firing weapon's projectileSpeed). Unused on forked bullets themselves — they don't re-fork. */
+  /** Speed to give any fork spawned from this line's first impact (the firing weapon's projectileSpeed) — carried forward to each chain link so the whole chain shares one projectile speed. */
   forkProjectileSpeed = 0;
-  /** Cone width (degrees) any forks spawned from this line's first impact should spread their heading within, centered on this bullet's heading at that impact. Unused on forked bullets themselves — they don't re-fork. */
+  /** Cone width (degrees) any fork spawned from this line's first impact should spread its heading within, centered on this bullet's heading at that impact — carried forward to each chain link. */
   forkConeDeg = 0;
   private fractions: number[] = [];
   private fractionIndex = 0;
@@ -50,7 +55,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   private baseHomingStrength = 0;
   private homingStrength = 0;
   private lockedTarget: Enemy | null = null;
-  /** This line's whole fork allotment, drained once (by `takePendingForks`) on the first hit it registers. Always 0 on a forked ("infinite") bullet — forks don't re-fork. */
+  /** How many more chain links remain after this one, drained once (by `takePendingForks`) on the first hit this bullet registers. Set on both `fireLine` and `fireForkedLine` so the fork chain can keep recursing across generations. */
   private pendingForkCount = 0;
 
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
@@ -92,11 +97,17 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     blastRadius: number,
     blastDamageFraction: number,
     homingStrength: number,
+    forkCount: number,
+    forkProjectileSpeed: number,
+    forkConeDeg: number,
     inheritedHit?: Enemy
   ): void {
     this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = true;
     this.hitsRemaining = hitsAllowed;
+    this.pendingForkCount = forkCount;
+    this.forkProjectileSpeed = forkProjectileSpeed;
+    this.forkConeDeg = forkConeDeg;
     if (inheritedHit) this.hitSet.add(inheritedHit);
   }
 

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -18,6 +18,8 @@ import type { Enemy } from "./Enemy";
  */
 export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   baseHit = 0;
+  /** Crits are resolved once per shot fired (combat.spec.todo.md) and shared by every line/fork that shot spawns — carried here purely for floating-combat-text display. */
+  numCrits = 0;
   blastRadius = 0;
   blastDamageFraction = 0;
   private fractions: number[] = [];
@@ -36,11 +38,12 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     vx: number,
     vy: number,
     baseHit: number,
+    numCrits: number,
     fractions: number[],
     blastRadius: number,
     blastDamageFraction: number
   ): void {
-    this.reset(x, y, vx, vy, baseHit, blastRadius, blastDamageFraction);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction);
     this.infinite = false;
     this.fractions = fractions;
     this.fractionIndex = 0;
@@ -52,11 +55,12 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     vx: number,
     vy: number,
     baseHit: number,
+    numCrits: number,
     hitsAllowed: number,
     blastRadius: number,
     blastDamageFraction: number
   ): void {
-    this.reset(x, y, vx, vy, baseHit, blastRadius, blastDamageFraction);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction);
     this.infinite = true;
     this.hitsRemaining = hitsAllowed;
   }
@@ -67,10 +71,12 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     vx: number,
     vy: number,
     baseHit: number,
+    numCrits: number,
     blastRadius: number,
     blastDamageFraction: number
   ): void {
     this.baseHit = baseHit;
+    this.numCrits = numCrits;
     this.blastRadius = blastRadius;
     this.blastDamageFraction = blastDamageFraction;
     this.hitSet.clear();

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -1,6 +1,8 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { TUNING } from "../tuning";
 import type { Enemy } from "./Enemy";
+import type { ShmupPlayScene } from "./types";
 
 /**
  * Pooled player projectile. One bullet is either:
@@ -15,6 +17,11 @@ import type { Enemy } from "./Enemy";
  * combat.spec.todo.md). Blast radius is a real spatial query the scene runs
  * against the enemies group on each fresh impact this bullet registers, not
  * something the bullet itself queries.
+ *
+ * Homing (see TUNING.homing) is the one piece of steering the bullet does
+ * own: it searches/turns toward a locked enemy in its own preUpdate, decaying
+ * the same way damage decays on a finite pierce line and never decaying on
+ * an infinite forked one.
  */
 export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   baseHit = 0;
@@ -27,6 +34,10 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   private infinite = false;
   private hitsRemaining = 0;
   private readonly hitSet = new Set<Enemy>();
+  /** Set once per shot; decays on finite pierce lines the same way damage decays (TUNING.homing doc comment). Forked "infinite" lines never decay it, same as they never decay damage. */
+  private baseHomingStrength = 0;
+  private homingStrength = 0;
+  private lockedTarget: Enemy | null = null;
 
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
     super(scene, x, y, texture);
@@ -41,9 +52,10 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     numCrits: number,
     fractions: number[],
     blastRadius: number,
-    blastDamageFraction: number
+    blastDamageFraction: number,
+    homingStrength: number
   ): void {
-    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = false;
     this.fractions = fractions;
     this.fractionIndex = 0;
@@ -58,9 +70,10 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     numCrits: number,
     hitsAllowed: number,
     blastRadius: number,
-    blastDamageFraction: number
+    blastDamageFraction: number,
+    homingStrength: number
   ): void {
-    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
     this.infinite = true;
     this.hitsRemaining = hitsAllowed;
   }
@@ -73,12 +86,16 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     baseHit: number,
     numCrits: number,
     blastRadius: number,
-    blastDamageFraction: number
+    blastDamageFraction: number,
+    homingStrength: number
   ): void {
     this.baseHit = baseHit;
     this.numCrits = numCrits;
     this.blastRadius = blastRadius;
     this.blastDamageFraction = blastDamageFraction;
+    this.baseHomingStrength = homingStrength;
+    this.homingStrength = homingStrength;
+    this.lockedTarget = null;
     this.hitSet.clear();
     this.setPosition(x, y);
     this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
@@ -111,6 +128,9 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
 
     const fraction = this.fractions[this.fractionIndex];
     this.fractionIndex += 1;
+    // Homing decays exactly like damage: the next leg of flight uses
+    // whatever tailHitFraction will apply to the next hit (0 once spent).
+    this.homingStrength = this.baseHomingStrength * (this.fractions[this.fractionIndex] ?? 0);
     if (this.fractionIndex >= this.fractions.length) this.recycle();
     return fraction;
   }
@@ -128,6 +148,63 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     if (!this.active) return;
     if (this.y < -32 || this.y > GAME_HEIGHT + 32 || this.x < -32 || this.x > GAME_WIDTH + 32) {
       this.recycle();
+      return;
     }
+    this.updateHoming(delta / 1000);
+  }
+
+  /**
+   * Lock-on is sticky (design discussion, F6 #134): once locked, this bullet
+   * keeps turning toward `lockedTarget` until it dies, never re-targeting
+   * mid-flight. While unlocked it searches a circle that leads its own
+   * heading (TUNING.homing doc comment) so it can't lock onto something
+   * it's already flown past.
+   */
+  private updateHoming(dt: number): void {
+    if (this.homingStrength <= 0) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    const speed = Math.hypot(body.velocity.x, body.velocity.y);
+    if (speed <= 0) return;
+
+    if (this.lockedTarget && !this.lockedTarget.active) this.lockedTarget = null;
+    if (!this.lockedTarget) {
+      this.lockedTarget = this.findTarget(body, speed);
+      if (!this.lockedTarget) return;
+    }
+
+    const turnRateDegPerSec = Math.min(
+      TUNING.homing.maxTurnRateDegPerSec,
+      TUNING.homing.turnRateDegPerSecPerStrength * this.homingStrength
+    );
+    const currentAngle = Math.atan2(body.velocity.y, body.velocity.x);
+    const targetAngle = Phaser.Math.Angle.Between(this.x, this.y, this.lockedTarget.x, this.lockedTarget.y);
+    const newAngle = Phaser.Math.Angle.RotateTo(
+      currentAngle,
+      targetAngle,
+      Phaser.Math.DegToRad(turnRateDegPerSec) * dt
+    );
+    body.setVelocity(Math.cos(newAngle) * speed, Math.sin(newAngle) * speed);
+    this.setRotation(newAngle + Math.PI / 2);
+  }
+
+  private findTarget(body: Phaser.Physics.Arcade.Body, speed: number): Enemy | null {
+    const radius = Math.min(TUNING.homing.maxRadiusPx, speed * TUNING.homing.seekAheadSeconds * this.homingStrength);
+    if (radius <= 0) return null;
+    const dirX = body.velocity.x / speed;
+    const dirY = body.velocity.y / speed;
+    const centerX = this.x + dirX * radius;
+    const centerY = this.y + dirY * radius;
+
+    let best: Enemy | null = null;
+    let bestDist = Infinity;
+    for (const enemy of (this.scene as ShmupPlayScene).enemies.getChildren() as Enemy[]) {
+      if (!enemy.active) continue;
+      const dist = Phaser.Math.Distance.Between(centerX, centerY, enemy.x, enemy.y);
+      if (dist <= radius && dist < bestDist) {
+        best = enemy;
+        bestDist = dist;
+      }
+    }
+    return best;
   }
 }

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -50,7 +50,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   private fractionIndex = 0;
   private infinite = false;
   private hitsRemaining = 0;
-  private readonly hitSet = new Set<Enemy>();
+  /** Tracks `Enemy.spawnId`, not the `Enemy` object itself — enemy sprites are pooled and reused across spawns, so an object-reference Set would risk a later, logically-different enemy reusing the same pooled object and being skipped as "already hit". */
+  private readonly hitSet = new Set<number>();
   /** Set once per shot; decays on finite pierce lines the same way damage decays (TUNING.homing doc comment). Forked "infinite" lines never decay it, same as they never decay damage. */
   private baseHomingStrength = 0;
   private homingStrength = 0;
@@ -108,7 +109,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     this.pendingForkCount = forkCount;
     this.forkProjectileSpeed = forkProjectileSpeed;
     this.forkConeDeg = forkConeDeg;
-    if (inheritedHit) this.hitSet.add(inheritedHit);
+    if (inheritedHit) this.hitSet.add(inheritedHit.spawnId);
   }
 
   private reset(
@@ -146,7 +147,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
 
   /** True once this bullet has already damaged `enemy` — it should pass through without re-hitting it. */
   hasHit(enemy: Enemy): boolean {
-    return this.hitSet.has(enemy);
+    return this.hitSet.has(enemy.spawnId);
   }
 
   /** This shot's original Homing Strength, undecayed — what a fork spawned off this line should carry, since forked "infinite" lines never decay homing (same as they never decay damage). */
@@ -167,8 +168,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
    * hit by this bullet. Recycles the bullet once its pierce/hits are spent.
    */
   registerHit(enemy: Enemy): number | undefined {
-    if (this.hitSet.has(enemy)) return undefined;
-    this.hitSet.add(enemy);
+    if (this.hitSet.has(enemy.spawnId)) return undefined;
+    this.hitSet.add(enemy.spawnId);
 
     if (this.infinite) {
       this.hitsRemaining -= 1;
@@ -250,7 +251,7 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     for (const enemy of (this.scene as ShmupPlayScene).enemies.getChildren() as Enemy[]) {
       // Can't hit it again (it's already in this bullet's hit-list, same as
       // collision exclusion), so it shouldn't be seekable either.
-      if (!enemy.active || this.hitSet.has(enemy)) continue;
+      if (!enemy.active || this.hitSet.has(enemy.spawnId)) continue;
       const dist = Phaser.Math.Distance.Between(centerX, centerY, enemy.x, enemy.y);
       if (dist <= radius && dist < bestDist) {
         best = enemy;

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -1,0 +1,127 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import type { Enemy } from "./Enemy";
+
+/**
+ * Pooled player projectile. One bullet is either:
+ * - a decaying pierce "line" (`fireLine`) — each impact applies the next
+ *   `tailHitFractions` entry, in order, then recycles once exhausted, or
+ * - a forked "infinite" line (`fireForkedLine`) — full damage every impact,
+ *   capped by `TUNING.weapons.maxHitsPerInfiniteBullet` rather than decaying
+ *   (weapons.spec.todo.md's fork-overflow behavior).
+ *
+ * `baseHit` is the already-crit-resolved damage for this shot (crit is
+ * rolled once per shot fired, never re-rolled per pierce impact/fork —
+ * combat.spec.todo.md). Blast radius is a real spatial query the scene runs
+ * against the enemies group on each fresh impact this bullet registers, not
+ * something the bullet itself queries.
+ */
+export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
+  baseHit = 0;
+  blastRadius = 0;
+  blastDamageFraction = 0;
+  private fractions: number[] = [];
+  private fractionIndex = 0;
+  private infinite = false;
+  private hitsRemaining = 0;
+  private readonly hitSet = new Set<Enemy>();
+
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
+    super(scene, x, y, texture);
+  }
+
+  fireLine(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    baseHit: number,
+    fractions: number[],
+    blastRadius: number,
+    blastDamageFraction: number
+  ): void {
+    this.reset(x, y, vx, vy, baseHit, blastRadius, blastDamageFraction);
+    this.infinite = false;
+    this.fractions = fractions;
+    this.fractionIndex = 0;
+  }
+
+  fireForkedLine(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    baseHit: number,
+    hitsAllowed: number,
+    blastRadius: number,
+    blastDamageFraction: number
+  ): void {
+    this.reset(x, y, vx, vy, baseHit, blastRadius, blastDamageFraction);
+    this.infinite = true;
+    this.hitsRemaining = hitsAllowed;
+  }
+
+  private reset(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    baseHit: number,
+    blastRadius: number,
+    blastDamageFraction: number
+  ): void {
+    this.baseHit = baseHit;
+    this.blastRadius = blastRadius;
+    this.blastDamageFraction = blastDamageFraction;
+    this.hitSet.clear();
+    this.setPosition(x, y);
+    this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
+    this.setActive(true);
+    this.setVisible(true);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.enable = true;
+    body.setVelocity(vx, vy);
+  }
+
+  /** True once this bullet has already damaged `enemy` — it should pass through without re-hitting it. */
+  hasHit(enemy: Enemy): boolean {
+    return this.hitSet.has(enemy);
+  }
+
+  /**
+   * Registers a fresh impact against `enemy`. Returns the damage fraction
+   * (relative to `baseHit`) to apply, or undefined if `enemy` was already
+   * hit by this bullet. Recycles the bullet once its pierce/hits are spent.
+   */
+  registerHit(enemy: Enemy): number | undefined {
+    if (this.hitSet.has(enemy)) return undefined;
+    this.hitSet.add(enemy);
+
+    if (this.infinite) {
+      this.hitsRemaining -= 1;
+      if (this.hitsRemaining <= 0) this.recycle();
+      return 1;
+    }
+
+    const fraction = this.fractions[this.fractionIndex];
+    this.fractionIndex += 1;
+    if (this.fractionIndex >= this.fractions.length) this.recycle();
+    return fraction;
+  }
+
+  recycle(): void {
+    this.setActive(false);
+    this.setVisible(false);
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.stop();
+    body.enable = false;
+  }
+
+  preUpdate(time: number, delta: number): void {
+    super.preUpdate(time, delta);
+    if (!this.active) return;
+    if (this.y < -32 || this.y > GAME_HEIGHT + 32 || this.x < -32 || this.x > GAME_WIDTH + 32) {
+      this.recycle();
+    }
+  }
+}

--- a/games/shmup/src/entities/index.ts
+++ b/games/shmup/src/entities/index.ts
@@ -1,0 +1,6 @@
+export { Player } from "./Player";
+export type { PlayerFireRequest } from "./Player";
+export { Enemy } from "./Enemy";
+export { EnemyBullet } from "./EnemyBullet";
+export { PlayerBullet } from "./PlayerBullet";
+export type { ShmupPlayScene } from "./types";

--- a/games/shmup/src/entities/types.ts
+++ b/games/shmup/src/entities/types.ts
@@ -3,10 +3,12 @@ import type { Player } from "./Player";
 
 /**
  * Structural contract PlayScene satisfies. Lets pooled entities (Enemy,
- * EnemyBullet) read the player's resolved stats (e.g. Reflexes, for the
- * enemy bullet/move slow channels) without importing PlayScene itself and
- * creating scenes <-> entities import cycle.
+ * EnemyBullet, PlayerBullet) read the player's resolved stats (e.g.
+ * Reflexes, for the enemy bullet/move slow channels) and the live enemy
+ * group (homing's target search) without importing PlayScene itself and
+ * creating a scenes <-> entities import cycle.
  */
 export interface ShmupPlayScene extends Phaser.Scene {
   player: Player;
+  enemies: Phaser.Physics.Arcade.Group;
 }

--- a/games/shmup/src/entities/types.ts
+++ b/games/shmup/src/entities/types.ts
@@ -1,0 +1,12 @@
+import type Phaser from "phaser";
+import type { Player } from "./Player";
+
+/**
+ * Structural contract PlayScene satisfies. Lets pooled entities (Enemy,
+ * EnemyBullet) read the player's resolved stats (e.g. Reflexes, for the
+ * enemy bullet/move slow channels) without importing PlayScene itself and
+ * creating scenes <-> entities import cycle.
+ */
+export interface ShmupPlayScene extends Phaser.Scene {
+  player: Player;
+}

--- a/games/shmup/src/scenes/BootScene.ts
+++ b/games/shmup/src/scenes/BootScene.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import { copy } from "../content";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { requestMotionPermission } from "../debug/ShakeDetector";
 
 /**
  * Title card — proves the skeleton renders and that copy comes from the
@@ -55,7 +56,13 @@ export class BootScene extends Phaser.Scene {
       repeat: -1,
     });
 
-    const start = () => this.scene.start("Play");
+    // iOS gates devicemotion (shake-to-open the debug overlay) behind a
+    // permission prompt that only resolves from inside a user-gesture
+    // handler — this tap is the only one guaranteed before PlayScene exists.
+    const start = () => {
+      requestMotionPermission();
+      this.scene.start("Play");
+    };
     this.input.keyboard?.once("keydown", start);
     this.input.once("pointerdown", start);
   }

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -256,44 +256,30 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const homingStrength = this.player.stats.homingStrength;
     const originX = this.player.x;
     const originY = this.player.y - this.player.height / 2;
+    const angleRad = Phaser.Math.DegToRad(this.player.debugFiringAngleDeg);
+    const vx = Math.sin(angleRad) * req.projectileSpeed;
+    const vy = -Math.cos(angleRad) * req.projectileSpeed;
 
+    const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
     this.spawnPlayerLine(
       originX,
       originY,
-      0,
-      -req.projectileSpeed,
+      vx,
+      vy,
       hit,
       numCrits,
       tailHitFractions,
       blastRadius,
       blastDamageFraction,
-      homingStrength
+      homingStrength,
+      forkCount,
+      req.projectileSpeed
     );
-
-    const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
-    for (let i = 0; i < forkCount; i++) {
-      const angle = this.forkAngle();
-      const vx = Math.sin(angle) * req.projectileSpeed;
-      const vy = -Math.cos(angle) * req.projectileSpeed;
-      this.spawnPlayerFork(
-        originX,
-        originY,
-        vx,
-        vy,
-        hit,
-        numCrits,
-        TUNING.weapons.maxHitsPerInfiniteBullet,
-        blastRadius,
-        blastDamageFraction,
-        homingStrength
-      );
-    }
   }
 
-  /** Each fork gets its own random heading (weapons.spec.todo.md) so it's visibly distinct from the main line and other forks, rather than a deterministic fan that collapses to 0deg for the common 1-fork case. */
+  /** Each fork gets its own random heading (weapons.spec.todo.md) — fully random rather than a fan off the muzzle, since a fork is born from an impact point that can be anywhere on screen, not from the gun. */
   private forkAngle(): number {
-    const maxSpreadDeg = 50;
-    return Phaser.Math.DegToRad(Phaser.Math.FloatBetween(-maxSpreadDeg, maxSpreadDeg));
+    return Phaser.Math.FloatBetween(0, Math.PI * 2);
   }
 
   private spawnPlayerLine(
@@ -306,10 +292,25 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     fractions: number[],
     blastRadius: number,
     blastDamageFraction: number,
-    homingStrength: number
+    homingStrength: number,
+    forkCount: number,
+    forkProjectileSpeed: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireLine(x, y, vx, vy, hit, numCrits, fractions, blastRadius, blastDamageFraction, homingStrength);
+    bullet?.fireLine(
+      x,
+      y,
+      vx,
+      vy,
+      hit,
+      numCrits,
+      fractions,
+      blastRadius,
+      blastDamageFraction,
+      homingStrength,
+      forkCount,
+      forkProjectileSpeed
+    );
   }
 
   private spawnPlayerFork(
@@ -322,12 +323,33 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     hitsAllowed: number,
     blastRadius: number,
     blastDamageFraction: number,
-    homingStrength: number
+    homingStrength: number,
+    inheritedHit?: Enemy
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireForkedLine(x, y, vx, vy, hit, numCrits, hitsAllowed, blastRadius, blastDamageFraction, homingStrength);
+    bullet?.fireForkedLine(
+      x,
+      y,
+      vx,
+      vy,
+      hit,
+      numCrits,
+      hitsAllowed,
+      blastRadius,
+      blastDamageFraction,
+      homingStrength,
+      inheritedHit
+    );
   }
 
+  /**
+   * Forks aren't spawned at the muzzle — weapons.spec.todo.md's "forked
+   * projectiles inherit the firing projectile's hit-list" only makes sense
+   * once the line has actually scored an impact. So the main line carries
+   * its whole fork allotment and hands it off here, on its first registered
+   * hit, spawning that many full-damage forked lines from this impact point
+   * (each pre-seeded with `enemy` so they can't immediately re-hit it).
+   */
   private onPlayerBulletHitEnemy(bullet: PlayerBullet, enemy: Enemy): void {
     if (this.gameOver || !bullet.active || !enemy.active || bullet.hasHit(enemy)) return;
     const fraction = bullet.registerHit(enemy);
@@ -342,6 +364,26 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
         const dist = Phaser.Math.Distance.Between(enemy.x, enemy.y, other.x, other.y);
         if (dist <= bullet.blastRadius) this.damageEnemy(other, blastDamage, bullet.numCrits);
       }
+    }
+
+    const forkCount = bullet.takePendingForks();
+    for (let i = 0; i < forkCount; i++) {
+      const angle = this.forkAngle();
+      const vx = Math.cos(angle) * bullet.forkProjectileSpeed;
+      const vy = Math.sin(angle) * bullet.forkProjectileSpeed;
+      this.spawnPlayerFork(
+        bullet.x,
+        bullet.y,
+        vx,
+        vy,
+        bullet.baseHit,
+        bullet.numCrits,
+        TUNING.weapons.maxHitsPerInfiniteBullet,
+        bullet.blastRadius,
+        bullet.blastDamageFraction,
+        bullet.shotHomingStrength,
+        enemy
+      );
     }
   }
 

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -6,7 +6,7 @@ import { preloadSprites, ensurePlaceholderTextures } from "../sprites";
 import type { SpriteKey } from "../sprites";
 import { Player, Enemy, EnemyBullet, PlayerBullet } from "../entities";
 import type { PlayerFireRequest, ShmupPlayScene } from "../entities";
-import { applyDamage, reflexBulletSpeedMult, resolveHit, tickShieldRegen } from "../systems/combat";
+import { applyDamage, applyLifesteal, reflexBulletSpeedMult, rollCrit, tickHpRegen, tickShieldRegen } from "../systems/combat";
 import { DebugOverlay } from "../debug/DebugOverlay";
 
 // Logical roles -> sprite registry keys (specs/games/shmup/content-and-assets.spec.md).
@@ -176,6 +176,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     }
 
     tickShieldRegen(this.player.defender, this.player.stats.maxShield, dt);
+    tickHpRegen(this.player.defender, this.player.stats.maxHp, this.player.stats.hpRegen, dt);
     this.updateHud();
 
     this.background.tilePositionY -= TUNING.visuals.bgScrollSpeed * dt;
@@ -248,21 +249,28 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
    * fraction of that single resolved hit, they never re-roll it.
    */
   private fireWeapon(req: PlayerFireRequest): void {
-    const hit = resolveHit({
-      damage: this.player.stats.damage,
-      critChance: this.player.stats.critChance,
-      critDamage: this.player.stats.critDamage,
-    });
+    const { numCrits, critFactor } = rollCrit(this.player.stats.critChance, this.player.stats.critDamage);
+    const hit = this.player.stats.damage * critFactor;
     const { flatLineCount, tailHitFractions, blastDamageFraction } = req.behavior;
     const blastRadius = this.player.stats.blastRadius;
     const originX = this.player.x;
     const originY = this.player.y - this.player.height / 2;
 
-    this.spawnPlayerLine(originX, originY, 0, -req.projectileSpeed, hit, tailHitFractions, blastRadius, blastDamageFraction);
+    this.spawnPlayerLine(
+      originX,
+      originY,
+      0,
+      -req.projectileSpeed,
+      hit,
+      numCrits,
+      tailHitFractions,
+      blastRadius,
+      blastDamageFraction
+    );
 
     const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
     for (let i = 0; i < forkCount; i++) {
-      const angle = this.forkAngle(i, forkCount);
+      const angle = this.forkAngle();
       const vx = Math.sin(angle) * req.projectileSpeed;
       const vy = -Math.cos(angle) * req.projectileSpeed;
       this.spawnPlayerFork(
@@ -271,6 +279,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
         vx,
         vy,
         hit,
+        numCrits,
         TUNING.weapons.maxHitsPerInfiniteBullet,
         blastRadius,
         blastDamageFraction
@@ -278,14 +287,10 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     }
   }
 
-  /** Fans forked lines out symmetrically around straight-up so each fork is visibly its own line. */
-  private forkAngle(i: number, count: number): number {
-    const stepDeg = 6;
+  /** Each fork gets its own random heading (weapons.spec.todo.md) so it's visibly distinct from the main line and other forks, rather than a deterministic fan that collapses to 0deg for the common 1-fork case. */
+  private forkAngle(): number {
     const maxSpreadDeg = 50;
-    const spreadDeg = Math.min(maxSpreadDeg, stepDeg * Math.max(0, count - 1));
-    const startDeg = -spreadDeg / 2;
-    const angleDeg = count <= 1 ? startDeg : startDeg + (spreadDeg * i) / (count - 1);
-    return Phaser.Math.DegToRad(angleDeg);
+    return Phaser.Math.DegToRad(Phaser.Math.FloatBetween(-maxSpreadDeg, maxSpreadDeg));
   }
 
   private spawnPlayerLine(
@@ -294,12 +299,13 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     vx: number,
     vy: number,
     hit: number,
+    numCrits: number,
     fractions: number[],
     blastRadius: number,
     blastDamageFraction: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireLine(x, y, vx, vy, hit, fractions, blastRadius, blastDamageFraction);
+    bullet?.fireLine(x, y, vx, vy, hit, numCrits, fractions, blastRadius, blastDamageFraction);
   }
 
   private spawnPlayerFork(
@@ -308,12 +314,13 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     vx: number,
     vy: number,
     hit: number,
+    numCrits: number,
     hitsAllowed: number,
     blastRadius: number,
     blastDamageFraction: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireForkedLine(x, y, vx, vy, hit, hitsAllowed, blastRadius, blastDamageFraction);
+    bullet?.fireForkedLine(x, y, vx, vy, hit, numCrits, hitsAllowed, blastRadius, blastDamageFraction);
   }
 
   private onPlayerBulletHitEnemy(bullet: PlayerBullet, enemy: Enemy): void {
@@ -321,25 +328,52 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const fraction = bullet.registerHit(enemy);
     if (fraction === undefined) return;
 
-    this.damageEnemy(enemy, bullet.baseHit * fraction);
+    this.damageEnemy(enemy, bullet.baseHit * fraction, bullet.numCrits);
 
     if (bullet.blastRadius > 0) {
       const blastDamage = bullet.baseHit * bullet.blastDamageFraction;
       for (const other of this.enemies.getChildren() as Enemy[]) {
         if (other === enemy || !other.active) continue;
         const dist = Phaser.Math.Distance.Between(enemy.x, enemy.y, other.x, other.y);
-        if (dist <= bullet.blastRadius) this.damageEnemy(other, blastDamage);
+        if (dist <= bullet.blastRadius) this.damageEnemy(other, blastDamage, bullet.numCrits);
       }
     }
   }
 
-  private damageEnemy(enemy: Enemy, damage: number): void {
+  private damageEnemy(enemy: Enemy, damage: number, numCrits: number): void {
     enemy.hp -= damage;
+    applyLifesteal(this.player.defender, this.player.stats.maxHp, damage, this.player.stats.lifesteal);
+    this.spawnDamageNumber(enemy.x, enemy.y, damage, numCrits);
     if (enemy.hp <= 0) {
       enemy.recycle();
       this.score += enemy.scoreValue;
       this.scoreText.setText(copy("play.score", { score: this.score }));
     }
+  }
+
+  /** Crit styling per the user's request: bigger, gold-colored, one "!" per crit stacked on the shot (combat.spec.todo.md's numCrits, not re-rolled per pierce/fork impact). */
+  private spawnDamageNumber(x: number, y: number, damage: number, numCrits: number): void {
+    const rounded = Math.round(damage);
+    if (numCrits > 0) {
+      this.spawnFloatingText(x, y, `${rounded}${"!".repeat(numCrits)}`, "#ffcc00", 20);
+    } else {
+      this.spawnFloatingText(x, y, `${rounded}`, "#ffffff", 13);
+    }
+  }
+
+  private spawnFloatingText(x: number, y: number, text: string, color: string, fontSize: number): void {
+    const t = this.add
+      .text(x, y, text, { fontFamily: "monospace", fontSize: `${fontSize}px`, color, fontStyle: "bold" })
+      .setOrigin(0.5)
+      .setDepth(150);
+    this.tweens.add({
+      targets: t,
+      y: y - 40,
+      alpha: 0,
+      duration: 700,
+      ease: "Cubic.Out",
+      onComplete: () => t.destroy(),
+    });
   }
 
   private onEnemyBulletHitPlayer(bullet: EnemyBullet): void {
@@ -357,7 +391,10 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   private damagePlayer(hit: number): void {
     if (this.player.invulnerable) return;
     const result = applyDamage(this.player.defender, hit, this.player.stats.armor, this.player.stats.evasion);
-    if (result.dodged) return;
+    if (result.dodged) {
+      this.spawnFloatingText(this.player.x, this.player.y - this.player.height / 2, "MISS!", "#88ccff", 16);
+      return;
+    }
     this.player.triggerIFrame();
     this.cameras.main.flash(120, 150, 0, 0);
     if (result.defeated) this.endEpisode();

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -339,6 +339,9 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     blastRadius: number,
     blastDamageFraction: number,
     homingStrength: number,
+    forkCount: number,
+    forkProjectileSpeed: number,
+    forkConeDeg: number,
     inheritedHit?: Enemy
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
@@ -353,6 +356,9 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       blastRadius,
       blastDamageFraction,
       homingStrength,
+      forkCount,
+      forkProjectileSpeed,
+      forkConeDeg,
       inheritedHit
     );
   }
@@ -360,10 +366,15 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   /**
    * Forks aren't spawned at the muzzle — weapons.spec.todo.md's "forked
    * projectiles inherit the firing projectile's hit-list" only makes sense
-   * once the line has actually scored an impact. So the main line carries
-   * its whole fork allotment and hands it off here, on its first registered
-   * hit, spawning that many full-damage forked lines from this impact point
-   * (each pre-seeded with `enemy` so they can't immediately re-hit it).
+   * once the line has actually scored an impact. So a bullet (the main line
+   * or an earlier fork) carries its remaining chain-link count and hands it
+   * off here, on its first registered hit, spawning exactly ONE more forked
+   * line from this impact point (pre-seeded with `enemy` so it can't
+   * immediately re-hit it) and carrying the chain count minus one. That new
+   * fork resolves the same rule recursively on its OWN first impact
+   * (weapons.spec.todo.md), so pierce well above 200% is only visible as a
+   * multi-generation chain if every link in it keeps landing hits — a link
+   * that flies past everything ends the chain early.
    */
   private onPlayerBulletHitEnemy(bullet: PlayerBullet, enemy: Enemy): void {
     if (this.gameOver || !bullet.active || !enemy.active || bullet.hasHit(enemy)) return;
@@ -381,10 +392,10 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       }
     }
 
-    const bulletBody = bullet.body as Phaser.Physics.Arcade.Body;
-    const baseAngle = Math.atan2(bulletBody.velocity.y, bulletBody.velocity.x);
-    const forkCount = bullet.takePendingForks();
-    for (let i = 0; i < forkCount; i++) {
+    const remainingForks = bullet.takePendingForks();
+    if (remainingForks > 0) {
+      const bulletBody = bullet.body as Phaser.Physics.Arcade.Body;
+      const baseAngle = Math.atan2(bulletBody.velocity.y, bulletBody.velocity.x);
       const angle = this.forkAngle(baseAngle, bullet.forkConeDeg);
       const vx = Math.cos(angle) * bullet.forkProjectileSpeed;
       const vy = Math.sin(angle) * bullet.forkProjectileSpeed;
@@ -399,6 +410,9 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
         bullet.blastRadius,
         bullet.blastDamageFraction,
         bullet.shotHomingStrength,
+        remainingForks - 1,
+        bullet.forkProjectileSpeed,
+        bullet.forkConeDeg,
         enemy
       );
     }

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -1,40 +1,54 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { TUNING } from "../tuning";
+import { copy } from "../content";
 import { preloadSprites, ensurePlaceholderTextures } from "../sprites";
 import type { SpriteKey } from "../sprites";
+import { Player, Enemy, EnemyBullet, PlayerBullet } from "../entities";
+import type { PlayerFireRequest, ShmupPlayScene } from "../entities";
+import { applyDamage, reflexBulletSpeedMult, resolveHit, tickShieldRegen } from "../systems/combat";
 
-// Logical roles → sprite registry keys (specs/games/shmup/content-and-assets.spec.md).
+// Logical roles -> sprite registry keys (specs/games/shmup/content-and-assets.spec.md).
 // Code never inlines a draw call or file path — it asks for one of these keys,
 // and the registry decides whether that currently means a colored primitive
-// or real art. Add new entities to sprites/manifest.json, not here.
+// or real art. Add new entries to sprites/manifest.json, not here.
 const TEX = {
   ship: "shipPlayer",
-  bullet: "bulletPlayer",
+  bulletPlayer: "bulletPlayer",
+  bulletEnemy: "bulletEnemy",
   enemy: "enemyDrone",
   star: "fxStarDust",
+  bg: "bgSpace",
 } satisfies Record<string, SpriteKey>;
 
-const PLAYER_SPEED = 340; // px/s — shared by keyboard and drag so both move at the same rate
 const DRAG_OFFSET_Y = 120; // float the ship well above the finger so it stays visible
-const FIRE_COOLDOWN_MS = 160;
 
 /**
- * Interactive placeholder slice — everything is a generated colored primitive
- * (placeholder-first art, per specs). Demonstrates the core loop: move, shoot,
- * destroy drifting targets, score. Controls: drag/point to move + auto-fire
- * (mobile-friendly), or arrows/WASD on desktop.
+ * The F6 #134 core gameplay loop — the integration point for F3 (stats),
+ * F4 (weapon/item effect composition), and F5 (sprite registry): a player
+ * ship whose speed/fire-rate/damage come from the resolved stat pool, a
+ * weapon that fires through resolveLoadout()'s projectile behavior
+ * (pierce/fork), and pooled Arcade-physics entities for bullets/enemies.
  */
-export class PlayScene extends Phaser.Scene {
-  private player!: Phaser.Physics.Arcade.Image;
-  private bullets!: Phaser.Physics.Arcade.Group;
+export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
+  player!: Player;
+  private playerBullets!: Phaser.Physics.Arcade.Group;
+  private enemyBullets!: Phaser.Physics.Arcade.Group;
   private enemies!: Phaser.Physics.Arcade.Group;
   private stars!: Phaser.GameObjects.Group;
+  private background!: Phaser.GameObjects.TileSprite;
+
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private keys!: Record<string, Phaser.Input.Keyboard.Key>;
+  private focusKey!: Phaser.Input.Keyboard.Key;
   private pointerTarget: { x: number; y: number } | null = null;
-  private lastFired = 0;
+
   private score = 0;
   private scoreText!: Phaser.GameObjects.Text;
+  private hpBar!: Phaser.GameObjects.Graphics;
+  private shieldBar!: Phaser.GameObjects.Graphics;
+
+  private gameOver = false;
 
   constructor() {
     super("Play");
@@ -46,36 +60,59 @@ export class PlayScene extends Phaser.Scene {
 
   create() {
     ensurePlaceholderTextures(this);
+    this.gameOver = false;
+    this.score = 0;
+
+    this.background = this.add
+      .tileSprite(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, TEX.bg)
+      .setDepth(-20);
 
     this.stars = this.add.group();
-    for (let i = 0; i < 70; i++) {
+    for (let i = 0; i < TUNING.visuals.starCount; i++) {
       const s = this.add
         .image(Phaser.Math.Between(0, GAME_WIDTH), Phaser.Math.Between(0, GAME_HEIGHT), TEX.star)
-        .setAlpha(Phaser.Math.FloatBetween(0.2, 1));
-      s.setData("speed", Phaser.Math.Between(40, 180));
+        .setAlpha(Phaser.Math.FloatBetween(0.2, 1))
+        .setDepth(-10);
+      s.setData("speed", Phaser.Math.Between(TUNING.visuals.starMinSpeed, TUNING.visuals.starMaxSpeed));
       this.stars.add(s);
     }
 
-    this.player = this.physics.add.image(GAME_WIDTH / 2, GAME_HEIGHT - 90, TEX.ship);
+    this.playerBullets = this.physics.add.group({
+      classType: PlayerBullet,
+      maxSize: TUNING.performance.maxPlayerBullets,
+      runChildUpdate: true,
+    });
+    this.enemyBullets = this.physics.add.group({
+      classType: EnemyBullet,
+      maxSize: TUNING.performance.maxEnemyBullets,
+      runChildUpdate: true,
+    });
+    this.enemies = this.physics.add.group({
+      classType: Enemy,
+      maxSize: TUNING.performance.maxEnemies,
+      runChildUpdate: true,
+    });
+
+    this.player = new Player(this, GAME_WIDTH / 2, GAME_HEIGHT - 90, TEX.ship);
     this.player.setCollideWorldBounds(true);
+    this.player.setDepth(10);
 
-    this.bullets = this.physics.add.group();
-    this.enemies = this.physics.add.group();
-
-    this.physics.add.overlap(this.bullets, this.enemies, (b, e) =>
-      this.hitEnemy(b as Phaser.Physics.Arcade.Image, e as Phaser.Physics.Arcade.Image)
+    this.physics.add.overlap(this.playerBullets, this.enemies, (bulletObj, enemyObj) =>
+      this.onPlayerBulletHitEnemy(bulletObj as PlayerBullet, enemyObj as Enemy)
     );
-    this.physics.add.overlap(this.player, this.enemies, () =>
-      this.cameras.main.flash(140, 150, 0, 0)
+    this.physics.add.overlap(this.enemyBullets, this.player, (bulletObj) =>
+      this.onEnemyBulletHitPlayer(bulletObj as EnemyBullet)
+    );
+    this.physics.add.overlap(this.enemies, this.player, (enemyObj) =>
+      this.onEnemyContactPlayer(enemyObj as Enemy)
     );
 
     this.cursors = this.input.keyboard!.createCursorKeys();
-    this.keys = this.input.keyboard!.addKeys("W,A,S,D") as Record<
-      string,
-      Phaser.Input.Keyboard.Key
-    >;
+    this.keys = this.input.keyboard!.addKeys("W,A,S,D") as Record<string, Phaser.Input.Keyboard.Key>;
+    this.focusKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
 
     // Pointer / touch: drag-to-move (the ship follows the finger, floated above it).
+    // Mobile Focus is TBD (combat.spec.todo.md) — not wired to the pointer here.
     this.input.on("pointerdown", (p: Phaser.Input.Pointer) => {
       this.pointerTarget = { x: p.x, y: p.y - DRAG_OFFSET_Y };
     });
@@ -86,110 +123,284 @@ export class PlayScene extends Phaser.Scene {
       this.pointerTarget = null;
     });
 
-    this.time.addEvent({ delay: 650, loop: true, callback: () => this.spawnEnemy() });
+    this.time.addEvent({
+      delay: TUNING.enemies.drone.spawnIntervalMs,
+      loop: true,
+      callback: () => this.spawnEnemy(),
+    });
+
+    this.scoreText = this.add
+      .text(16, 14, copy("play.score", { score: 0 }), {
+        fontFamily: "monospace",
+        fontSize: "18px",
+        color: "#ffffff",
+      })
+      .setDepth(100);
 
     this.add
-      .text(GAME_WIDTH / 2, 18, "SHMUP — placeholder build", {
+      .text(GAME_WIDTH / 2, GAME_HEIGHT - 14, copy("play.hint"), {
         fontFamily: "monospace",
-        fontSize: "16px",
-        color: "#ff6b00",
-      })
-      .setOrigin(0.5, 0);
-    this.add
-      .text(GAME_WIDTH / 2, GAME_HEIGHT - 22, "Drag to move · auto-fire   (or Arrows / WASD)", {
-        fontFamily: "monospace",
-        fontSize: "13px",
+        fontSize: "12px",
         color: "#888888",
       })
-      .setOrigin(0.5, 1);
-    this.scoreText = this.add.text(16, 14, "SCORE 0", {
-      fontFamily: "monospace",
-      fontSize: "18px",
-      color: "#ffffff",
-    });
+      .setOrigin(0.5, 1)
+      .setDepth(100);
+
+    this.hpBar = this.add.graphics().setDepth(100);
+    this.shieldBar = this.add.graphics().setDepth(100);
   }
 
-  private spawnEnemy() {
-    const e = this.enemies.create(
-      Phaser.Math.Between(24, GAME_WIDTH - 24),
-      -20,
-      TEX.enemy
-    ) as Phaser.Physics.Arcade.Image;
-    e.setVelocityY(Phaser.Math.Between(90, 190));
-  }
+  update(_time: number, delta: number) {
+    if (this.gameOver) return;
 
-  // Placeholder: fires on a fixed cadence regardless of targets.
-  // TODO (future, see weapons spec): smart auto-fire — only fire when an enemy
-  // is within a weapon's range/arc, and lead/target the nearest valid one.
-  private fire(time: number) {
-    if (time < this.lastFired) return;
-    this.lastFired = time + FIRE_COOLDOWN_MS;
-    const b = this.bullets.create(
-      this.player.x,
-      this.player.y - 20,
-      TEX.bullet
-    ) as Phaser.Physics.Arcade.Image;
-    b.setVelocityY(-560);
-  }
-
-  private hitEnemy(bullet: Phaser.Physics.Arcade.Image, enemy: Phaser.Physics.Arcade.Image) {
-    bullet.destroy();
-    enemy.destroy();
-    this.score += 10;
-    this.scoreText.setText("SCORE " + this.score);
-  }
-
-  update(time: number, delta: number) {
     const dt = delta / 1000;
+
+    this.updateMovement(dt);
+    this.player.tickIFrame(delta);
+
+    for (const req of this.player.tryFire(delta)) {
+      this.fireWeapon(req);
+    }
+
+    for (const enemy of this.enemies.getChildren() as Enemy[]) {
+      if (enemy.active && enemy.tryFire(delta)) this.fireEnemyBullet(enemy);
+    }
+
+    tickShieldRegen(this.player.defender, this.player.stats.maxShield, dt);
+    this.updateHud();
+
+    this.background.tilePositionY -= TUNING.visuals.bgScrollSpeed * dt;
+    for (const star of this.stars.getChildren() as Phaser.GameObjects.Image[]) {
+      star.y += (star.getData("speed") as number) * dt;
+      if (star.y > GAME_HEIGHT) {
+        star.y = 0;
+        star.x = Phaser.Math.Between(0, GAME_WIDTH);
+      }
+    }
+  }
+
+  private updateMovement(dt: number): void {
     const left = this.cursors.left.isDown || this.keys.A.isDown;
     const right = this.cursors.right.isDown || this.keys.D.isDown;
     const up = this.cursors.up.isDown || this.keys.W.isDown;
     const down = this.cursors.down.isDown || this.keys.S.isDown;
     const kbActive = left || right || up || down;
 
+    this.player.setFocus(this.focusKey.isDown);
+    const speed = this.player.currentSpeed();
+
     if (kbActive) {
       // Keyboard overrides any active drag.
       this.pointerTarget = null;
       this.player.setVelocity(0);
-      if (left) this.player.setVelocityX(-PLAYER_SPEED);
-      if (right) this.player.setVelocityX(PLAYER_SPEED);
-      if (up) this.player.setVelocityY(-PLAYER_SPEED);
-      if (down) this.player.setVelocityY(PLAYER_SPEED);
+      if (left) this.player.setVelocityX(-speed);
+      if (right) this.player.setVelocityX(speed);
+      if (up) this.player.setVelocityY(-speed);
+      if (down) this.player.setVelocityY(speed);
     } else if (this.pointerTarget) {
-      // Drag-to-move: glide toward the finger at the SAME capped speed as keyboard.
+      // Drag-to-move: glide toward the finger at the same capped speed as keyboard.
       this.player.setVelocity(0);
       const dx = this.pointerTarget.x - this.player.x;
-      const dyToTarget = this.pointerTarget.y - this.player.y;
-      const dist = Math.hypot(dx, dyToTarget);
-      const step = PLAYER_SPEED * dt;
+      const dy = this.pointerTarget.y - this.player.y;
+      const dist = Math.hypot(dx, dy);
+      const step = speed * dt;
       if (dist <= step || dist === 0) {
         this.player.setPosition(this.pointerTarget.x, this.pointerTarget.y);
       } else {
         this.player.x += (dx / dist) * step;
-        this.player.y += (dyToTarget / dist) * step;
+        this.player.y += (dy / dist) * step;
       }
       this.player.x = Phaser.Math.Clamp(this.player.x, 16, GAME_WIDTH - 16);
       this.player.y = Phaser.Math.Clamp(this.player.y, 15, GAME_HEIGHT - 15);
     } else {
       this.player.setVelocity(0);
     }
+  }
 
-    // Auto-fire (bullet-heaven default — no fire button).
-    this.fire(time);
+  private spawnEnemy(): void {
+    if (this.gameOver) return;
+    const x = Phaser.Math.Between(24, GAME_WIDTH - 24);
+    const y = -20;
+    const enemy = this.enemies.get(x, y, TEX.enemy) as Enemy | null;
+    enemy?.spawn(x, y);
+  }
 
-    (this.stars.getChildren() as Phaser.GameObjects.Image[]).forEach((s) => {
-      s.y += (s.getData("speed") as number) * dt;
-      if (s.y > GAME_HEIGHT) {
-        s.y = 0;
-        s.x = Phaser.Math.Between(0, GAME_WIDTH);
+  private fireEnemyBullet(enemy: Enemy): void {
+    const x = enemy.x;
+    const y = enemy.y + enemy.height / 2;
+    const speed = TUNING.enemies.drone.bulletSpeed * reflexBulletSpeedMult(this.player.stats.reflexes);
+    const bullet = this.enemyBullets.get(x, y, TEX.bulletEnemy) as EnemyBullet | null;
+    bullet?.fire(x, y, 0, speed, TUNING.enemies.drone.bulletDamage);
+  }
+
+  /**
+   * Crit is resolved once per shot fired (combat.spec.todo.md), so `baseHit`
+   * is shared by every line/fork this shot spawns — pierce/fork decay the
+   * fraction of that single resolved hit, they never re-roll it.
+   */
+  private fireWeapon(req: PlayerFireRequest): void {
+    const hit = resolveHit({
+      damage: this.player.stats.damage,
+      critChance: this.player.stats.critChance,
+      critDamage: this.player.stats.critDamage,
+    });
+    const { flatLineCount, tailHitFractions, blastDamageFraction } = req.behavior;
+    const blastRadius = this.player.stats.blastRadius;
+    const originX = this.player.x;
+    const originY = this.player.y - this.player.height / 2;
+
+    this.spawnPlayerLine(originX, originY, 0, -req.projectileSpeed, hit, tailHitFractions, blastRadius, blastDamageFraction);
+
+    const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
+    for (let i = 0; i < forkCount; i++) {
+      const angle = this.forkAngle(i, forkCount);
+      const vx = Math.sin(angle) * req.projectileSpeed;
+      const vy = -Math.cos(angle) * req.projectileSpeed;
+      this.spawnPlayerFork(
+        originX,
+        originY,
+        vx,
+        vy,
+        hit,
+        TUNING.weapons.maxHitsPerInfiniteBullet,
+        blastRadius,
+        blastDamageFraction
+      );
+    }
+  }
+
+  /** Fans forked lines out symmetrically around straight-up so each fork is visibly its own line. */
+  private forkAngle(i: number, count: number): number {
+    const stepDeg = 6;
+    const maxSpreadDeg = 50;
+    const spreadDeg = Math.min(maxSpreadDeg, stepDeg * Math.max(0, count - 1));
+    const startDeg = -spreadDeg / 2;
+    const angleDeg = count <= 1 ? startDeg : startDeg + (spreadDeg * i) / (count - 1);
+    return Phaser.Math.DegToRad(angleDeg);
+  }
+
+  private spawnPlayerLine(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    hit: number,
+    fractions: number[],
+    blastRadius: number,
+    blastDamageFraction: number
+  ): void {
+    const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
+    bullet?.fireLine(x, y, vx, vy, hit, fractions, blastRadius, blastDamageFraction);
+  }
+
+  private spawnPlayerFork(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    hit: number,
+    hitsAllowed: number,
+    blastRadius: number,
+    blastDamageFraction: number
+  ): void {
+    const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
+    bullet?.fireForkedLine(x, y, vx, vy, hit, hitsAllowed, blastRadius, blastDamageFraction);
+  }
+
+  private onPlayerBulletHitEnemy(bullet: PlayerBullet, enemy: Enemy): void {
+    if (this.gameOver || !bullet.active || !enemy.active || bullet.hasHit(enemy)) return;
+    const fraction = bullet.registerHit(enemy);
+    if (fraction === undefined) return;
+
+    this.damageEnemy(enemy, bullet.baseHit * fraction);
+
+    if (bullet.blastRadius > 0) {
+      const blastDamage = bullet.baseHit * bullet.blastDamageFraction;
+      for (const other of this.enemies.getChildren() as Enemy[]) {
+        if (other === enemy || !other.active) continue;
+        const dist = Phaser.Math.Distance.Between(enemy.x, enemy.y, other.x, other.y);
+        if (dist <= bullet.blastRadius) this.damageEnemy(other, blastDamage);
       }
-    });
+    }
+  }
 
-    (this.bullets.getChildren() as Phaser.Physics.Arcade.Image[]).forEach((b) => {
-      if (b.y < -20) b.destroy();
-    });
-    (this.enemies.getChildren() as Phaser.Physics.Arcade.Image[]).forEach((e) => {
-      if (e.y > GAME_HEIGHT + 40) e.destroy();
-    });
+  private damageEnemy(enemy: Enemy, damage: number): void {
+    enemy.hp -= damage;
+    if (enemy.hp <= 0) {
+      enemy.recycle();
+      this.score += enemy.scoreValue;
+      this.scoreText.setText(copy("play.score", { score: this.score }));
+    }
+  }
+
+  private onEnemyBulletHitPlayer(bullet: EnemyBullet): void {
+    if (this.gameOver || !bullet.active) return;
+    bullet.recycle();
+    this.damagePlayer(bullet.damage);
+  }
+
+  private onEnemyContactPlayer(enemy: Enemy): void {
+    if (this.gameOver || !enemy.active) return;
+    enemy.recycle();
+    this.damagePlayer(TUNING.enemies.drone.contactDamage);
+  }
+
+  private damagePlayer(hit: number): void {
+    if (this.player.invulnerable) return;
+    const result = applyDamage(this.player.defender, hit, this.player.stats.armor, this.player.stats.evasion);
+    if (result.dodged) return;
+    this.player.triggerIFrame();
+    this.cameras.main.flash(120, 150, 0, 0);
+    if (result.defeated) this.endEpisode();
+  }
+
+  // No-hull-lives model (combat.spec.todo.md / run-structure.spec.todo.md): one
+  // death ends the episode. The map/run-structure system (F8/F11) doesn't
+  // exist yet, so F6's vertical slice simplifies "returned to the map" to an
+  // immediate restart.
+  private endEpisode(): void {
+    this.gameOver = true;
+    this.physics.pause();
+
+    const lines = [
+      copy("play.episodeOver.title"),
+      "",
+      copy("play.episodeOver.score", { score: this.score }),
+      "",
+      copy("play.episodeOver.restartPrompt"),
+    ];
+    this.add
+      .text(GAME_WIDTH / 2, GAME_HEIGHT / 2, lines.join("\n"), {
+        fontFamily: "monospace",
+        fontSize: "20px",
+        color: "#ff6b00",
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setDepth(200);
+
+    const restart = () => this.scene.restart();
+    this.input.keyboard?.once("keydown", restart);
+    this.input.once("pointerdown", restart);
+  }
+
+  private updateHud(): void {
+    const x = 16;
+    const width = 200;
+    const height = 10;
+    const hpY = 44;
+    const shieldY = 60;
+
+    this.hpBar.clear();
+    this.hpBar.fillStyle(0x404040).fillRect(x, hpY, width, height);
+    const hpFrac = Phaser.Math.Clamp(this.player.defender.hp / this.player.stats.maxHp, 0, 1);
+    this.hpBar.fillStyle(0xff6b00).fillRect(x, hpY, width * hpFrac, height);
+
+    this.shieldBar.clear();
+    if (this.player.stats.maxShield > 0) {
+      this.shieldBar.fillStyle(0x404040).fillRect(x, shieldY, width, height);
+      const shieldFrac = Phaser.Math.Clamp(this.player.defender.shield / this.player.stats.maxShield, 0, 1);
+      this.shieldBar.fillStyle(0x5599ff).fillRect(x, shieldY, width * shieldFrac, height);
+    }
   }
 }

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -51,6 +51,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
 
   private gameOver = false;
   private debugOverlay!: DebugOverlay;
+  private enemySpawnCooldownMs: number = TUNING.enemies.drone.spawnIntervalMs;
 
   constructor() {
     super("Play");
@@ -129,11 +130,13 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       this.pointerTarget = null;
     });
 
-    this.time.addEvent({
-      delay: TUNING.enemies.drone.spawnIntervalMs,
-      loop: true,
-      callback: () => this.spawnEnemy(),
-    });
+    this.enemySpawnCooldownMs = this.player.effectiveEnemySpawnIntervalMs;
+
+    // Depth 50: above every gameplay sprite (player is the highest at 10) so
+    // hitbox outlines aren't hidden beneath the sprites they outline, but
+    // below the HUD/debug-overlay text (100+).
+    this.physics.world.createDebugGraphic().setDepth(50);
+    this.physics.world.drawDebug = false;
 
     this.scoreText = this.add
       .text(16, 14, copy("play.score", { score: 0 }), {
@@ -160,6 +163,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
 
   update(_time: number, delta: number) {
     this.debugOverlay.update();
+    this.physics.world.drawDebug = this.player.debugShowHitboxes;
+    if (!this.physics.world.drawDebug) this.physics.world.debugGraphic?.clear();
     if (this.gameOver) return;
 
     const dt = delta / 1000;
@@ -169,6 +174,12 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
 
     for (const req of this.player.tryFire(delta)) {
       this.fireWeapon(req);
+    }
+
+    this.enemySpawnCooldownMs -= delta;
+    if (this.enemySpawnCooldownMs <= 0) {
+      this.spawnEnemy();
+      this.enemySpawnCooldownMs += this.player.effectiveEnemySpawnIntervalMs;
     }
 
     for (const enemy of this.enemies.getChildren() as Enemy[]) {
@@ -274,13 +285,14 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       blastDamageFraction,
       homingStrength,
       forkCount,
-      req.projectileSpeed
+      req.projectileSpeed,
+      this.player.effectiveForkConeDeg
     );
   }
 
-  /** Each fork gets its own random heading (weapons.spec.todo.md) — fully random rather than a fan off the muzzle, since a fork is born from an impact point that can be anywhere on screen, not from the gun. */
-  private forkAngle(): number {
-    return Phaser.Math.FloatBetween(0, Math.PI * 2);
+  /** A fork's heading is drawn from a cone around the forking bullet's own heading at the moment of impact (not fully random) — weapons.spec.todo.md follow-up, `WeaponDef.forkConeDeg`. */
+  private forkAngle(baseAngleRad: number, coneDeg: number): number {
+    return baseAngleRad + Phaser.Math.DegToRad(Phaser.Math.FloatBetween(-coneDeg / 2, coneDeg / 2));
   }
 
   private spawnPlayerLine(
@@ -295,7 +307,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     blastDamageFraction: number,
     homingStrength: number,
     forkCount: number,
-    forkProjectileSpeed: number
+    forkProjectileSpeed: number,
+    forkConeDeg: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
     bullet?.fireLine(
@@ -310,7 +323,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       blastDamageFraction,
       homingStrength,
       forkCount,
-      forkProjectileSpeed
+      forkProjectileSpeed,
+      forkConeDeg
     );
   }
 
@@ -367,9 +381,11 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       }
     }
 
+    const bulletBody = bullet.body as Phaser.Physics.Arcade.Body;
+    const baseAngle = Math.atan2(bulletBody.velocity.y, bulletBody.velocity.x);
     const forkCount = bullet.takePendingForks();
     for (let i = 0; i < forkCount; i++) {
-      const angle = this.forkAngle();
+      const angle = this.forkAngle(baseAngle, bullet.forkConeDeg);
       const vx = Math.cos(angle) * bullet.forkProjectileSpeed;
       const vy = Math.sin(angle) * bullet.forkProjectileSpeed;
       this.spawnPlayerFork(

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -100,10 +100,14 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     this.physics.add.overlap(this.playerBullets, this.enemies, (bulletObj, enemyObj) =>
       this.onPlayerBulletHitEnemy(bulletObj as PlayerBullet, enemyObj as Enemy)
     );
-    this.physics.add.overlap(this.enemyBullets, this.player, (bulletObj) =>
+    // Arcade's overlap() always normalizes a Sprite-vs-Group pair to
+    // collideCallback(sprite, groupMember) regardless of the order the two
+    // arguments are passed in, so the player (a lone Sprite, not a Group)
+    // is always the first callback argument here.
+    this.physics.add.overlap(this.enemyBullets, this.player, (_player, bulletObj) =>
       this.onEnemyBulletHitPlayer(bulletObj as EnemyBullet)
     );
-    this.physics.add.overlap(this.enemies, this.player, (enemyObj) =>
+    this.physics.add.overlap(this.enemies, this.player, (_player, enemyObj) =>
       this.onEnemyContactPlayer(enemyObj as Enemy)
     );
 

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -35,7 +35,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   player!: Player;
   private playerBullets!: Phaser.Physics.Arcade.Group;
   private enemyBullets!: Phaser.Physics.Arcade.Group;
-  private enemies!: Phaser.Physics.Arcade.Group;
+  enemies!: Phaser.Physics.Arcade.Group;
   private stars!: Phaser.GameObjects.Group;
   private background!: Phaser.GameObjects.TileSprite;
 
@@ -253,6 +253,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const hit = this.player.stats.damage * critFactor;
     const { flatLineCount, tailHitFractions, blastDamageFraction } = req.behavior;
     const blastRadius = this.player.stats.blastRadius;
+    const homingStrength = this.player.stats.homingStrength;
     const originX = this.player.x;
     const originY = this.player.y - this.player.height / 2;
 
@@ -265,7 +266,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       numCrits,
       tailHitFractions,
       blastRadius,
-      blastDamageFraction
+      blastDamageFraction,
+      homingStrength
     );
 
     const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
@@ -282,7 +284,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
         numCrits,
         TUNING.weapons.maxHitsPerInfiniteBullet,
         blastRadius,
-        blastDamageFraction
+        blastDamageFraction,
+        homingStrength
       );
     }
   }
@@ -302,10 +305,11 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     numCrits: number,
     fractions: number[],
     blastRadius: number,
-    blastDamageFraction: number
+    blastDamageFraction: number,
+    homingStrength: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireLine(x, y, vx, vy, hit, numCrits, fractions, blastRadius, blastDamageFraction);
+    bullet?.fireLine(x, y, vx, vy, hit, numCrits, fractions, blastRadius, blastDamageFraction, homingStrength);
   }
 
   private spawnPlayerFork(
@@ -317,10 +321,11 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     numCrits: number,
     hitsAllowed: number,
     blastRadius: number,
-    blastDamageFraction: number
+    blastDamageFraction: number,
+    homingStrength: number
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
-    bullet?.fireForkedLine(x, y, vx, vy, hit, numCrits, hitsAllowed, blastRadius, blastDamageFraction);
+    bullet?.fireForkedLine(x, y, vx, vy, hit, numCrits, hitsAllowed, blastRadius, blastDamageFraction, homingStrength);
   }
 
   private onPlayerBulletHitEnemy(bullet: PlayerBullet, enemy: Enemy): void {

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -22,7 +22,7 @@ const TEX = {
   bg: "bgSpace",
 } satisfies Record<string, SpriteKey>;
 
-const DRAG_OFFSET_Y = 120; // float the ship well above the finger so it stays visible
+const DRAG_OFFSET_Y = 240; // float the ship well above the finger so it stays visible
 
 /**
  * The F6 #134 core gameplay loop — the integration point for F3 (stats),

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -22,7 +22,7 @@ const TEX = {
   bg: "bgSpace",
 } satisfies Record<string, SpriteKey>;
 
-const DRAG_OFFSET_Y = 240; // float the ship well above the finger so it stays visible
+const DRAG_OFFSET_Y = 132; // float the ship well above the finger so it stays visible
 
 /**
  * The F6 #134 core gameplay loop — the integration point for F3 (stats),

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -256,7 +256,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const homingStrength = this.player.stats.homingStrength;
     const originX = this.player.x;
     const originY = this.player.y - this.player.height / 2;
-    const angleRad = Phaser.Math.DegToRad(this.player.debugFiringAngleDeg);
+    const coneDeg = this.player.debugFiringConeDeg;
+    const angleRad = Phaser.Math.DegToRad(Phaser.Math.FloatBetween(-coneDeg / 2, coneDeg / 2));
     const vx = Math.sin(angleRad) * req.projectileSpeed;
     const vy = -Math.cos(angleRad) * req.projectileSpeed;
 

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -7,6 +7,7 @@ import type { SpriteKey } from "../sprites";
 import { Player, Enemy, EnemyBullet, PlayerBullet } from "../entities";
 import type { PlayerFireRequest, ShmupPlayScene } from "../entities";
 import { applyDamage, reflexBulletSpeedMult, resolveHit, tickShieldRegen } from "../systems/combat";
+import { DebugOverlay } from "../debug/DebugOverlay";
 
 // Logical roles -> sprite registry keys (specs/games/shmup/content-and-assets.spec.md).
 // Code never inlines a draw call or file path — it asks for one of these keys,
@@ -49,6 +50,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   private shieldBar!: Phaser.GameObjects.Graphics;
 
   private gameOver = false;
+  private debugOverlay!: DebugOverlay;
 
   constructor() {
     super("Play");
@@ -152,9 +154,12 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
 
     this.hpBar = this.add.graphics().setDepth(100);
     this.shieldBar = this.add.graphics().setDepth(100);
+
+    this.debugOverlay = new DebugOverlay(this, this.player);
   }
 
   update(_time: number, delta: number) {
+    this.debugOverlay.update();
     if (this.gameOver) return;
 
     const dt = delta / 1000;

--- a/games/shmup/src/sprites/manifest.json
+++ b/games/shmup/src/sprites/manifest.json
@@ -34,5 +34,23 @@
     "frameCount": 1,
     "frameDuration": 100,
     "placeholder": { "shape": "rect", "color": "#ffffff" }
+  },
+  "bulletEnemy": {
+    "category": "projectiles",
+    "path": "projectiles/projectile_bullet_enemy_01.png",
+    "frameWidth": 4,
+    "frameHeight": 12,
+    "frameCount": 1,
+    "frameDuration": 100,
+    "placeholder": { "shape": "rect", "color": "#ff3344" }
+  },
+  "bgSpace": {
+    "category": "effects",
+    "path": "effects/fx_bg_space_01.png",
+    "frameWidth": 64,
+    "frameHeight": 64,
+    "frameCount": 1,
+    "frameDuration": 100,
+    "placeholder": { "shape": "rect", "color": "#160900" }
   }
 }

--- a/games/shmup/src/systems/combat/applyDamage.test.ts
+++ b/games/shmup/src/systems/combat/applyDamage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyDamage, tickShieldRegen } from "./applyDamage";
+import { applyDamage, applyLifesteal, tickHpRegen, tickShieldRegen } from "./applyDamage";
 import { TUNING } from "../../tuning";
 import type { Defender } from "./types";
 
@@ -77,5 +77,45 @@ describe("tickShieldRegen", () => {
     const d = defender({ shield: 95, shieldRegenDelayRemaining: 0 });
     tickShieldRegen(d, 100, 10);
     expect(d.shield).toBe(100);
+  });
+});
+
+describe("tickHpRegen", () => {
+  it("adds hpRegenPerSecond * dt to hp", () => {
+    const d = defender({ hp: 50 });
+    tickHpRegen(d, 100, 10, 1);
+    expect(d.hp).toBe(60);
+  });
+
+  it("never regens past maxHp", () => {
+    const d = defender({ hp: 95 });
+    tickHpRegen(d, 100, 10, 10);
+    expect(d.hp).toBe(100);
+  });
+
+  it("is a no-op at zero hpRegen", () => {
+    const d = defender({ hp: 50 });
+    tickHpRegen(d, 100, 0, 1);
+    expect(d.hp).toBe(50);
+  });
+});
+
+describe("applyLifesteal", () => {
+  it("heals hp by damageDealt * lifesteal", () => {
+    const d = defender({ hp: 50 });
+    applyLifesteal(d, 100, 40, 0.5);
+    expect(d.hp).toBe(70);
+  });
+
+  it("never heals past maxHp", () => {
+    const d = defender({ hp: 95 });
+    applyLifesteal(d, 100, 40, 0.5);
+    expect(d.hp).toBe(100);
+  });
+
+  it("is a no-op at zero lifesteal", () => {
+    const d = defender({ hp: 50 });
+    applyLifesteal(d, 100, 40, 0);
+    expect(d.hp).toBe(50);
   });
 });

--- a/games/shmup/src/systems/combat/applyDamage.test.ts
+++ b/games/shmup/src/systems/combat/applyDamage.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { applyDamage, tickShieldRegen } from "./applyDamage";
+import { TUNING } from "../../tuning";
+import type { Defender } from "./types";
+
+function defender(overrides: Partial<Defender> = {}): Defender {
+  return { hp: 100, shield: 0, shieldRegenDelayRemaining: 0, ...overrides };
+}
+
+describe("applyDamage", () => {
+  it("a dodge (roll below evasion) deals zero damage and doesn't touch hp/shield", () => {
+    const d = defender({ hp: 50, shield: 20 });
+    const result = applyDamage(d, 30, 0, 0.5, () => 0.1);
+    expect(result.dodged).toBe(true);
+    expect(result.shieldDamage).toBe(0);
+    expect(result.hpDamage).toBe(0);
+    expect(d.hp).toBe(50);
+    expect(d.shield).toBe(20);
+  });
+
+  it("shield absorbs at full value, ignoring armor, before HP is touched", () => {
+    const d = defender({ hp: 100, shield: 20 });
+    const result = applyDamage(d, 30, 0.9, 0, () => 0.99);
+    expect(result.dodged).toBe(false);
+    expect(result.shieldDamage).toBe(20);
+    expect(d.shield).toBe(0);
+    // overflow = 10, armor 0.9 mitigates it down to 1
+    expect(result.hpDamage).toBeCloseTo(1, 10);
+    expect(d.hp).toBeCloseTo(99, 10);
+  });
+
+  it("armor only mitigates the overflow past shield, never the shielded portion", () => {
+    const d = defender({ hp: 100, shield: 100 });
+    const result = applyDamage(d, 30, 0.9, 0, () => 0.99);
+    expect(result.shieldDamage).toBe(30);
+    expect(result.hpDamage).toBe(0);
+    expect(d.hp).toBe(100);
+  });
+
+  it("with no shield, armor mitigates the full hit", () => {
+    const d = defender({ hp: 100, shield: 0 });
+    const result = applyDamage(d, 50, 0.5, 0, () => 0.99);
+    expect(result.shieldDamage).toBe(0);
+    expect(result.hpDamage).toBeCloseTo(25, 10);
+    expect(d.hp).toBeCloseTo(75, 10);
+  });
+
+  it("hp is floored at 0 and marks defeated", () => {
+    const d = defender({ hp: 10, shield: 0 });
+    const result = applyDamage(d, 1000, 0, 0, () => 0.99);
+    expect(d.hp).toBe(0);
+    expect(result.defeated).toBe(true);
+  });
+
+  it("a non-dodged hit resets the shield regen delay", () => {
+    const d = defender({ hp: 100, shield: 50, shieldRegenDelayRemaining: 0 });
+    applyDamage(d, 10, 0, 0, () => 0.99);
+    expect(d.shieldRegenDelayRemaining).toBe(TUNING.combat.shieldRegenDelay);
+  });
+});
+
+describe("tickShieldRegen", () => {
+  it("does not regen while the delay is still counting down", () => {
+    const d = defender({ shield: 0, shieldRegenDelayRemaining: 2 });
+    tickShieldRegen(d, 100, 1);
+    expect(d.shield).toBe(0);
+    expect(d.shieldRegenDelayRemaining).toBe(1);
+  });
+
+  it("regens as a fraction of maxShield/s once the delay elapses", () => {
+    const d = defender({ shield: 0, shieldRegenDelayRemaining: 0 });
+    tickShieldRegen(d, 100, 1);
+    expect(d.shield).toBeCloseTo(100 * TUNING.combat.shieldRegenFracPerSecond, 10);
+  });
+
+  it("never regens past maxShield", () => {
+    const d = defender({ shield: 95, shieldRegenDelayRemaining: 0 });
+    tickShieldRegen(d, 100, 10);
+    expect(d.shield).toBe(100);
+  });
+});

--- a/games/shmup/src/systems/combat/applyDamage.ts
+++ b/games/shmup/src/systems/combat/applyDamage.ts
@@ -1,0 +1,55 @@
+/**
+ * Defense pipeline (combat.spec.todo.md), incoming hit, no hull lives:
+ *   1. EVASION  chance = Evasion/(Evasion+Ke) -> dodged => 0 damage
+ *   2. SHIELD   absorbs at FULL value, armor IGNORED: shield -= HIT
+ *   3. OVERFLOW past shield continues down
+ *   4. ARMOR    mitigates overflow only: toHP = overflow * (1 - Armor/(Armor+Ka))
+ *   5. HP       -= toHP -> HP <= 0 ends the episode (run-structure.spec.todo.md)
+ *
+ * `evasion` and `armor` arrive already hyperbolic-transformed by F3's
+ * computeStats() (stats.spec.md: archetype "hyperbolic", effective =
+ * raw/(raw+K)) — they ARE the dodge chance / mitigation fraction already,
+ * so this module never touches a K constant itself.
+ */
+import { TUNING } from "../../tuning";
+import type { ApplyDamageResult, Defender } from "./types";
+
+export function rollEvasion(evasion: number, rng: () => number = Math.random): boolean {
+  return rng() < evasion;
+}
+
+export function applyDamage(
+  defender: Defender,
+  hit: number,
+  armor: number,
+  evasion: number,
+  rng: () => number = Math.random
+): ApplyDamageResult {
+  if (rollEvasion(evasion, rng)) {
+    return { dodged: true, shieldDamage: 0, hpDamage: 0, defeated: false };
+  }
+
+  let remaining = hit;
+  let shieldDamage = 0;
+  if (defender.shield > 0) {
+    shieldDamage = Math.min(defender.shield, remaining);
+    defender.shield -= shieldDamage;
+    remaining -= shieldDamage;
+  }
+
+  const hpDamage = remaining * (1 - armor);
+  defender.hp = Math.max(0, defender.hp - hpDamage);
+  defender.shieldRegenDelayRemaining = TUNING.combat.shieldRegenDelay;
+
+  return { dodged: false, shieldDamage, hpDamage, defeated: defender.hp <= 0 };
+}
+
+/** Shield regen ticks down its delay, then refills as a fraction of maxShield/s (combat.spec.todo.md). Called once per frame. */
+export function tickShieldRegen(defender: Defender, maxShield: number, dt: number): void {
+  if (defender.shieldRegenDelayRemaining > 0) {
+    defender.shieldRegenDelayRemaining = Math.max(0, defender.shieldRegenDelayRemaining - dt);
+    return;
+  }
+  if (defender.shield >= maxShield) return;
+  defender.shield = Math.min(maxShield, defender.shield + maxShield * TUNING.combat.shieldRegenFracPerSecond * dt);
+}

--- a/games/shmup/src/systems/combat/applyDamage.ts
+++ b/games/shmup/src/systems/combat/applyDamage.ts
@@ -53,3 +53,15 @@ export function tickShieldRegen(defender: Defender, maxShield: number, dt: numbe
   if (defender.shield >= maxShield) return;
   defender.shield = Math.min(maxShield, defender.shield + maxShield * TUNING.combat.shieldRegenFracPerSecond * dt);
 }
+
+/** HP Regen is the only self-regen HP has (combat.spec.todo.md: "armored core; no self-regen except the HP Regen stat") — a flat HP/s rate, no delay/gate unlike shield. Called once per frame. */
+export function tickHpRegen(defender: Defender, maxHp: number, hpRegenPerSecond: number, dt: number): void {
+  if (hpRegenPerSecond <= 0 || defender.hp >= maxHp) return;
+  defender.hp = Math.min(maxHp, defender.hp + hpRegenPerSecond * dt);
+}
+
+/** Lifesteal restores HP only (combat.spec.todo.md), as a fraction of the damage just dealt. */
+export function applyLifesteal(defender: Defender, maxHp: number, damageDealt: number, lifesteal: number): void {
+  if (lifesteal <= 0 || damageDealt <= 0) return;
+  defender.hp = Math.min(maxHp, defender.hp + damageDealt * lifesteal);
+}

--- a/games/shmup/src/systems/combat/index.ts
+++ b/games/shmup/src/systems/combat/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./resolveHit";
+export * from "./applyDamage";
+export * from "./reflexes";

--- a/games/shmup/src/systems/combat/reflexes.test.ts
+++ b/games/shmup/src/systems/combat/reflexes.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { reflexBulletSpeedMult, reflexMoveSpeedMult } from "./reflexes";
+import { TUNING } from "../../tuning";
+
+describe("reflexBulletSpeedMult / reflexMoveSpeedMult", () => {
+  it("zero reflexes leaves speed untouched", () => {
+    expect(reflexBulletSpeedMult(0)).toBe(1);
+    expect(reflexMoveSpeedMult(0)).toBe(1);
+  });
+
+  it("approaches but never reaches the bullet slow cap as reflexes grows", () => {
+    const mult = reflexBulletSpeedMult(1_000_000);
+    expect(mult).toBeGreaterThan(1 - TUNING.combat.reflexBulletSlowCap);
+    expect(mult).toBeCloseTo(1 - TUNING.combat.reflexBulletSlowCap, 3);
+  });
+
+  it("approaches but never reaches the move slow cap as reflexes grows", () => {
+    const mult = reflexMoveSpeedMult(1_000_000);
+    expect(mult).toBeGreaterThan(1 - TUNING.combat.reflexMoveSlowCap);
+    expect(mult).toBeCloseTo(1 - TUNING.combat.reflexMoveSlowCap, 3);
+  });
+
+  it("the two channels use independent K constants and so can diverge", () => {
+    const reflexes = TUNING.combat.reflexMoveK;
+    // At reflexes == reflexMoveK, the move channel is at half its cap.
+    expect(reflexMoveSpeedMult(reflexes)).toBeCloseTo(1 - TUNING.combat.reflexMoveSlowCap / 2, 10);
+  });
+});

--- a/games/shmup/src/systems/combat/reflexes.ts
+++ b/games/shmup/src/systems/combat/reflexes.ts
@@ -1,0 +1,24 @@
+/**
+ * Reflexes (combat.spec.todo.md / stats.spec.md): one raw unboundedMult stat
+ * feeding two separate hyperbolic channels, each with its own K and cap —
+ * applied downstream by combat (here), not by computeStats(). Reflexes is
+ * unboundedMult with no archetype transform, so computeStats()'s output for
+ * it already equals the raw pre-transform value; no separate aggregateRaw
+ * call is needed by callers.
+ */
+import { TUNING } from "../../tuning";
+
+function hyperbolicSlow(raw: number, k: number, cap: number): number {
+  if (raw <= 0) return 0;
+  return cap * (raw / (raw + k));
+}
+
+/** Multiplier applied to enemy bullet speed (floors toward ~20% of normal per combat.spec.todo.md). */
+export function reflexBulletSpeedMult(reflexes: number): number {
+  return 1 - hyperbolicSlow(reflexes, TUNING.combat.reflexBulletK, TUNING.combat.reflexBulletSlowCap);
+}
+
+/** Multiplier applied to enemy movement speed (floors toward ~50% of normal per combat.spec.todo.md). */
+export function reflexMoveSpeedMult(reflexes: number): number {
+  return 1 - hyperbolicSlow(reflexes, TUNING.combat.reflexMoveK, TUNING.combat.reflexMoveSlowCap);
+}

--- a/games/shmup/src/systems/combat/resolveHit.test.ts
+++ b/games/shmup/src/systems/combat/resolveHit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { rollCrit, resolveHit } from "./resolveHit";
+
+interface CritCase {
+  name: string;
+  given: { critChance: number; critDamage: number; roll: number };
+  then: { numCrits: number; critFactor: number };
+}
+
+const CRIT_CASES: CritCase[] = [
+  {
+    name: "below 100% chance with a high roll never crits",
+    given: { critChance: 0.5, critDamage: 0.5, roll: 0.9 },
+    then: { numCrits: 0, critFactor: 1 },
+  },
+  {
+    name: "below 100% chance with a low roll crits once",
+    given: { critChance: 0.5, critDamage: 0.5, roll: 0.1 },
+    then: { numCrits: 1, critFactor: 1.5 },
+  },
+  {
+    name: "100% chance is a guaranteed single crit",
+    given: { critChance: 1, critDamage: 1, roll: 0.99 },
+    then: { numCrits: 1, critFactor: 2 },
+  },
+  {
+    name: "250% chance guarantees 2 crits, +50% chance of a 3rd (low roll hits the 3rd)",
+    given: { critChance: 2.5, critDamage: 1, roll: 0.1 },
+    then: { numCrits: 3, critFactor: 8 },
+  },
+  {
+    name: "250% chance guarantees 2 crits, the 3rd is NOT guaranteed (high roll misses it)",
+    given: { critChance: 2.5, critDamage: 1, roll: 0.9 },
+    then: { numCrits: 2, critFactor: 4 },
+  },
+];
+
+describe("rollCrit", () => {
+  it.each(CRIT_CASES)("$name", ({ given, then }) => {
+    const result = rollCrit(given.critChance, given.critDamage, () => given.roll);
+    expect(result.numCrits).toBe(then.numCrits);
+    expect(result.critFactor).toBeCloseTo(then.critFactor, 10);
+  });
+});
+
+describe("resolveHit", () => {
+  it("multiplies stats.damage by the crit factor", () => {
+    const hit = resolveHit({ damage: 10, critChance: 1, critDamage: 1 }, () => 0.5);
+    expect(hit).toBeCloseTo(20, 10);
+  });
+
+  it("a guaranteed-zero crit chance returns exactly stats.damage", () => {
+    const hit = resolveHit({ damage: 7, critChance: 0, critDamage: 5 }, () => 0.5);
+    expect(hit).toBeCloseTo(7, 10);
+  });
+});

--- a/games/shmup/src/systems/combat/resolveHit.ts
+++ b/games/shmup/src/systems/combat/resolveHit.ts
@@ -1,0 +1,44 @@
+/**
+ * Damage-per-hit (combat.spec.todo.md):
+ *   HIT = (Base + Flat) x DamageMult x CritFactor x ConditionalMult
+ *
+ * stats.damage (an "unboundedMult" F3 stat — see stats.spec.md) already
+ * folds (Base + Flat) x DamageMult: TUNING.stats.damageBase is the Base,
+ * weapon/item flat mods are the Flat, and percent mods are DamageMult's
+ * additive-within-category / multiplicative-across-category pool. This
+ * module applies the one piece `special(crit, DR)` explicitly defers to
+ * combat: the crit roll. ConditionalMult stays at 1 until a conditional-tag
+ * system (e.g. "+50% vs ground") exists; no system in this repo grants one
+ * yet.
+ */
+import type { DamageStats } from "./types";
+
+export interface CritRoll {
+  numCrits: number;
+  critFactor: number;
+}
+
+/**
+ * NumCrits = floor(CritChance) + (rand() < frac(CritChance) ? 1 : 0)
+ * CritFactor = (1 + CritDamage) ^ NumCrits
+ * Crit chance is uncapped (stats.spec.md) — 250% is 2 guaranteed crits plus
+ * a 50% chance of a 3rd, not clamped to 100%.
+ */
+export function rollCrit(critChance: number, critDamage: number, rng: () => number = Math.random): CritRoll {
+  const guaranteed = Math.floor(critChance);
+  const frac = critChance - guaranteed;
+  const numCrits = guaranteed + (rng() < frac ? 1 : 0);
+  const critFactor = Math.pow(1 + critDamage, numCrits);
+  return { numCrits, critFactor };
+}
+
+/**
+ * Resolved once per shot fired (weapons.spec.todo.md: "Crit is resolved once
+ * per shot fired, baked into the base HIT upstream... never re-rolled per
+ * pierce impact or per fork") — callers fire this once per shot and reuse
+ * the result for every line/fork that shot produces.
+ */
+export function resolveHit(stats: DamageStats, rng: () => number = Math.random): number {
+  const { critFactor } = rollCrit(stats.critChance, stats.critDamage, rng);
+  return stats.damage * critFactor;
+}

--- a/games/shmup/src/systems/combat/types.ts
+++ b/games/shmup/src/systems/combat/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Combat (F6 #134) consumes the F3 stat schema for the damage/defense
+ * pipeline (combat.spec.todo.md). No parallel stat definitions here.
+ */
+import type { StatBlock } from "../stats";
+
+export type DamageStats = Pick<StatBlock, "damage" | "critChance" | "critDamage">;
+
+/** armor/evasion arrive already hyperbolic-transformed by computeStats() — they ARE the mitigation/dodge fractions. */
+export type DefenseStats = Pick<StatBlock, "armor" | "evasion">;
+
+/** Mutable combat state for one ship (player or — in principle — any future shielded enemy). */
+export interface Defender {
+  hp: number;
+  shield: number;
+  /** Seconds remaining before shield regen resumes; reset to TUNING.combat.shieldRegenDelay on any non-dodged hit. */
+  shieldRegenDelayRemaining: number;
+}
+
+export interface ApplyDamageResult {
+  dodged: boolean;
+  shieldDamage: number;
+  hpDamage: number;
+  defeated: boolean;
+}

--- a/games/shmup/src/systems/effects/types.ts
+++ b/games/shmup/src/systems/effects/types.ts
@@ -52,6 +52,15 @@ export interface WeaponDef {
    * stay single-target; high values (chain lightning) lean into forking hard.
    */
   pierceDecay?: number;
+  /**
+   * Per-weapon authored property: a forked line's heading (when Pierce
+   * overflows past 100%) is drawn from a cone of this full width, in
+   * degrees, around the forking bullet's heading at the moment of impact —
+   * not fully at random. Defaults to `TUNING.weapons.defaultForkConeDeg`
+   * when omitted. A narrow cone keeps forks reading as "this weapon, but
+   * more of it"; a wide one sprays them.
+   */
+  forkConeDeg?: number;
   /** Stats this weapon's tooltip should display itself scaling with. */
   scalesWith: StatId[];
   mods: ScalingModifier[];

--- a/games/shmup/src/tuning/index.ts
+++ b/games/shmup/src/tuning/index.ts
@@ -36,6 +36,22 @@ export const TUNING = {
     reflexMoveK: 1,
     reflexBulletSlowCap: 0.8,
     reflexMoveSlowCap: 0.5,
+    // Focus (chassis.spec.todo.md): hold to move slower for precision. The
+    // default chassis (F10 #138) hasn't landed yet, so F6 ships the
+    // universal base behavior plus a hitbox shrink (genre-standard "graze
+    // box") as the vertical-slice default; a future chassis quirk may
+    // override hitboxRadiusFocus instead of relying on this global.
+    focusSpeedMult: 0.45,
+    hitboxRadiusNormal: 6,
+    hitboxRadiusFocus: 3,
+    // Shield (combat.spec.todo.md): "auto-refills after ShieldDelay s without
+    // a hit, at ShieldRegen/s." Shield regen rate isn't one of the 16 main
+    // stats, so its rate lives here as a fraction of Max Shield per second.
+    shieldRegenDelay: 3,
+    shieldRegenFracPerSecond: 0.25,
+    // Brief invulnerability after any non-dodged hit — without this, an
+    // overlapping enemy/bullet would re-deal damage every physics step.
+    playerIFrameMs: 500,
   },
   hype: {
     // hypeBase, k_idle, k_level, baseDecay, M (ScoreMult depth) — F7
@@ -75,5 +91,48 @@ export const TUNING = {
     // each dealt blastDamageFraction of HIT.
     blastTargetsPerPx: 0.01,
     blastDamageFraction: 0.5,
+    // Auto-fire cadence at attackSpeed = 1 (shots/second); actual cadence is
+    // baseFireRate * stats.attackSpeed (combat.spec.todo.md: "weapons fire
+    // on their own cadence (attack speed)").
+    baseFireRate: 2.5,
+    // F6 performance ceilings (weapons.spec.todo.md's "hard performance
+    // ceiling that bounds worst-case concurrent projectiles") — the engine's
+    // own maxForksPerImpact/maxTailHits guard the pure math; these guard the
+    // actual pooled bullets a single shot is allowed to spawn/keep piercing.
+    maxForkedBulletsPerShot: 12,
+    maxHitsPerInfiniteBullet: 50,
+  },
+  // Object-pool ceilings (F6 #134: "Arcade Physics groups with object
+  // pooling for bullets and enemies"). Sized well above any realistic
+  // worst-case concurrent count so pooling never silently drops shots in
+  // normal play, while still bounding worst-case memory/collision cost.
+  performance: {
+    maxPlayerBullets: 240,
+    maxEnemyBullets: 120,
+    maxEnemies: 40,
+  },
+  // Basic placeholder enemy (run-structure.spec.todo.md's Difficulty (D)
+  // scaling owns real enemy stat curves — F8 #136 — this is the one
+  // hand-authored "drone" needed for F6's vertical slice and for grazing
+  // (F7 #135) to have something to graze).
+  enemies: {
+    drone: {
+      maxHp: 18,
+      speed: 130,
+      fireIntervalMs: 1400,
+      bulletDamage: 6,
+      bulletSpeed: 260,
+      contactDamage: 10,
+      scoreValue: 10,
+      spawnIntervalMs: 850,
+    },
+  },
+  // Purely cosmetic — background scroll / starfield drift — but still tuning,
+  // not magic numbers inline in PlayScene.
+  visuals: {
+    bgScrollSpeed: 40,
+    starCount: 70,
+    starMinSpeed: 40,
+    starMaxSpeed: 180,
   },
 } as const;

--- a/games/shmup/src/tuning/index.ts
+++ b/games/shmup/src/tuning/index.ts
@@ -102,6 +102,28 @@ export const TUNING = {
     maxForkedBulletsPerShot: 12,
     maxHitsPerInfiniteBullet: 50,
   },
+  // Homing (F6 #134's exotic Homing Strength stat). A bullet only seeks
+  // within a circle that leads it along its current heading — center =
+  // bullet position + heading * radius, so the near edge sits at the
+  // bullet's nose and the far edge is 2x radius ahead. This guarantees a
+  // homing bullet never locks onto (and U-turns into) something it just
+  // flew past. Once locked, it keeps turning toward that target until it
+  // dies — no re-targeting mid-flight. Pierce decays Homing Strength the
+  // same way it decays damage: a pierced bullet's remaining hits use
+  // homingStrength * the same tailHitFraction applied to damage; forked
+  // "infinite" lines don't decay damage, so they don't decay homing either.
+  homing: {
+    // 100% Homing Strength scans this many seconds of travel ahead (scaled
+    // by the firing weapon's own projectile speed, so fast and slow weapons
+    // get a proportionally sane circle instead of one fixed pixel radius).
+    seekAheadSeconds: 0.35,
+    // Hard cap regardless of how high Homing Strength is stacked.
+    maxRadiusPx: 280,
+    // Turn rate once locked scales linearly with Homing Strength, capped
+    // well short of an instant snap-to-target even at extreme values.
+    turnRateDegPerSecPerStrength: 180,
+    maxTurnRateDegPerSec: 360,
+  },
   // Object-pool ceilings (F6 #134: "Arcade Physics groups with object
   // pooling for bullets and enemies"). Sized well above any realistic
   // worst-case concurrent count so pooling never silently drops shots in

--- a/games/shmup/src/tuning/index.ts
+++ b/games/shmup/src/tuning/index.ts
@@ -82,6 +82,12 @@ export const TUNING = {
     // Never let an authored pierceDecay reach/exceed 95% — keeps the fork
     // chain converging quickly regardless of how high pierce is stacked.
     maxPierceDecay: 0.95,
+    // Fork heading spread (weapons.spec.todo.md follow-up): a forked line's
+    // heading is drawn from a cone around the bullet's heading at the
+    // moment it forked (not fully random), full width in degrees.
+    // Authored per-weapon (WeaponDef.forkConeDeg), defaulting to this value
+    // when omitted.
+    defaultForkConeDeg: 60,
     // Hard safety caps against pathological stat stacking — not meaningful
     // gameplay limits, just backstops against unbounded array growth.
     maxForksPerImpact: 1000,
@@ -156,5 +162,16 @@ export const TUNING = {
     starCount: 70,
     starMinSpeed: 40,
     starMaxSpeed: 180,
+  },
+  // Debug-only (C12 #151 follow-up) — not gameplay tuning, but kept here so
+  // every numeric constant still has one home. Per-entity-category outline
+  // colors for the debug overlay's hitbox toggle.
+  debug: {
+    hitboxColors: {
+      player: 0x00ffff,
+      enemy: 0xff3333,
+      playerBullet: 0x33ff33,
+      enemyBullet: 0xffaa00,
+    },
   },
 } as const;


### PR DESCRIPTION
## Summary

Closes #134. Replaces the placeholder `PlayScene` with the real core gameplay loop, wiring together the systems landed in F3–F5:

- **Player** (`entities/Player.ts`) — speed, fire cadence, and damage all read from `computeStats`/`resolveLoadout` (F3 + F4), not hardcoded. Focus mode (Shift/tap-hold) slows movement via `TUNING.combat.focusSpeedMult` and shrinks the hitbox (`hitboxRadiusNormal`/`hitboxRadiusFocus`) per the vertical-slice default.
- **Weapons fire through the real F4 engine** — `resolveProjectileBehavior`'s pierce decomposition drives `PlayerBullet`: a decaying pierce line for ≤100% pierce, and forked "infinite" lines (capped by `TUNING.weapons.maxForkedBulletsPerShot`/`maxHitsPerInfiniteBullet`) for overflow above 100%. Crit is resolved once per shot fired (`resolveHit`) and shared across every pierce impact/fork, per the locked combat spec.
- **New `systems/combat` module** — `resolveHit` (HIT formula + crit), `applyDamage` (evasion → shield → armor → HP pipeline, no hull lives), and `reflexes` (the two hyperbolic bullet/move-speed channels fed by the Reflexes stat).
- **Real blast-radius spatial query** — on each fresh primary impact, `PlayScene` scans nearby active enemies within `stats.blastRadius` px and applies `blastDamageFraction`, replacing F4's pure-math density placeholder with the actual targeting F6 owns.
- **Object pooling** — `PlayerBullet`, `EnemyBullet`, and `Enemy` are pooled Arcade-physics groups (`TUNING.performance.max*`), self-managing activation/recycling since `Group.get()` only repositions inactive members.
- **Sprite registry (F5)** — all entities render via `SpriteKey`s from the manifest (`shipPlayer`, `bulletPlayer`, `bulletEnemy` (new), `enemyDrone`, `bgSpace` (new)) through `ensurePlaceholderTextures`, never primitives drawn ad hoc.
- **No-hull-lives model** — HP ≤ 0 ends the episode (`endEpisode()`), shows a game-over screen with final score, and restarts on any key/tap (full map-return flow is out of scope until F8/F11 land).
- Added `TUNING.visuals` (background scroll speed, starfield tuning) and new `copy.ts` keys for the HUD/episode-over flow — no magic numbers or inline strings.

## Test plan

- [x] `npm run build` (root, with the CLAUDE.md-mandated filtered grep) — zero TypeScript errors
- [x] `npx vitest run` in `games/shmup` — 10 test files, 97 tests passing
- [x] Manually verified in a browser via Playwright against the dev server: boot screen renders correctly, ship spawns and moves via drag/keyboard, auto-fire spawns bullets that travel upward, enemies spawn and descend, a kill increments the score (confirmed 0 → 10), HUD (score + HP bar) updates live, background/starfield scroll
- [ ] Manual playtest in an actual browser (not just headless screenshots) for feel/balance — left to a human reviewer since balance numbers are placeholders pending F8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143dp1q9ATBqHJvv5mXU2hm


---
_Generated by [Claude Code](https://claude.ai/code/session_0143dp1q9ATBqHJvv5mXU2hm)_