### PR TITLE
Add swappable SaveStore for SHMUP, default to Doors FS

### DIFF
--- a/games/shmup/README.md
+++ b/games/shmup/README.md
@@ -28,7 +28,26 @@ games/shmup/         (design specs live at repo-root specs/games/shmup/*.spec.to
     systems/         stat/effect/economy engines land here (F3/F4/F9…)
     sprites/         sprite registry — placeholder primitives + manifest.json (F5)
     assets/sprites/  bundled sprite art, wired by path from sprites/manifest.json (F5)
+    save/            SaveStore — swappable save/settings persistence (S1)
 ```
+
+## Save storage
+
+Gameplay/menu code depends only on the `SaveStore` interface exported from
+`src/save/index.ts` — never a concrete store. That one file is the
+composition root: a single `SAVE_BACKEND` constant picks which implementation
+backs `saveStore`.
+
+- **Default — `DoorsFsSaveStore`:** persists into the Doors 97 virtual
+  filesystem (same-origin read/write of the shared `ns97_fs_v1` localStorage
+  blob, mirroring `src/sprites/fsOverride.ts`'s read-only precedent). Saves
+  appear as real, hackable files under `C:\Programs\Games\SHMUP\Saves\` in
+  the Doors 97 file browser.
+- **Fallback — `LocalSaveStore`:** plain `localStorage`, namespaced under
+  `shmup:save:`, for contexts without a Doors 97 FS to write into.
+
+See [`specs/games/shmup/save.spec.md`](../../specs/games/shmup/save.spec.md)
+for the full design.
 
 ## Dev (once F1 wires the workspace)
 

--- a/games/shmup/src/save/doorsFsSaveStore.test.ts
+++ b/games/shmup/src/save/doorsFsSaveStore.test.ts
@@ -15,6 +15,7 @@ interface FsNodeLite {
   name: string;
   parentId: string | null;
   content?: string;
+  system?: boolean;
 }
 
 function nodes(...entries: FsNodeLite[]): Map<string, FsNodeLite> {
@@ -33,6 +34,11 @@ describe("ensureSavesFolder", () => {
     const savesId = ensureSavesFolder(tree);
     expect(savesId).toBe("fs:shmup-saves");
     expect(tree.get("fs:root")?.kind).toBe("folder");
+    // Must match seed.ts's root node exactly (name "C:\\", system: true) so a
+    // later Doors load doesn't find a malformed, unprotected root left behind
+    // by SHMUP bootstrapping the FS blob first.
+    expect(tree.get("fs:root")?.name).toBe("C:\\");
+    expect(tree.get("fs:root")?.system).toBe(true);
     expect(tree.get("fs:programs")?.parentId).toBe("fs:root");
     expect(tree.get("fs:games")?.parentId).toBe("fs:programs");
     expect(tree.get("fs:shmup")?.parentId).toBe("fs:games");

--- a/games/shmup/src/save/doorsFsSaveStore.test.ts
+++ b/games/shmup/src/save/doorsFsSaveStore.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  saveFileName,
+  findChild,
+  ensureSavesFolder,
+  readSave,
+  writeSave,
+  removeSave,
+  listSaves,
+} from "./doorsFsSaveStore";
+
+interface FsNodeLite {
+  id: string;
+  kind: "file" | "folder";
+  name: string;
+  parentId: string | null;
+  content?: string;
+}
+
+function nodes(...entries: FsNodeLite[]): Map<string, FsNodeLite> {
+  return new Map(entries.map((n) => [n.id, n]));
+}
+
+describe("saveFileName", () => {
+  it("uppercases the key and appends .DAT", () => {
+    expect(saveFileName("career-checkpoint")).toBe("CAREER-CHECKPOINT.DAT");
+  });
+});
+
+describe("ensureSavesFolder", () => {
+  it("builds the full ROOT > Programs > Games > SHMUP > Saves chain from empty", () => {
+    const tree = nodes();
+    const savesId = ensureSavesFolder(tree);
+    expect(savesId).toBe("fs:shmup-saves");
+    expect(tree.get("fs:root")?.kind).toBe("folder");
+    expect(tree.get("fs:programs")?.parentId).toBe("fs:root");
+    expect(tree.get("fs:games")?.parentId).toBe("fs:programs");
+    expect(tree.get("fs:shmup")?.parentId).toBe("fs:games");
+    expect(tree.get("fs:shmup-saves")?.parentId).toBe("fs:shmup");
+  });
+
+  it("does not overwrite nodes that already exist (idempotent against a real Doors-seeded tree)", () => {
+    const tree = nodes(
+      { id: "fs:root", kind: "folder", name: "C:", parentId: null },
+      { id: "fs:programs", kind: "folder", name: "Programs", parentId: "fs:root" },
+      { id: "fs:games", kind: "folder", name: "Games", parentId: "fs:programs" },
+      { id: "fs:shmup", kind: "folder", name: "SHMUP", parentId: "fs:games" }
+    );
+    ensureSavesFolder(tree);
+    // Pre-existing nodes keep their identity (same object reference = untouched)
+    expect(tree.get("fs:shmup")?.name).toBe("SHMUP");
+    expect(tree.size).toBe(5);
+  });
+});
+
+describe("write/read/remove/list round trip", () => {
+  it("writes a save into a freshly-bootstrapped tree and reads it back", () => {
+    const tree = nodes();
+    writeSave(tree, "settings", '{"sound":true}');
+    expect(readSave(tree, "settings")).toBe('{"sound":true}');
+  });
+
+  it("returns null reading a key that was never written", () => {
+    const tree = nodes();
+    expect(readSave(tree, "nope")).toBeNull();
+  });
+
+  it("read does not mutate the tree (no folder bootstrap on a pure read)", () => {
+    const tree = nodes();
+    readSave(tree, "settings");
+    expect(tree.size).toBe(0);
+  });
+
+  it("overwrites an existing save in place rather than creating a duplicate file", () => {
+    const tree = nodes();
+    writeSave(tree, "settings", "v1");
+    writeSave(tree, "settings", "v2");
+    expect(readSave(tree, "settings")).toBe("v2");
+    const savesChildren = [...tree.values()].filter((n) => n.parentId === "fs:shmup-saves");
+    expect(savesChildren).toHaveLength(1);
+  });
+
+  it("round-trips through JSON serialization, mirroring a localStorage blob reload", () => {
+    const tree = nodes();
+    writeSave(tree, "career", '{"season":3}');
+    const serialized = JSON.stringify([...tree.entries()]);
+    const reloaded = new Map(JSON.parse(serialized));
+    expect(readSave(reloaded as Map<string, FsNodeLite>, "career")).toBe('{"season":3}');
+  });
+
+  it("removes a save so a later read returns null", () => {
+    const tree = nodes();
+    writeSave(tree, "settings", "v1");
+    removeSave(tree, "settings");
+    expect(readSave(tree, "settings")).toBeNull();
+  });
+
+  it("remove on a key that was never written is a no-op", () => {
+    const tree = nodes();
+    expect(() => removeSave(tree, "nope")).not.toThrow();
+  });
+
+  it("lists keys by prefix, case-insensitively, stripping the .DAT extension", () => {
+    const tree = nodes();
+    writeSave(tree, "slot-1", "a");
+    writeSave(tree, "slot-2", "b");
+    writeSave(tree, "settings", "c");
+    expect(listSaves(tree, "slot-").sort()).toEqual(["slot-1", "slot-2"]);
+    expect(listSaves(tree, "SLOT-").sort()).toEqual(["slot-1", "slot-2"]);
+    expect(listSaves(tree, "")).toHaveLength(3);
+  });
+
+  it("list on a tree with no Saves folder yet returns an empty array", () => {
+    expect(listSaves(nodes(), "")).toEqual([]);
+  });
+});
+
+describe("findChild", () => {
+  it("is case-insensitive", () => {
+    const tree = nodes({ id: "fs:a", kind: "file", name: "SETTINGS.DAT", parentId: "fs:shmup-saves" });
+    expect(findChild(tree, "fs:shmup-saves", "settings.dat")?.id).toBe("fs:a");
+  });
+});

--- a/games/shmup/src/save/doorsFsSaveStore.ts
+++ b/games/shmup/src/save/doorsFsSaveStore.ts
@@ -85,17 +85,20 @@ export function findChild(
 
 /** Idempotent: creates any missing link in the ROOT > Programs > Games > SHMUP > Saves chain, using Doors' own stable ids, without touching nodes that already exist. */
 export function ensureSavesFolder(nodes: Map<string, FsNodeLite>): string {
-  const ensureFolder = (id: string, name: string, parentId: string | null) => {
+  const ensureFolder = (id: string, name: string, parentId: string | null, system: boolean) => {
     const existing = nodes.get(id);
     if (existing?.kind === "folder") return;
     const now = Date.now();
-    nodes.set(id, { id, kind: "folder", name, parentId, createdAt: now, modifiedAt: now, system: false });
+    nodes.set(id, { id, kind: "folder", name, parentId, createdAt: now, modifiedAt: now, system });
   };
-  ensureFolder(ROOT_ID, "C:", null);
-  ensureFolder(PROGRAMS_ID, "Programs", ROOT_ID);
-  ensureFolder(GAMES_ID, "Games", PROGRAMS_ID);
-  ensureFolder(SHMUP_FOLDER_ID, "SHMUP", GAMES_ID);
-  ensureFolder(SHMUP_SAVES_ID, "Saves", SHMUP_FOLDER_ID);
+  // Name/system flags here must match seed.ts exactly — if SHMUP bootstraps
+  // the FS blob first (no Doors load yet on this origin), a later Doors load
+  // finds these nodes already present and skips re-seeding them as-is.
+  ensureFolder(ROOT_ID, "C:\\", null, true);
+  ensureFolder(PROGRAMS_ID, "Programs", ROOT_ID, false);
+  ensureFolder(GAMES_ID, "Games", PROGRAMS_ID, false);
+  ensureFolder(SHMUP_FOLDER_ID, "SHMUP", GAMES_ID, false);
+  ensureFolder(SHMUP_SAVES_ID, "Saves", SHMUP_FOLDER_ID, false);
   return SHMUP_SAVES_ID;
 }
 

--- a/games/shmup/src/save/doorsFsSaveStore.ts
+++ b/games/shmup/src/save/doorsFsSaveStore.ts
@@ -1,0 +1,184 @@
+/**
+ * Default SaveStore — persists into the Doors 97 virtual filesystem so
+ * saves/settings show up in the file browser (the hackable-FS vision; see
+ * root CLAUDE.md "Unified Virtual Filesystem"). SHMUP is a separately-built
+ * Vite bundle served full-page at /shmup/, not embedded in the Doors 97
+ * React app, so importing the live `fsStore` singleton would pull the whole
+ * Doors app (React, the full desktop seed data) into this package's bundle.
+ * Both apps run on the same origin and share localStorage, so this is a
+ * same-origin reader/writer of the shared "ns97_fs_v1" blob, mirroring just
+ * the slice of FileSystemStore's node shape and mutation logic this needs —
+ * the same precedent as ../sprites/fsOverride.ts, but read-write instead of
+ * read-only.
+ *
+ * The target folder (C:\Programs\Games\SHMUP\Saves\) is seeded by the main
+ * app in filesystem/seed.ts and filesystem/migrate() under the stable id
+ * SHMUP_SAVES_ID, so this store can address it directly without a path
+ * walk. If that folder doesn't exist yet (e.g. /shmup/ was hit on an origin
+ * that has never loaded Doors 97), writes bootstrap the same chain of
+ * stable ids Doors itself uses, so a later Doors load recognizes and merges
+ * with it instead of creating a duplicate.
+ */
+import type { SaveStore } from "./types";
+
+const FS_STORAGE_KEY = "ns97_fs_v1";
+const ROOT_ID = "fs:root";
+const PROGRAMS_ID = "fs:programs";
+const GAMES_ID = "fs:games";
+const SHMUP_FOLDER_ID = "fs:shmup";
+const SHMUP_SAVES_ID = "fs:shmup-saves";
+
+// Metadata fields beyond id/kind/name/parentId/content are optional here so
+// tests can build minimal fixtures; writeSave/ensureSavesFolder always fill
+// every field with a concrete value when they create a node, matching the
+// real Doors FSFile/FSFolder shape (filesystem/types.ts) the file browser expects.
+interface FsFileLite {
+  id: string;
+  kind: "file";
+  name: string;
+  parentId: string | null;
+  content?: string;
+  createdAt?: number;
+  modifiedAt?: number;
+  fileType?: string;
+  mimeType?: string;
+  system?: boolean;
+  readonly?: boolean;
+}
+
+interface FsFolderLite {
+  id: string;
+  kind: "folder";
+  name: string;
+  parentId: string | null;
+  createdAt?: number;
+  modifiedAt?: number;
+  system?: boolean;
+}
+
+type FsNodeLite = FsFileLite | FsFolderLite;
+
+function genId(): string {
+  return "fs:" + Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}
+
+/** SaveStore keys map to DOS-flavored filenames, matching SCORES.DAT/SAVE.DAT elsewhere in the FS. */
+export function saveFileName(key: string): string {
+  return key.toUpperCase() + ".DAT";
+}
+
+function keyFromFileName(name: string): string {
+  return name.replace(/\.DAT$/i, "").toLowerCase();
+}
+
+export function findChild(
+  nodes: Map<string, FsNodeLite>,
+  parentId: string,
+  name: string
+): FsNodeLite | undefined {
+  const lower = name.toLowerCase();
+  for (const node of nodes.values()) {
+    if (node.parentId === parentId && node.name.toLowerCase() === lower) return node;
+  }
+  return undefined;
+}
+
+/** Idempotent: creates any missing link in the ROOT > Programs > Games > SHMUP > Saves chain, using Doors' own stable ids, without touching nodes that already exist. */
+export function ensureSavesFolder(nodes: Map<string, FsNodeLite>): string {
+  const ensureFolder = (id: string, name: string, parentId: string | null) => {
+    const existing = nodes.get(id);
+    if (existing?.kind === "folder") return;
+    const now = Date.now();
+    nodes.set(id, { id, kind: "folder", name, parentId, createdAt: now, modifiedAt: now, system: false });
+  };
+  ensureFolder(ROOT_ID, "C:", null);
+  ensureFolder(PROGRAMS_ID, "Programs", ROOT_ID);
+  ensureFolder(GAMES_ID, "Games", PROGRAMS_ID);
+  ensureFolder(SHMUP_FOLDER_ID, "SHMUP", GAMES_ID);
+  ensureFolder(SHMUP_SAVES_ID, "Saves", SHMUP_FOLDER_ID);
+  return SHMUP_SAVES_ID;
+}
+
+export function readSave(nodes: Map<string, FsNodeLite>, key: string): string | null {
+  if (!nodes.has(SHMUP_SAVES_ID)) return null;
+  const file = findChild(nodes, SHMUP_SAVES_ID, saveFileName(key));
+  return file?.kind === "file" ? file.content ?? null : null;
+}
+
+export function writeSave(nodes: Map<string, FsNodeLite>, key: string, value: string): void {
+  const savesId = ensureSavesFolder(nodes);
+  const name = saveFileName(key);
+  const existing = findChild(nodes, savesId, name);
+  const now = Date.now();
+  if (existing?.kind === "file") {
+    nodes.set(existing.id, { ...existing, content: value, modifiedAt: now });
+    return;
+  }
+  const id = genId();
+  nodes.set(id, {
+    id, kind: "file", name, parentId: savesId,
+    createdAt: now, modifiedAt: now,
+    fileType: "dat", content: value, mimeType: "text/plain",
+    system: false, readonly: false,
+  });
+}
+
+export function removeSave(nodes: Map<string, FsNodeLite>, key: string): void {
+  if (!nodes.has(SHMUP_SAVES_ID)) return;
+  const file = findChild(nodes, SHMUP_SAVES_ID, saveFileName(key));
+  if (file) nodes.delete(file.id);
+}
+
+export function listSaves(nodes: Map<string, FsNodeLite>, prefix: string): string[] {
+  if (!nodes.has(SHMUP_SAVES_ID)) return [];
+  const upperPrefix = prefix.toUpperCase();
+  const out: string[] = [];
+  for (const node of nodes.values()) {
+    if (node.parentId === SHMUP_SAVES_ID && node.kind === "file" && node.name.toUpperCase().startsWith(upperPrefix)) {
+      out.push(keyFromFileName(node.name));
+    }
+  }
+  return out;
+}
+
+function loadNodes(): Map<string, FsNodeLite> {
+  if (typeof window === "undefined") return new Map();
+  try {
+    const raw = window.localStorage.getItem(FS_STORAGE_KEY);
+    if (!raw) return new Map();
+    return new Map(JSON.parse(raw) as [string, FsNodeLite][]);
+  } catch {
+    return new Map();
+  }
+}
+
+function persistNodes(nodes: Map<string, FsNodeLite>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(FS_STORAGE_KEY, JSON.stringify([...nodes.entries()]));
+  } catch {
+    /* quota exceeded or storage disabled — silently drop, mirrors StorageAdapter.ts */
+  }
+}
+
+export class DoorsFsSaveStore implements SaveStore {
+  read(key: string): string | null {
+    return readSave(loadNodes(), key);
+  }
+
+  write(key: string, value: string): void {
+    const nodes = loadNodes();
+    writeSave(nodes, key, value);
+    persistNodes(nodes);
+  }
+
+  remove(key: string): void {
+    const nodes = loadNodes();
+    removeSave(nodes, key);
+    persistNodes(nodes);
+  }
+
+  list(prefix: string): string[] {
+    return listSaves(loadNodes(), prefix);
+  }
+}

--- a/games/shmup/src/save/index.ts
+++ b/games/shmup/src/save/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The single composition root for save/settings storage (S1 #171). Every
+ * other module imports `saveStore` from here and the `SaveStore` type —
+ * never `DoorsFsSaveStore`/`LocalSaveStore` directly — so the backing
+ * mechanism stays swappable behind one switch.
+ */
+import type { SaveStore } from "./types";
+import { DoorsFsSaveStore } from "./doorsFsSaveStore";
+import { LocalSaveStore } from "./localSaveStore";
+
+export type { SaveStore } from "./types";
+
+const SAVE_BACKEND: "doors-fs" | "local" = "doors-fs";
+
+export const saveStore: SaveStore =
+  SAVE_BACKEND === "doors-fs" ? new DoorsFsSaveStore() : new LocalSaveStore();

--- a/games/shmup/src/save/localSaveStore.test.ts
+++ b/games/shmup/src/save/localSaveStore.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { LocalSaveStore } from "./localSaveStore";
+
+// vitest's "node" environment (vitest.config.ts) has no window/localStorage —
+// the same environment SHMUP's other tests run in (see fsOverride.test.ts).
+// A minimal in-memory Storage shim lets us exercise the real read/write/list
+// paths rather than just the typeof-window guards.
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+describe("LocalSaveStore", () => {
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    (globalThis as { window?: unknown }).window = { localStorage: new MemoryStorage() };
+  });
+
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  it("returns null for a key that was never written", () => {
+    expect(new LocalSaveStore().read("settings")).toBeNull();
+  });
+
+  it("round-trips a write through read, namespaced under shmup:save:", () => {
+    const store = new LocalSaveStore();
+    store.write("settings", '{"sound":true}');
+    expect(store.read("settings")).toBe('{"sound":true}');
+    expect(window.localStorage.getItem("shmup:save:settings")).toBe('{"sound":true}');
+  });
+
+  it("remove clears a previously written key", () => {
+    const store = new LocalSaveStore();
+    store.write("settings", "v1");
+    store.remove("settings");
+    expect(store.read("settings")).toBeNull();
+  });
+
+  it("list returns keys under a prefix, stripped of the namespace", () => {
+    const store = new LocalSaveStore();
+    store.write("slot-1", "a");
+    store.write("slot-2", "b");
+    store.write("settings", "c");
+    expect(store.list("slot-").sort()).toEqual(["slot-1", "slot-2"]);
+  });
+
+  it("is a no-op (not a throw) when window is unavailable", () => {
+    (globalThis as { window?: unknown }).window = undefined;
+    const store = new LocalSaveStore();
+    expect(() => store.write("settings", "v1")).not.toThrow();
+    expect(store.read("settings")).toBeNull();
+    expect(store.list("")).toEqual([]);
+    expect(() => store.remove("settings")).not.toThrow();
+  });
+});

--- a/games/shmup/src/save/localSaveStore.ts
+++ b/games/shmup/src/save/localSaveStore.ts
@@ -1,0 +1,48 @@
+import type { SaveStore } from "./types";
+
+const KEY_PREFIX = "shmup:save:";
+
+/** Standalone fallback — plain localStorage, namespaced so it can't collide with the Doors FS blob or other apps' keys. */
+export class LocalSaveStore implements SaveStore {
+  read(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(KEY_PREFIX + key);
+    } catch {
+      return null;
+    }
+  }
+
+  write(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(KEY_PREFIX + key, value);
+    } catch {
+      /* quota exceeded or storage disabled — silently drop, mirrors StorageAdapter.ts */
+    }
+  }
+
+  remove(key: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(KEY_PREFIX + key);
+    } catch {
+      /* silent */
+    }
+  }
+
+  list(prefix: string): string[] {
+    if (typeof window === "undefined") return [];
+    try {
+      const fullPrefix = KEY_PREFIX + prefix;
+      const out: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const k = window.localStorage.key(i);
+        if (k && k.startsWith(fullPrefix)) out.push(k.slice(KEY_PREFIX.length));
+      }
+      return out;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/games/shmup/src/save/types.ts
+++ b/games/shmup/src/save/types.ts
@@ -1,0 +1,13 @@
+/**
+ * The persistence port — gameplay/menu/settings code depends only on this
+ * interface, never a concrete storage mechanism (see games/shmup/README.md
+ * "Save storage" and specs/games/shmup/save.spec.md). Values are strings;
+ * callers JSON-encode/decode their own payloads.
+ */
+export interface SaveStore {
+  read(key: string): string | null;
+  write(key: string, value: string): void;
+  remove(key: string): void;
+  /** Optional: lists keys whose name starts with `prefix` (save slots, hall of fame, etc.). */
+  list?(prefix: string): string[];
+}

--- a/specs/games/shmup/overview.spec.todo.md
+++ b/specs/games/shmup/overview.spec.todo.md
@@ -48,4 +48,5 @@ A **career** = ~5 **Seasons**, each a node map ending in a **Season Finale boss*
 | `audience-and-score.spec.todo.md` | studio audience, crowd comments, score & results | T10 #161, C14 #163 |
 | `content-and-assets.spec.md` | sprite registry, asset pipeline — **implemented** | F5 #133 |
 | `content-and-assets.spec.todo.md` | copy registry | F2 #130 |
+| `save.spec.md` | swappable SaveStore, Doors-FS-backed default — **implemented** | S1 #171 |
 | `tuning.spec.todo.md` | the single home of every numeric lever | (all) |

--- a/specs/games/shmup/save.spec.md
+++ b/specs/games/shmup/save.spec.md
@@ -85,7 +85,6 @@ and write/remove swallow quota-exceeded errors — mirrors
 
 ## Related
 
-- [`overview.spec.todo.md`](./overview.spec.todo.md)
 - [`content-and-assets.spec.md`](./content-and-assets.spec.md) — the
   `fsOverride.ts` read-only precedent this design extends to read-write
 - `src/experiences/NsDoors97/filesystem/` — `seed.ts`, `FileSystemStore.ts`

--- a/specs/games/shmup/save.spec.md
+++ b/specs/games/shmup/save.spec.md
@@ -1,0 +1,92 @@
+# Shmup — Save Storage Spec
+
+> Issue: **S1 #171**. Implemented in `games/shmup/src/save/`. Status: current,
+> shippable behavior.
+
+## The interface
+
+Gameplay, menu, and settings code depend only on the `SaveStore` port — never
+a concrete storage mechanism:
+
+```ts
+interface SaveStore {
+  read(key: string): string | null;
+  write(key: string, value: string): void;
+  remove(key: string): void;
+  list?(prefix: string): string[]; // save slots, hall of fame, etc.
+}
+```
+
+Values are strings; callers JSON-encode/decode their own payloads. `list`
+returns keys whose name starts with `prefix`, with any storage-specific
+namespacing/extension stripped back off.
+
+## One composition root
+
+`games/shmup/src/save/index.ts` is the only place that picks a concrete
+implementation. Every other module imports `saveStore` (the instance) and the
+`SaveStore` type from this one file — never `DoorsFsSaveStore` or
+`LocalSaveStore` directly:
+
+```ts
+const SAVE_BACKEND: "doors-fs" | "local" = "doors-fs";
+
+export const saveStore: SaveStore =
+  SAVE_BACKEND === "doors-fs" ? new DoorsFsSaveStore() : new LocalSaveStore();
+```
+
+Swapping backends (e.g. for a future IndexedDB-backed store) means writing a
+new `SaveStore` implementation and changing this one constant.
+
+## Default: `DoorsFsSaveStore` — Doors 97 virtual filesystem
+
+SHMUP is a separately-built Vite bundle served full-page at `/shmup/`, not
+embedded in the Doors 97 React app, so it can't import the live `fsStore`
+singleton without pulling the whole Doors app (React, full desktop seed data)
+into this package's bundle. Instead `DoorsFsSaveStore` is a same-origin
+reader/writer of the shared `ns97_fs_v1` localStorage blob both apps read —
+the same precedent as `src/sprites/fsOverride.ts` (content-and-assets spec),
+but read-write instead of read-only.
+
+- Keys map to DOS-flavored filenames: `key.toUpperCase() + ".DAT"` (matches
+  `SCORES.DAT`/`SAVE.DAT` elsewhere in the FS).
+- Files live under `C:\Programs\Games\SHMUP\Saves\`, seeded under the stable
+  id `SHMUP_SAVES_ID` (`fs:shmup-saves`) in the main app's `seed.ts` and
+  `migrate()` — both fresh installs and existing sessions get the folder.
+- Writes are idempotent against an already-Doors-seeded tree: if `/shmup/` is
+  hit before Doors 97 has ever loaded on that origin, `write()` bootstraps
+  the same `ROOT → Programs → Games → SHMUP → Saves` chain of stable ids
+  Doors itself uses, so a later Doors load recognizes and merges with it
+  instead of creating a duplicate.
+- A second write to an existing key updates that file's `content` in place —
+  no duplicate file is created.
+- Because saves are real `FSFile` nodes, they're visible and hackable in the
+  Doors 97 file browser and Notebook, same as `SCORES.DAT` elsewhere in the
+  FS (root `CLAUDE.md` — "NS Doors 97 is hackable").
+
+## Fallback: `LocalSaveStore` — plain localStorage
+
+The standalone fallback for contexts without a Doors 97 FS to write into.
+Keys are namespaced under `shmup:save:` in `localStorage` directly. Every
+method is a no-op (not a throw) when `window`/`localStorage` is unavailable,
+and write/remove swallow quota-exceeded errors — mirrors
+`StorageAdapter.ts`'s `LocalStorageAdapter` in the main app.
+
+## Verification
+
+- Unit tests: `doorsFsSaveStore.test.ts` (pure `Map`-based logic — folder
+  bootstrap, idempotency, write/read/remove/list, JSON round-trip simulating
+  a real localStorage reload) and `localSaveStore.test.ts` (round-trip
+  against an in-memory `Storage` shim, namespacing, no-window no-op).
+- Manual end-to-end: load Doors 97 (seeds the FS) → load the deployed
+  `/shmup/` build → `saveStore.write()` → reload `/shmup/` → `saveStore.read()`
+  returns the same value → back in Doors 97, the same `ns97_fs_v1` blob shows
+  a `*.DAT` file node parented under `fs:shmup-saves`.
+
+## Related
+
+- [`overview.spec.todo.md`](./overview.spec.todo.md)
+- [`content-and-assets.spec.md`](./content-and-assets.spec.md) — the
+  `fsOverride.ts` read-only precedent this design extends to read-write
+- `src/experiences/NsDoors97/filesystem/` — `seed.ts`, `FileSystemStore.ts`
+  (`migrate()`), `types.ts` (`SHMUP_SAVES_ID`) in the main app

--- a/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
+++ b/src/experiences/NsDoors97/filesystem/FileSystemStore.ts
@@ -5,7 +5,7 @@ import {
   MJ_SCORES_ID, MJ_TILES_FOLDER_ID, MJ_STATE_ID,
   JB_SCORES_ID, BB_SCORES_ID,
   JP_SCORES_ID, JP_STATE_ID, JP_IMAGE_ID,
-  SHMUP_FOLDER_ID, SHMUP_EXE_ID, SHMUP_SPRITES_ID,
+  SHMUP_FOLDER_ID, SHMUP_EXE_ID, SHMUP_SPRITES_ID, SHMUP_SAVES_ID,
 } from "./types";
 import { StorageAdapter, LocalStorageAdapter } from "./StorageAdapter";
 import { seedFileSystem } from "./seed";
@@ -375,6 +375,19 @@ export class FileSystemStore {
           };
           this.nodes.set(folder.id, folder);
         }
+        changed = true;
+      }
+    }
+
+    // Ensure SHMUP's Saves folder exists (existing sessions) — DoorsFsSaveStore's target
+    if (!this.nodes.has(SHMUP_SAVES_ID)) {
+      const shmupDir = this.getNodeByPath("C:\\Programs\\Games\\SHMUP");
+      if (shmupDir?.kind === "folder") {
+        this.nodes.set(SHMUP_SAVES_ID, {
+          id: SHMUP_SAVES_ID, kind: "folder", name: "Saves",
+          parentId: shmupDir.id, createdAt: Date.now(), modifiedAt: Date.now(),
+          system: false,
+        } as FSFolder);
         changed = true;
       }
     }

--- a/src/experiences/NsDoors97/filesystem/seed.ts
+++ b/src/experiences/NsDoors97/filesystem/seed.ts
@@ -5,7 +5,7 @@ import {
   NS_ART_BACKUP_ID, DH_SCORES_ID, TR_SCORES_ID, SYSTEM_INI_ID,
   GOOBER_FOLDER_ID, GOOBER_SPRITES_ID, CK_SCORES_ID,
   MJ_SCORES_ID, MJ_TILES_FOLDER_ID, MJ_STATE_ID,
-  SHMUP_FOLDER_ID, SHMUP_EXE_ID, SHMUP_SPRITES_ID,
+  SHMUP_FOLDER_ID, SHMUP_EXE_ID, SHMUP_SPRITES_ID, SHMUP_SAVES_ID,
   JB_SCORES_ID, BB_SCORES_ID,
   JP_SCORES_ID, JP_STATE_ID, JP_IMAGE_ID,
 } from "./types";
@@ -392,6 +392,8 @@ export function seedFileSystem(store: FileSystemStore): void {
   store.createFolder(shmupSpritesDir.id, "enemies");
   store.createFolder(shmupSpritesDir.id, "effects");
   store.createFolder(shmupSpritesDir.id, "projectiles");
+  // SaveStore's Doors-FS adapter writes save/settings files here (S1 #171).
+  store.createFolder(shmupDir.id, "Saves", { id: SHMUP_SAVES_ID });
 
   const tttDir = store.createFolder(GAMES_ID, "Tic-Tac-Toe");
   store.createFile(tttDir.id, "Tic-Tac-Toe.exe", { fileType: "exe", appId: "tictactoe" });

--- a/src/experiences/NsDoors97/filesystem/types.ts
+++ b/src/experiences/NsDoors97/filesystem/types.ts
@@ -28,6 +28,7 @@ export const JP_IMAGE_ID       = "fs:jp-custom-image";
 export const SHMUP_FOLDER_ID   = "fs:shmup";
 export const SHMUP_EXE_ID      = "fs:shmup-exe";
 export const SHMUP_SPRITES_ID  = "fs:shmup-sprites";
+export const SHMUP_SAVES_ID    = "fs:shmup-saves";
 
 export type FSFileType =
   | "text" | "exe" | "bat" | "sys" | "scr" | "drv"


### PR DESCRIPTION
## Summary
- Adds a small `SaveStore` interface (`read`/`write`/`remove`/optional `list`) that gameplay/menu code depends on instead of any concrete storage mechanism, per #171.
- Default `DoorsFsSaveStore` persists saves into the shared Doors 97 virtual filesystem (same-origin read/write of the `ns97_fs_v1` localStorage blob, extending the existing read-only `fsOverride.ts` precedent), so saves appear as real, hackable `.DAT` files under `C:\Programs\Games\SHMUP\Saves\` in the Doors 97 file browser.
- `LocalSaveStore` is the plain-`localStorage` fallback, namespaced under `shmup:save:`.
- `games/shmup/src/save/index.ts` is the single composition root (`SAVE_BACKEND` constant) that picks which implementation backs the exported `saveStore`.
- Adds the `SHMUP_SAVES_ID` stable FS node to both `seed.ts` (fresh installs) and `migrate()` (existing sessions), per the FS architecture's mandatory rule.
- Documents the system in `games/shmup/README.md` and `specs/games/shmup/save.spec.md`.

## Test plan
- [x] `npm run test:unit -w games/shmup` — 121 tests pass, including 18 new tests across `doorsFsSaveStore.test.ts` and `localSaveStore.test.ts`
- [x] `npm run build` (root) passes with zero TypeScript errors per the repo's mandated filtered-error check
- [x] Manual round-trip verification against the deployed `/shmup/` build with Playwright: load Doors 97 (seeds FS) → load `/shmup/` → `saveStore.write()` → reload `/shmup/` → `saveStore.read()` returns the same value → `list()` sees the key → back in Doors 97, the raw `ns97_fs_v1` blob shows a `VERIFY-TEST.DAT` file node parented under `fs:shmup-saves`
- [x] Confirmed no gameplay/menu code imports `DoorsFsSaveStore`/`LocalSaveStore` directly — only `save/index.ts` does

https://claude.ai/code/session_014QXQW8iupU5STQhYSmDPo4


---
_Generated by [Claude Code](https://claude.ai/code/session_014QXQW8iupU5STQhYSmDPo4)_