### PR TITLE
[Shmup][F10/C7] Chassis framework, default chassis + Ikaruga polarity chassis

### DIFF
--- a/games/shmup/README.md
+++ b/games/shmup/README.md
@@ -25,7 +25,7 @@ games/shmup/         (design specs live at repo-root specs/games/shmup/*.spec.to
     scenes/          BootScene, MapScene (Season node-map), PlayScene (F6 loop), ResolveScene (episode->map cash-in)
     content/         copy registry ("copy is an asset")
     tuning/          numeric levers ("tuning is an asset")
-    systems/         stat/effect/economy engines land here (F3/F4/F9…)
+    systems/         stat/effect/chassis/economy engines land here (F3/F4/F10/F9…)
     sprites/         sprite registry — placeholder primitives + manifest.json (F5)
     assets/sprites/  bundled sprite art, wired by path from sprites/manifest.json (F5)
     save/            SaveStore — swappable save/settings persistence (S1)

--- a/games/shmup/src/content/chassis.test.ts
+++ b/games/shmup/src/content/chassis.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_CHASSIS, chassisById } from "./chassis";
+import { resolveLoadout } from "../systems/effects";
+import { TUNING } from "../tuning";
+
+describe("chassisById", () => {
+  it("resolves the default chassis by id", () => {
+    expect(chassisById("default")).toBe(DEFAULT_CHASSIS);
+  });
+
+  it("falls back to the default chassis for an unknown id, same convention as weaponById", () => {
+    expect(chassisById("not-a-real-chassis")).toBe(DEFAULT_CHASSIS);
+  });
+});
+
+describe("DEFAULT_CHASSIS — applied through resolveLoadout with zero engine changes", () => {
+  it("carries the framework's default 6 weapon-slot cap", () => {
+    expect(DEFAULT_CHASSIS.maxWeaponSlots).toBe(TUNING.weapons.maxWeaponSlots);
+  });
+
+  it("has no identity quirks — a clean baseline chassis", () => {
+    expect(DEFAULT_CHASSIS.mods).toEqual([]);
+    expect(DEFAULT_CHASSIS.statBase).toBeUndefined();
+  });
+
+  it("slots into resolveLoadout via the existing chassisBase/chassisMods/maxWeaponSlots fields", () => {
+    const { stats } = resolveLoadout({
+      chassisBase: DEFAULT_CHASSIS.statBase,
+      chassisMods: DEFAULT_CHASSIS.mods,
+      maxWeaponSlots: DEFAULT_CHASSIS.maxWeaponSlots,
+    });
+    // No quirks means the resolved stats equal the all-defaults baseline.
+    expect(stats).toEqual(resolveLoadout({}).stats);
+  });
+
+  it("opts into a Focus hitbox-shrink perk on top of the universal base Focus action", () => {
+    expect(DEFAULT_CHASSIS.focus.speedMult).toBe(TUNING.combat.focusSpeedMult);
+    expect(DEFAULT_CHASSIS.focus.hitboxRadiusFocus).toBe(TUNING.combat.hitboxRadiusFocus);
+    expect(DEFAULT_CHASSIS.hitboxRadiusNormal).toBe(TUNING.combat.hitboxRadiusNormal);
+  });
+});

--- a/games/shmup/src/content/chassis.test.ts
+++ b/games/shmup/src/content/chassis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_CHASSIS, chassisById } from "./chassis";
+import { DEFAULT_CHASSIS, IKARUGA_CHASSIS, ALL_CHASSIS, chassisById } from "./chassis";
 import { resolveLoadout } from "../systems/effects";
 import { TUNING } from "../tuning";
 
@@ -8,8 +8,45 @@ describe("chassisById", () => {
     expect(chassisById("default")).toBe(DEFAULT_CHASSIS);
   });
 
+  it("resolves the Ikaruga chassis by id", () => {
+    expect(chassisById("ikaruga")).toBe(IKARUGA_CHASSIS);
+  });
+
   it("falls back to the default chassis for an unknown id, same convention as weaponById", () => {
     expect(chassisById("not-a-real-chassis")).toBe(DEFAULT_CHASSIS);
+  });
+
+  it("registers every chassis in ALL_CHASSIS", () => {
+    expect(ALL_CHASSIS).toEqual(expect.arrayContaining([DEFAULT_CHASSIS, IKARUGA_CHASSIS]));
+  });
+});
+
+describe("IKARUGA_CHASSIS — the polarity flagship (chassis.spec.md's Epic 2 validation)", () => {
+  it("has no static stat quirks — its identity is entirely the polarity hook", () => {
+    expect(IKARUGA_CHASSIS.mods).toEqual([]);
+    expect(IKARUGA_CHASSIS.statBase).toBeUndefined();
+  });
+
+  it("has no Focus hitbox-shrink perk (that's DEFAULT_CHASSIS's own quirk, not a rule)", () => {
+    expect(IKARUGA_CHASSIS.focus.hitboxRadiusFocus).toBeUndefined();
+  });
+
+  it("carries a polarity config sourced from TUNING.chassis.ikaruga", () => {
+    expect(IKARUGA_CHASSIS.polarity).toEqual({
+      initial: "red",
+      damageMultiplierSame: TUNING.chassis.ikaruga.damageMultiplierSame,
+      damageMultiplierOpposite: TUNING.chassis.ikaruga.damageMultiplierOpposite,
+      absorbHypeBase: TUNING.chassis.ikaruga.absorbHypeBase,
+    });
+  });
+
+  it("still slots into resolveLoadout with zero engine changes, same as DEFAULT_CHASSIS", () => {
+    const { stats } = resolveLoadout({
+      chassisBase: IKARUGA_CHASSIS.statBase,
+      chassisMods: IKARUGA_CHASSIS.mods,
+      maxWeaponSlots: IKARUGA_CHASSIS.maxWeaponSlots,
+    });
+    expect(stats).toEqual(resolveLoadout({}).stats);
   });
 });
 

--- a/games/shmup/src/content/chassis.ts
+++ b/games/shmup/src/content/chassis.ts
@@ -27,8 +27,35 @@ export const DEFAULT_CHASSIS: ChassisDef = {
   mods: [],
 };
 
+/**
+ * The Ikaruga-style polarity-switch flagship (chassis.spec.md's Epic 2
+ * validation, C7 #146): no static stat quirks and no Focus hitbox-shrink
+ * perk — its entire identity is the `polarity` hook, resolved by
+ * `systems/combat/polarity.ts`'s pure functions against
+ * `Player.polarity`/`Enemy.polarity`/bullet polarity. Same 6 slots and
+ * hitbox as the default frame; the tradeoff is all offense/defense, not
+ * chassis geometry.
+ */
+export const IKARUGA_CHASSIS: ChassisDef = {
+  id: "ikaruga",
+  name: copy("chassis.ikaruga.name"),
+  maxWeaponSlots: TUNING.weapons.maxWeaponSlots,
+  hitboxRadiusNormal: TUNING.combat.hitboxRadiusNormal,
+  focus: {
+    speedMult: TUNING.combat.focusSpeedMult,
+  },
+  mods: [],
+  polarity: {
+    initial: "red",
+    damageMultiplierSame: TUNING.chassis.ikaruga.damageMultiplierSame,
+    damageMultiplierOpposite: TUNING.chassis.ikaruga.damageMultiplierOpposite,
+    absorbHypeBase: TUNING.chassis.ikaruga.absorbHypeBase,
+  },
+};
+
 const CHASSIS_REGISTRY: Record<string, ChassisDef> = {
   [DEFAULT_CHASSIS.id]: DEFAULT_CHASSIS,
+  [IKARUGA_CHASSIS.id]: IKARUGA_CHASSIS,
 };
 
 /** Every chassis in the registry. */

--- a/games/shmup/src/content/chassis.ts
+++ b/games/shmup/src/content/chassis.ts
@@ -1,0 +1,40 @@
+/**
+ * Chassis registry (chassis.spec.md, F10 #138). A chassis is pure data run
+ * through the same `resolveLoadout()` path as weapons/items — the framework
+ * lands here in `systems/chassis/types.ts`; this file only supplies content.
+ * C7 #146 (Ikaruga polarity) / C8 #147 (more chassis) grow this registry.
+ */
+import { copy } from "./accessors";
+import { TUNING } from "../tuning";
+import type { ChassisDef } from "../systems/chassis";
+
+/**
+ * The default chassis (chassis.spec.md's "ship a clean DEFAULT chassis"): no
+ * identity quirks, the framework-standard 6 weapon slots, and the
+ * genre-standard Focus hitbox-shrink perk (`hitboxRadiusFocus`) — the base
+ * Focus action itself (slower movement) is universal to every chassis, not
+ * this chassis's doing; see `ChassisFocusDef.speedMult`.
+ */
+export const DEFAULT_CHASSIS: ChassisDef = {
+  id: "default",
+  name: copy("chassis.default.name"),
+  maxWeaponSlots: TUNING.weapons.maxWeaponSlots,
+  hitboxRadiusNormal: TUNING.combat.hitboxRadiusNormal,
+  focus: {
+    speedMult: TUNING.combat.focusSpeedMult,
+    hitboxRadiusFocus: TUNING.combat.hitboxRadiusFocus,
+  },
+  mods: [],
+};
+
+const CHASSIS_REGISTRY: Record<string, ChassisDef> = {
+  [DEFAULT_CHASSIS.id]: DEFAULT_CHASSIS,
+};
+
+/** Every chassis in the registry. */
+export const ALL_CHASSIS: ChassisDef[] = Object.values(CHASSIS_REGISTRY);
+
+/** Looks up a ChassisDef by id — unknown ids fall back to the default rather than crashing (same convention as `weaponById`). */
+export function chassisById(id: string): ChassisDef {
+  return CHASSIS_REGISTRY[id] ?? DEFAULT_CHASSIS;
+}

--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -42,9 +42,11 @@ export const COPY = {
   "enemy.placeholder.name": "Drone",
   "enemy.placeholder.description": "Cheap, expendable, everywhere.",
 
-  // ---- Chassis (chassis.spec.md, F10 #138) ----
+  // ---- Chassis (chassis.spec.md, F10 #138 / C7 #146) ----
   "chassis.default.name": "Roadrunner Mk. I",
   "chassis.default.description": "No frills, no gimmicks. A balanced stock frame.",
+  "chassis.ikaruga.name": "Chromashift Mk. I",
+  "chassis.ikaruga.description": "Switch polarity to absorb same-color fire into Hype. Wrong-color shots bounce off enemies harmlessly.",
 
   // ---- Passive items (items-and-brands.spec.todo.md, F9 #137) ----
   "item.lucky-rabbits-foot.name": "Lucky Rabbit's Foot",
@@ -106,6 +108,13 @@ export const COPY = {
   "map.newCareer.confirm": "TAP AGAIN TO CONFIRM",
   "map.desynced.title": "MAP ERROR",
   "map.desynced.flavor": "No reachable episodes from here. Start a new career to keep playing.",
+  "map.hangar": "HANGAR",
+
+  // ---- Hangar / chassis selection (chassis.spec.md, F10 #138 / C7 #146) ----
+  "hangar.title": "HANGAR",
+  "hangar.hint": "Tap a chassis to equip it",
+  "hangar.equipped": "EQUIPPED",
+  "hangar.back": "BACK TO MAP",
 
   // ---- Level-up (economy.spec.todo.md, F9 #137): end-of-level break only, batched, never mid-play ----
   "levelup.title": "LEVEL UP!",

--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -42,6 +42,10 @@ export const COPY = {
   "enemy.placeholder.name": "Drone",
   "enemy.placeholder.description": "Cheap, expendable, everywhere.",
 
+  // ---- Chassis (chassis.spec.md, F10 #138) ----
+  "chassis.default.name": "Roadrunner Mk. I",
+  "chassis.default.description": "No frills, no gimmicks. A balanced stock frame.",
+
   // ---- Passive items (items-and-brands.spec.todo.md, F9 #137) ----
   "item.lucky-rabbits-foot.name": "Lucky Rabbit's Foot",
   "item.piggy-bank.name": "Piggy Bank",

--- a/games/shmup/src/content/index.ts
+++ b/games/shmup/src/content/index.ts
@@ -24,7 +24,7 @@ export { BRANDS } from "./brands";
 export type { SponsorBrand, BrandId } from "./brands";
 export { PLACEHOLDER_WEAPON, ALL_WEAPONS, weaponById } from "./weapons";
 export { ALL_ITEMS, itemById } from "./items";
-export { DEFAULT_CHASSIS, ALL_CHASSIS, chassisById } from "./chassis";
+export { DEFAULT_CHASSIS, IKARUGA_CHASSIS, ALL_CHASSIS, chassisById } from "./chassis";
 export { CROWD_COMMENTS } from "./crowdComments";
 export type { CrowdCommentLine } from "./crowdComments";
 export type { CrowdTag } from "./tags";

--- a/games/shmup/src/content/index.ts
+++ b/games/shmup/src/content/index.ts
@@ -24,6 +24,7 @@ export { BRANDS } from "./brands";
 export type { SponsorBrand, BrandId } from "./brands";
 export { PLACEHOLDER_WEAPON, ALL_WEAPONS, weaponById } from "./weapons";
 export { ALL_ITEMS, itemById } from "./items";
+export { DEFAULT_CHASSIS, ALL_CHASSIS, chassisById } from "./chassis";
 export { CROWD_COMMENTS } from "./crowdComments";
 export type { CrowdCommentLine } from "./crowdComments";
 export type { CrowdTag } from "./tags";

--- a/games/shmup/src/entities/Enemy.ts
+++ b/games/shmup/src/entities/Enemy.ts
@@ -3,6 +3,7 @@ import { TUNING } from "../tuning";
 import { GAME_HEIGHT } from "../config";
 import { reflexMoveSpeedMult } from "../systems/combat";
 import type { EnemyArchetypeId, ScaledEnemyStats } from "../systems/difficulty";
+import type { Polarity } from "../systems/chassis";
 import type { ShmupPlayScene } from "./types";
 
 /**
@@ -22,6 +23,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
   contactDamage = 0;
   bulletDamage = 0;
   bulletSpeed = 0;
+  /** Assigned every spawn regardless of the equipped chassis (chassis.spec.md's Ikaruga flagship example) — inert unless the player's chassis actually declares a `polarity` mechanic, in which case it gates damage from player shots. */
+  polarity: Polarity = "red";
   private moveSpeedValue = 0;
   /** Identifies this enemy's current life, not the pooled object — bullets must track hits by this, not by object reference, since the underlying sprite is reused across spawns (Group.get() recycling). */
   spawnId = 0;
@@ -44,6 +47,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     this.fireIntervalMs = stats.fireIntervalMs;
     this.fireCooldownMs = stats.fireIntervalMs;
     this.spawnId = Enemy.nextSpawnId++;
+    this.polarity = Math.random() < 0.5 ? "red" : "blue";
+    this.applyPolarityTint();
     this.setPosition(x, y);
     this.setActive(true);
     this.setVisible(true);
@@ -83,6 +88,16 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
   private moveSpeed(): number {
     const reflexes = (this.scene as ShmupPlayScene).player?.stats.reflexes ?? 0;
     return this.moveSpeedValue * reflexMoveSpeedMult(reflexes);
+  }
+
+  /** Only visually tints by polarity when the equipped chassis actually uses it — a polarity-agnostic chassis (e.g. DEFAULT_CHASSIS) never shows a meaningless red/blue split. */
+  private applyPolarityTint(): void {
+    const chassis = (this.scene as ShmupPlayScene).player?.chassis;
+    if (!chassis?.polarity) {
+      this.clearTint();
+      return;
+    }
+    this.setTintFill(TUNING.chassis.polarityColors[this.polarity]);
   }
 
   preUpdate(time: number, delta: number): void {

--- a/games/shmup/src/entities/EnemyBullet.ts
+++ b/games/shmup/src/entities/EnemyBullet.ts
@@ -1,12 +1,16 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { TUNING } from "../tuning";
+import type { Polarity } from "../systems/chassis";
+import type { ShmupPlayScene } from "./types";
 
 /** Pooled enemy bullet — fixed damage, no pierce/blast (those are player-weapon-only mechanics). */
 export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
   private static nextSpawnId = 1;
 
   damage = 0;
+  /** Inherited from the firing enemy (chassis.spec.md's Ikaruga flagship example) — inert unless the player's chassis declares a `polarity` mechanic, in which case a same-polarity bullet is absorbed instead of damaging the player. */
+  polarity: Polarity = "red";
   /** Identifies this bullet's current life, not the pooled object — grazing (F7 #135) must track relationships by this, not by object reference, since the underlying sprite is reused across fires (Group.get() recycling). */
   spawnId = 0;
 
@@ -14,8 +18,9 @@ export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
     super(scene, x, y, texture);
   }
 
-  fire(x: number, y: number, vx: number, vy: number, damage: number): void {
+  fire(x: number, y: number, vx: number, vy: number, damage: number, polarity: Polarity = "red"): void {
     this.damage = damage;
+    this.polarity = polarity;
     this.spawnId = EnemyBullet.nextSpawnId++;
     this.setPosition(x, y);
     this.setRotation(Math.atan2(vy, vx) + Math.PI / 2);
@@ -26,6 +31,9 @@ export class EnemyBullet extends Phaser.Physics.Arcade.Sprite {
     body.setVelocity(vx, vy);
     body.debugBodyColor = TUNING.debug.hitboxColors.enemyBullet;
     body.debugShowVelocity = false;
+    const chassis = (this.scene as ShmupPlayScene).player?.chassis;
+    if (chassis?.polarity) this.setTintFill(TUNING.chassis.polarityColors[polarity]);
+    else this.clearTint();
   }
 
   recycle(): void {

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -1,10 +1,11 @@
 import Phaser from "phaser";
 import { TUNING } from "../tuning";
-import { resolveLoadout } from "../systems/effects";
+import { resolveLoadout, weaponFocusModsAtTier } from "../systems/effects";
 import type { OwnedItem, OwnedWeapon, ProjectileBehavior } from "../systems/effects";
 import type { StatBlock, StatId, StatModifier } from "../systems/stats";
 import type { Defender } from "../systems/combat";
-import { PLACEHOLDER_WEAPON } from "../content";
+import type { ChassisDef } from "../systems/chassis";
+import { DEFAULT_CHASSIS, PLACEHOLDER_WEAPON } from "../content";
 import type { DebugOverrides } from "../debug/debugSettings";
 
 /** One weapon ready to fire this frame, with everything its shot needs already resolved. */
@@ -19,6 +20,8 @@ const STARTING_WEAPONS: OwnedWeapon[] = [{ weapon: PLACEHOLDER_WEAPON, tier: 0 }
 
 export class Player extends Phaser.Physics.Arcade.Sprite {
   stats: StatBlock;
+  /** The equipped chassis (chassis.spec.md, F10 #138) — supplies stat weightings/quirks, weapon-slot cap, hitbox size, and Focus behavior, all applied via `resolveLoadout()`. Defaults to DEFAULT_CHASSIS until chassis selection (Epic 2) exists. */
+  readonly chassis: ChassisDef;
   /** The persisted career build (run-structure.spec.todo.md: "Build persists"), rehydrated by PlayScene from CareerState.weapons. */
   weapons: OwnedWeapon[];
   /** Owned passive items (economy.spec.todo.md, F9 #137), rehydrated from CareerState.items — stack through the F4 engine same as any item. */
@@ -53,12 +56,14 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     weapons: OwnedWeapon[] = STARTING_WEAPONS,
     debugOverrides?: DebugOverrides,
     items: OwnedItem[] = [],
-    persistentStatMods: StatModifier[] = []
+    persistentStatMods: StatModifier[] = [],
+    chassis: ChassisDef = DEFAULT_CHASSIS
   ) {
     super(scene, x, y, texture);
     scene.add.existing(this);
     scene.physics.add.existing(this);
 
+    this.chassis = chassis;
     this.weapons = weapons;
     this.items = items;
     this.persistentStatMods = persistentStatMods;
@@ -73,12 +78,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       this.debugShowHitboxes = debugOverrides.showHitboxes;
     }
 
-    const { stats, projectileBehaviors } = resolveLoadout({
-      weapons: this.weapons,
-      items: this.items,
-      chassisMods: this.persistentStatMods,
-      transientMods: [...this.debugMods.values()],
-    });
+    const { stats, projectileBehaviors } = this.resolveEffectiveLoadout();
     this.stats = stats;
     this.projectileBehaviors = projectileBehaviors;
     this.defender = { hp: stats.maxHp, shield: stats.maxShield, shieldRegenDelayRemaining: 0 };
@@ -133,19 +133,37 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     return this.debugMods.get(stat)?.amount ?? 0;
   }
 
-  private recompute(): void {
-    const { stats, projectileBehaviors } = resolveLoadout({
+  /**
+   * The single resolution call (chassis.spec.md): chassis stat weightings +
+   * quirks, level-up picks, items, weapon tiers, debug mods, and — only
+   * while Focus is held — each equipped weapon's optional focused-fire mods
+   * (transient, per stats.spec.md's "toggled by condition flips" convention).
+   */
+  private resolveEffectiveLoadout() {
+    const focusMods: StatModifier[] = this.focus
+      ? this.weapons.flatMap(({ weapon, tier }) => weaponFocusModsAtTier(weapon, tier))
+      : [];
+    return resolveLoadout({
       weapons: this.weapons,
       items: this.items,
-      chassisMods: this.persistentStatMods,
-      transientMods: [...this.debugMods.values()],
+      chassisBase: this.chassis.statBase,
+      chassisMods: this.chassis.mods,
+      statPickMods: this.persistentStatMods,
+      maxWeaponSlots: this.chassis.maxWeaponSlots,
+      transientMods: [...this.debugMods.values(), ...focusMods],
     });
+  }
+
+  private recompute(): void {
+    const { stats, projectileBehaviors } = this.resolveEffectiveLoadout();
     this.stats = stats;
     this.projectileBehaviors = projectileBehaviors;
   }
 
   private applyHitboxRadius(): void {
-    const r = this.focus ? TUNING.combat.hitboxRadiusFocus : TUNING.combat.hitboxRadiusNormal;
+    const r = this.focus
+      ? (this.chassis.focus.hitboxRadiusFocus ?? this.chassis.hitboxRadiusNormal)
+      : this.chassis.hitboxRadiusNormal;
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.setCircle(r, this.width / 2 - r, this.height / 2 - r);
   }
@@ -154,11 +172,12 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     if (this.focus === focus) return;
     this.focus = focus;
     this.applyHitboxRadius();
+    this.recompute();
   }
 
-  /** Movement speed for this frame, in px/s — Focus is movement-slow-only per chassis.spec.todo.md. */
+  /** Movement speed for this frame, in px/s — Focus's slowdown is the chassis's universal base action (chassis.spec.md's `ChassisFocusDef.speedMult`). */
   currentSpeed(): number {
-    return this.stats.playerSpeed * (this.focus ? TUNING.combat.focusSpeedMult : 1);
+    return this.stats.playerSpeed * (this.focus ? this.chassis.focus.speedMult : 1);
   }
 
   get invulnerable(): boolean {

--- a/games/shmup/src/entities/Player.ts
+++ b/games/shmup/src/entities/Player.ts
@@ -4,7 +4,7 @@ import { resolveLoadout, weaponFocusModsAtTier } from "../systems/effects";
 import type { OwnedItem, OwnedWeapon, ProjectileBehavior } from "../systems/effects";
 import type { StatBlock, StatId, StatModifier } from "../systems/stats";
 import type { Defender } from "../systems/combat";
-import type { ChassisDef } from "../systems/chassis";
+import type { ChassisDef, Polarity } from "../systems/chassis";
 import { DEFAULT_CHASSIS, PLACEHOLDER_WEAPON } from "../content";
 import type { DebugOverrides } from "../debug/debugSettings";
 
@@ -31,6 +31,8 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   projectileBehaviors: ProjectileBehavior[] = [];
   defender: Defender;
   focus = false;
+  /** Current polarity (chassis.spec.md's Ikaruga flagship example) — only meaningful when `chassis.polarity` is defined; harmlessly inert data otherwise. Initialized to the chassis's declared starting polarity, or "red" as a neutral default for chassis without the mechanic. */
+  polarity: Polarity;
   iFrameRemainingMs = 0;
   /** Debug-only (C12 #151): full width, in degrees, of a random cone around straight-up that each shot's heading is drawn from (0 = always straight up). Not a real StatId — there's no balance/upgrade source for it, it exists purely so the debug overlay can spread fire to inspect homing/fork/pierce behavior off-axis. */
   debugFiringConeDeg = 0;
@@ -64,6 +66,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     scene.physics.add.existing(this);
 
     this.chassis = chassis;
+    this.polarity = chassis.polarity?.initial ?? "red";
     this.weapons = weapons;
     this.items = items;
     this.persistentStatMods = persistentStatMods;
@@ -84,6 +87,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     this.defender = { hp: stats.maxHp, shield: stats.maxShield, shieldRegenDelayRemaining: 0 };
     this.fireCooldownMs = this.weapons.map(() => 0);
     this.applyHitboxRadius();
+    this.applyPolarityTint();
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.debugBodyColor = TUNING.debug.hitboxColors.player;
     body.debugShowVelocity = false;
@@ -173,6 +177,21 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     this.focus = focus;
     this.applyHitboxRadius();
     this.recompute();
+  }
+
+  /** Flips red/blue (chassis.spec.md's Ikaruga flagship example) — a no-op tint-wise on a chassis without `polarity`, since `applyPolarityTint()` clears any tint when the config is absent. */
+  togglePolarity(): void {
+    if (!this.chassis.polarity) return;
+    this.polarity = this.polarity === "red" ? "blue" : "red";
+    this.applyPolarityTint();
+  }
+
+  private applyPolarityTint(): void {
+    if (!this.chassis.polarity) {
+      this.clearTint();
+      return;
+    }
+    this.setTintFill(TUNING.chassis.polarityColors[this.polarity]);
   }
 
   /** Movement speed for this frame, in px/s — Focus's slowdown is the chassis's universal base action (chassis.spec.md's `ChassisFocusDef.speedMult`). */

--- a/games/shmup/src/entities/PlayerBullet.ts
+++ b/games/shmup/src/entities/PlayerBullet.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { TUNING } from "../tuning";
+import type { Polarity } from "../systems/chassis";
 import type { Enemy } from "./Enemy";
 import type { ShmupPlayScene } from "./types";
 
@@ -40,6 +41,8 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
   baseHit = 0;
   /** Crits are resolved once per shot fired (combat.spec.todo.md) and shared by every line/fork that shot spawns — carried here purely for floating-combat-text display. */
   numCrits = 0;
+  /** The firing player's polarity at the moment this shot was fired (chassis.spec.md's Ikaruga flagship example), baked in like crit so a mid-flight polarity switch doesn't retroactively change an already-fired shot. Null when the equipped chassis has no polarity mechanic — always resolves to no damage gating (`polarityDamageMultiplier`). */
+  shotPolarity: Polarity | null = null;
   blastRadius = 0;
   blastDamageFraction = 0;
   /** Speed to give any fork spawned from this line's first impact (the firing weapon's projectileSpeed) — carried forward to each chain link so the whole chain shares one projectile speed. */
@@ -76,9 +79,10 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     homingStrength: number,
     forkCount: number,
     forkProjectileSpeed: number,
-    forkConeDeg: number
+    forkConeDeg: number,
+    shotPolarity: Polarity | null = null
   ): void {
-    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength, shotPolarity);
     this.infinite = false;
     this.fractions = fractions;
     this.fractionIndex = 0;
@@ -101,9 +105,10 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     forkCount: number,
     forkProjectileSpeed: number,
     forkConeDeg: number,
-    inheritedHit?: Enemy
+    inheritedHit?: Enemy,
+    shotPolarity: Polarity | null = null
   ): void {
-    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength);
+    this.reset(x, y, vx, vy, baseHit, numCrits, blastRadius, blastDamageFraction, homingStrength, shotPolarity);
     this.infinite = true;
     this.hitsRemaining = hitsAllowed;
     this.pendingForkCount = forkCount;
@@ -121,10 +126,12 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     numCrits: number,
     blastRadius: number,
     blastDamageFraction: number,
-    homingStrength: number
+    homingStrength: number,
+    shotPolarity: Polarity | null
   ): void {
     this.baseHit = baseHit;
     this.numCrits = numCrits;
+    this.shotPolarity = shotPolarity;
     this.blastRadius = blastRadius;
     this.blastDamageFraction = blastDamageFraction;
     this.baseHomingStrength = homingStrength;
@@ -143,6 +150,9 @@ export class PlayerBullet extends Phaser.Physics.Arcade.Sprite {
     body.setVelocity(vx, vy);
     body.debugBodyColor = TUNING.debug.hitboxColors.playerBullet;
     body.debugShowVelocity = false;
+    const chassis = (this.scene as ShmupPlayScene).player?.chassis;
+    if (chassis?.polarity && shotPolarity) this.setTintFill(TUNING.chassis.polarityColors[shotPolarity]);
+    else this.clearTint();
   }
 
   /** True once this bullet has already damaged `enemy` — it should pass through without re-hitting it. */

--- a/games/shmup/src/main.ts
+++ b/games/shmup/src/main.ts
@@ -5,6 +5,7 @@ import { PlayScene } from "./scenes/PlayScene";
 import { ResolveScene } from "./scenes/ResolveScene";
 import { LevelUpScene } from "./scenes/LevelUpScene";
 import { ShopScene } from "./scenes/ShopScene";
+import { ChassisSelectScene } from "./scenes/ChassisSelectScene";
 import { GAME_WIDTH, GAME_HEIGHT } from "./config";
 
 new Phaser.Game({
@@ -23,5 +24,5 @@ new Phaser.Game({
     default: "arcade",
     arcade: { debug: false },
   },
-  scene: [BootScene, MapScene, PlayScene, ResolveScene, LevelUpScene, ShopScene],
+  scene: [BootScene, MapScene, PlayScene, ResolveScene, LevelUpScene, ShopScene, ChassisSelectScene],
 });

--- a/games/shmup/src/scenes/ChassisSelectScene.ts
+++ b/games/shmup/src/scenes/ChassisSelectScene.ts
@@ -1,0 +1,98 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { copy, ALL_CHASSIS } from "../content";
+import { loadCareer, saveCareer } from "../systems/career";
+import { SCENE_KEYS } from "./sceneData";
+
+const ROW_HEIGHT = 96;
+const ROW_START_Y = 130;
+
+/**
+ * The Hangar (chassis.spec.md, F10 #138 / C7 #146): a persisted, real
+ * chassis-selection screen — tap any chassis in `ALL_CHASSIS` to equip it
+ * onto the current career (`CareerState.chassisId`), same "id + registry
+ * lookup" persistence convention as owned weapons/items. Reachable any time
+ * from the map (not gated behind starting a new career), since a chassis is
+ * career-persistent equipment, not a one-time character pick.
+ */
+export class ChassisSelectScene extends Phaser.Scene {
+  constructor() {
+    super(SCENE_KEYS.chassisSelect);
+  }
+
+  create() {
+    const career = loadCareer();
+
+    this.add
+      .text(GAME_WIDTH / 2, 40, copy("hangar.title"), {
+        fontFamily: "monospace",
+        fontSize: "26px",
+        color: "#ffcc00",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(GAME_WIDTH / 2, 74, copy("hangar.hint"), {
+        fontFamily: "monospace",
+        fontSize: "12px",
+        color: "#cccccc",
+      })
+      .setOrigin(0.5);
+
+    ALL_CHASSIS.forEach((chassis, i) => {
+      const y = ROW_START_Y + i * ROW_HEIGHT;
+      const equipped = chassis.id === career.chassisId;
+
+      const panel = this.add
+        .rectangle(GAME_WIDTH / 2, y + ROW_HEIGHT / 2 - 10, GAME_WIDTH - 48, ROW_HEIGHT - 12, 0x2a1000)
+        .setStrokeStyle(3, equipped ? 0xffcc00 : 0x7b3dbe)
+        .setInteractive({ useHandCursor: true });
+
+      this.add
+        .text(40, y, chassis.name, {
+          fontFamily: "monospace",
+          fontSize: "16px",
+          color: "#ffffff",
+        })
+        .setOrigin(0, 0.5);
+
+      this.add
+        .text(40, y + 24, copy(`chassis.${chassis.id}.description`), {
+          fontFamily: "monospace",
+          fontSize: "11px",
+          color: "#cccccc",
+          wordWrap: { width: GAME_WIDTH - 120 },
+        })
+        .setOrigin(0, 0.5);
+
+      if (equipped) {
+        this.add
+          .text(GAME_WIDTH - 40, y, copy("hangar.equipped"), {
+            fontFamily: "monospace",
+            fontSize: "12px",
+            color: "#ffcc00",
+          })
+          .setOrigin(1, 0.5);
+      }
+
+      panel.on("pointerdown", () => {
+        if (equipped) return;
+        saveCareer({ ...career, chassisId: chassis.id });
+        this.scene.restart();
+      });
+    });
+
+    const backButton = this.add
+      .rectangle(GAME_WIDTH / 2, GAME_HEIGHT - 40, 220, 48, 0x1a5c2e)
+      .setStrokeStyle(3, 0x88ff88)
+      .setInteractive({ useHandCursor: true });
+    this.add
+      .text(GAME_WIDTH / 2, GAME_HEIGHT - 40, copy("hangar.back"), {
+        fontFamily: "monospace",
+        fontSize: "13px",
+        color: "#ffffff",
+      })
+      .setOrigin(0.5);
+    backButton.on("pointerdown", () => this.scene.start(SCENE_KEYS.map));
+  }
+}

--- a/games/shmup/src/scenes/MapScene.ts
+++ b/games/shmup/src/scenes/MapScene.ts
@@ -75,6 +75,7 @@ export class MapScene extends Phaser.Scene {
     const positions = this.layoutPositions(map);
 
     this.drawNewCareerControl(GAME_WIDTH - 12, 12, false);
+    this.drawHangarControl(12, 12);
 
     this.add
       .text(GAME_WIDTH / 2, 20, copy("map.title", { season: career.season }), {
@@ -173,8 +174,22 @@ export class MapScene extends Phaser.Scene {
     });
   }
 
+  /** Opposite corner from the New Career control — the Hangar (chassis.spec.md, F10 #138 / C7 #146) is reachable any time, not gated behind starting a new career. */
+  private drawHangarControl(x: number, y: number): void {
+    this.add
+      .text(x, y, copy("map.hangar"), {
+        fontFamily: "monospace",
+        fontSize: "10px",
+        color: "#7b3dbe",
+      })
+      .setOrigin(0, 0)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.scene.start(SCENE_KEYS.chassisSelect));
+  }
+
   private renderSyndication(career: CareerState): void {
     this.drawNewCareerControl(GAME_WIDTH - 12, 12, false);
+    this.drawHangarControl(12, 12);
 
     this.add
       .text(GAME_WIDTH / 2, GAME_HEIGHT * 0.3, copy("map.syndication.title"), {
@@ -244,6 +259,7 @@ export class MapScene extends Phaser.Scene {
         season: TUNING.difficulty.seasonCount,
         D,
         ratings: career.ratings,
+        chassisId: career.chassisId,
         weapons: career.weapons,
         items: career.items,
         statPicks: career.statPicks,
@@ -415,6 +431,7 @@ export class MapScene extends Phaser.Scene {
         season: career.season,
         D,
         ratings: career.ratings,
+        chassisId: career.chassisId,
         weapons: career.weapons,
         items: career.items,
         statPicks: career.statPicks,

--- a/games/shmup/src/scenes/PlayScene.ts
+++ b/games/shmup/src/scenes/PlayScene.ts
@@ -1,12 +1,21 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { TUNING } from "../tuning";
-import { copy, ratingsTierForScore, ratingsTierName, RATINGS_LADDER, weaponById, itemById } from "../content";
+import { copy, ratingsTierForScore, ratingsTierName, RATINGS_LADDER, weaponById, itemById, chassisById } from "../content";
 import { preloadSprites, ensurePlaceholderTextures } from "../sprites";
 import type { SpriteKey } from "../sprites";
 import { Player, Enemy, EnemyBullet, PlayerBullet, Coin } from "../entities";
 import type { PlayerFireRequest, ShmupPlayScene } from "../entities";
-import { applyDamage, applyLifesteal, reflexBulletSpeedMult, rollCrit, tickHpRegen, tickShieldRegen } from "../systems/combat";
+import {
+  absorbsBullet,
+  applyDamage,
+  applyLifesteal,
+  polarityDamageMultiplier,
+  reflexBulletSpeedMult,
+  rollCrit,
+  tickHpRegen,
+  tickShieldRegen,
+} from "../systems/combat";
 import {
   GrazeTracker,
   ShmupEventBus,
@@ -21,6 +30,7 @@ import {
 import type { HypeState, GrazeRingDef } from "../systems/hype";
 import { rollSpawnArchetype, scaledEnemyStats, rewardCurve } from "../systems/difficulty";
 import type { EnemyArchetypeId } from "../systems/difficulty";
+import type { Polarity } from "../systems/chassis";
 import { coinValue, rollsTip, statPickMods } from "../systems/economy";
 import type { OwnedItem } from "../systems/effects";
 import { DebugOverlay } from "../debug/DebugOverlay";
@@ -68,6 +78,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private keys!: Record<string, Phaser.Input.Keyboard.Key>;
   private focusKey!: Phaser.Input.Keyboard.Key;
+  private polarityKey!: Phaser.Input.Keyboard.Key;
   private pointerTarget: { x: number; y: number } | null = null;
 
   private score = 0;
@@ -203,7 +214,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       weapons,
       getDebugOverrides(),
       ownedItems,
-      persistentStatMods
+      persistentStatMods,
+      chassisById(this.episode.chassisId)
     );
     this.player.setCollideWorldBounds(true);
     this.player.setDepth(10);
@@ -225,6 +237,10 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     this.cursors = this.input.keyboard!.createCursorKeys();
     this.keys = this.input.keyboard!.addKeys("W,A,S,D") as Record<string, Phaser.Input.Keyboard.Key>;
     this.focusKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
+    // Polarity switch (chassis.spec.md's Ikaruga flagship example) — harmless
+    // to bind even on a chassis without `polarity`, since `togglePolarity()`
+    // no-ops without one. Mobile polarity switching is TBD, same as Focus.
+    this.polarityKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.X);
 
     // Pointer / touch: drag-to-move (the ship follows the finger, floated above it).
     // Mobile Focus is TBD (combat.spec.todo.md) — not wired to the pointer here.
@@ -349,6 +365,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     this.physics.resume();
 
     const dt = delta / 1000;
+
+    if (Phaser.Input.Keyboard.JustDown(this.polarityKey)) this.player.togglePolarity();
 
     this.updateMovement(dt);
     this.player.tickIFrame(delta);
@@ -495,7 +513,7 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const y = enemy.y + enemy.height / 2;
     const speed = enemy.bulletSpeed * reflexBulletSpeedMult(this.player.stats.reflexes);
     const bullet = this.enemyBullets.get(x, y, TEX.bulletEnemy) as EnemyBullet | null;
-    bullet?.fire(x, y, 0, speed, enemy.bulletDamage);
+    bullet?.fire(x, y, 0, speed, enemy.bulletDamage, enemy.polarity);
   }
 
   /**
@@ -515,6 +533,10 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const angleRad = Phaser.Math.DegToRad(Phaser.Math.FloatBetween(-coneDeg / 2, coneDeg / 2));
     const vx = Math.sin(angleRad) * req.projectileSpeed;
     const vy = -Math.cos(angleRad) * req.projectileSpeed;
+    // Baked in once per shot, same as crit (combat.spec.todo.md) — a switch
+    // mid-flight never retroactively changes an already-fired shot. Null on
+    // a chassis without `polarity`, which always resolves to no gating.
+    const shotPolarity = this.player.chassis.polarity ? this.player.polarity : null;
 
     const forkCount = Math.min(flatLineCount, TUNING.weapons.maxForkedBulletsPerShot);
     this.spawnPlayerLine(
@@ -530,7 +552,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       homingStrength,
       forkCount,
       req.projectileSpeed,
-      this.player.effectiveForkConeDeg
+      this.player.effectiveForkConeDeg,
+      shotPolarity
     );
   }
 
@@ -552,7 +575,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     homingStrength: number,
     forkCount: number,
     forkProjectileSpeed: number,
-    forkConeDeg: number
+    forkConeDeg: number,
+    shotPolarity: Polarity | null
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
     bullet?.fireLine(
@@ -568,7 +592,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       homingStrength,
       forkCount,
       forkProjectileSpeed,
-      forkConeDeg
+      forkConeDeg,
+      shotPolarity
     );
   }
 
@@ -586,7 +611,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     forkCount: number,
     forkProjectileSpeed: number,
     forkConeDeg: number,
-    inheritedHit?: Enemy
+    inheritedHit: Enemy | undefined,
+    shotPolarity: Polarity | null
   ): void {
     const bullet = this.playerBullets.get(x, y, TEX.bulletPlayer) as PlayerBullet | null;
     bullet?.fireForkedLine(
@@ -603,7 +629,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
       forkCount,
       forkProjectileSpeed,
       forkConeDeg,
-      inheritedHit
+      inheritedHit,
+      shotPolarity
     );
   }
 
@@ -625,14 +652,21 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
     const fraction = bullet.registerHit(enemy);
     if (fraction === undefined) return;
 
-    this.damageEnemy(enemy, bullet.baseHit * fraction, bullet.numCrits);
+    // "Current polarity gates which enemies take full damage from your
+    // shots" (chassis.spec.md's Ikaruga flagship example) — a no-op
+    // multiplier of 1 on any chassis without `polarity`.
+    const mult = polarityDamageMultiplier(this.player.chassis.polarity, bullet.shotPolarity, enemy.polarity);
+    this.damageEnemy(enemy, bullet.baseHit * fraction * mult, bullet.numCrits);
 
     if (bullet.blastRadius > 0) {
       const blastDamage = bullet.baseHit * bullet.blastDamageFraction;
       for (const other of this.enemies.getChildren() as Enemy[]) {
         if (other === enemy || !other.active) continue;
         const dist = Phaser.Math.Distance.Between(enemy.x, enemy.y, other.x, other.y);
-        if (dist <= bullet.blastRadius) this.damageEnemy(other, blastDamage, bullet.numCrits);
+        if (dist <= bullet.blastRadius) {
+          const blastMult = polarityDamageMultiplier(this.player.chassis.polarity, bullet.shotPolarity, other.polarity);
+          this.damageEnemy(other, blastDamage * blastMult, bullet.numCrits);
+        }
       }
     }
 
@@ -657,7 +691,8 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
         remainingForks - 1,
         bullet.forkProjectileSpeed,
         bullet.forkConeDeg,
-        enemy
+        enemy,
+        bullet.shotPolarity
       );
     }
   }
@@ -785,7 +820,28 @@ export class PlayScene extends Phaser.Scene implements ShmupPlayScene {
   private onEnemyBulletHitPlayer(bullet: EnemyBullet): void {
     if (this.gameOver || !bullet.active) return;
     bullet.recycle();
+    if (absorbsBullet(this.player.chassis.polarity, this.player.polarity, bullet.polarity)) {
+      this.absorbBullet();
+      return;
+    }
     this.damagePlayer(bullet.damage);
+  }
+
+  /**
+   * Same-color absorption feeds the same underlying graze-multiplier stat,
+   * repurposed as this chassis's absorb-meter gain rate (chassis.spec.md's
+   * Ikaruga flagship example) — an instantaneous Hype pulse through the
+   * exact `gainHype()` path grazing already uses, not a new meter.
+   */
+  private absorbBullet(): void {
+    const polarityDef = this.player.chassis.polarity;
+    if (!polarityDef) return;
+    this.hypeState = gainHype(this.hypeState, polarityDef.absorbHypeBase, this.hypeMaxValue, this.player.stats.grazeMultiplier);
+    this.hypeEvents.emit("hypeChanged", {
+      hype: this.hypeState.hype,
+      hypeMax: this.hypeMaxValue,
+      scoreMult: this.currentScoreMult,
+    });
   }
 
   private onEnemyContactPlayer(enemy: Enemy): void {

--- a/games/shmup/src/scenes/ResolveScene.ts
+++ b/games/shmup/src/scenes/ResolveScene.ts
@@ -1,6 +1,6 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
-import { DEFAULT_CHASSIS, copy, itemById, ratingsTierForScore, ratingsTierName, weaponById } from "../content";
+import { chassisById, copy, itemById, ratingsTierForScore, ratingsTierName, weaponById } from "../content";
 import { applyRatingsDelta } from "../systems/hype";
 import { advanceDeadline } from "../systems/map";
 import { advanceToNextSeason, createNewCareer, loadCareer, saveCareer } from "../systems/career";
@@ -127,13 +127,14 @@ export class ResolveScene extends Phaser.Scene {
         return item ? { item, count: ref.count } : undefined;
       })
       .filter((owned): owned is OwnedItem => owned !== undefined);
+    const chassis = chassisById(career.chassisId);
     return resolveLoadout({
       weapons,
       items,
-      chassisBase: DEFAULT_CHASSIS.statBase,
-      chassisMods: DEFAULT_CHASSIS.mods,
+      chassisBase: chassis.statBase,
+      chassisMods: chassis.mods,
       statPickMods: statPickMods(career.statPicks),
-      maxWeaponSlots: DEFAULT_CHASSIS.maxWeaponSlots,
+      maxWeaponSlots: chassis.maxWeaponSlots,
     }).stats.playerSpeed;
   }
 

--- a/games/shmup/src/scenes/ResolveScene.ts
+++ b/games/shmup/src/scenes/ResolveScene.ts
@@ -1,6 +1,6 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
-import { copy, itemById, ratingsTierForScore, ratingsTierName, weaponById } from "../content";
+import { DEFAULT_CHASSIS, copy, itemById, ratingsTierForScore, ratingsTierName, weaponById } from "../content";
 import { applyRatingsDelta } from "../systems/hype";
 import { advanceDeadline } from "../systems/map";
 import { advanceToNextSeason, createNewCareer, loadCareer, saveCareer } from "../systems/career";
@@ -127,8 +127,14 @@ export class ResolveScene extends Phaser.Scene {
         return item ? { item, count: ref.count } : undefined;
       })
       .filter((owned): owned is OwnedItem => owned !== undefined);
-    const chassisMods = statPickMods(career.statPicks);
-    return resolveLoadout({ weapons, items, chassisMods }).stats.playerSpeed;
+    return resolveLoadout({
+      weapons,
+      items,
+      chassisBase: DEFAULT_CHASSIS.statBase,
+      chassisMods: DEFAULT_CHASSIS.mods,
+      statPickMods: statPickMods(career.statPicks),
+      maxWeaponSlots: DEFAULT_CHASSIS.maxWeaponSlots,
+    }).stats.playerSpeed;
   }
 
   /**

--- a/games/shmup/src/scenes/ShopScene.ts
+++ b/games/shmup/src/scenes/ShopScene.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { TUNING } from "../tuning";
-import { ALL_ITEMS, ALL_WEAPONS, copy, itemById, ratingsTierForScore, ratingsTierRank, weaponById } from "../content";
+import { ALL_ITEMS, ALL_WEAPONS, DEFAULT_CHASSIS, copy, itemById, ratingsTierForScore, ratingsTierRank, weaponById } from "../content";
 import { loadCareer, saveCareer } from "../systems/career";
 import type { CareerState, OwnedItemRef } from "../systems/career";
 import {
@@ -146,7 +146,10 @@ export class ShopScene extends Phaser.Scene {
     return resolveLoadout({
       weapons: this.ownedWeapons(career),
       items: this.ownedItems(career),
-      chassisMods: statPickMods(career.statPicks),
+      chassisBase: DEFAULT_CHASSIS.statBase,
+      chassisMods: DEFAULT_CHASSIS.mods,
+      statPickMods: statPickMods(career.statPicks),
+      maxWeaponSlots: DEFAULT_CHASSIS.maxWeaponSlots,
     }).stats;
   }
 

--- a/games/shmup/src/scenes/ShopScene.ts
+++ b/games/shmup/src/scenes/ShopScene.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { TUNING } from "../tuning";
-import { ALL_ITEMS, ALL_WEAPONS, DEFAULT_CHASSIS, copy, itemById, ratingsTierForScore, ratingsTierRank, weaponById } from "../content";
+import { ALL_ITEMS, ALL_WEAPONS, chassisById, copy, itemById, ratingsTierForScore, ratingsTierRank, weaponById } from "../content";
 import { loadCareer, saveCareer } from "../systems/career";
 import type { CareerState, OwnedItemRef } from "../systems/career";
 import {
@@ -143,13 +143,14 @@ export class ShopScene extends Phaser.Scene {
   }
 
   private resolvedStats(career: CareerState) {
+    const chassis = chassisById(career.chassisId);
     return resolveLoadout({
       weapons: this.ownedWeapons(career),
       items: this.ownedItems(career),
-      chassisBase: DEFAULT_CHASSIS.statBase,
-      chassisMods: DEFAULT_CHASSIS.mods,
+      chassisBase: chassis.statBase,
+      chassisMods: chassis.mods,
       statPickMods: statPickMods(career.statPicks),
-      maxWeaponSlots: DEFAULT_CHASSIS.maxWeaponSlots,
+      maxWeaponSlots: chassis.maxWeaponSlots,
     }).stats;
   }
 

--- a/games/shmup/src/scenes/sceneData.ts
+++ b/games/shmup/src/scenes/sceneData.ts
@@ -15,6 +15,7 @@ export const SCENE_KEYS = {
   resolve: "Resolve",
   levelUp: "LevelUp",
   shop: "Shop",
+  chassisSelect: "ChassisSelect",
 } as const;
 
 /** Map -> Play: everything PlayScene needs to run one episode, resolved ahead of time by the map (Difficulty, build) so PlayScene has zero career/map knowledge of its own. */
@@ -26,6 +27,8 @@ export interface EpisodeLaunchData {
   D: number;
   /** Cumulative Ratings entering the episode — display-only (HUD tier readout); Ratings never changes mid-episode (Model 1). */
   ratings: number;
+  /** Equipped chassis id (chassis.spec.md, F10 #138 / C7 #146) — resolved via `chassisById()`, same id-indirection as `weapons`/`items`. */
+  chassisId: string;
   weapons: OwnedWeaponRef[];
   items: OwnedItemRef[];
   /** Level-up stat picks so far this career (economy.spec.todo.md) — folded into the resolved build the same way `weapons`/`items` are. */

--- a/games/shmup/src/systems/career/careerState.test.ts
+++ b/games/shmup/src/systems/career/careerState.test.ts
@@ -27,6 +27,11 @@ describe("createNewCareer", () => {
     expect(career.weapons).toEqual([{ weaponId: "placeholder", tier: 0 }]);
   });
 
+  it("starts equipped with the default chassis (chassis.spec.md)", () => {
+    const career = createNewCareer(0, 1);
+    expect(career.chassisId).toBe("default");
+  });
+
   it("starts with no gold/items and level 1 with zero exp/stat picks (economy.spec.todo.md, F9 #137)", () => {
     const career = createNewCareer(0, 1);
     expect(career.gold).toBe(0);

--- a/games/shmup/src/systems/career/careerState.ts
+++ b/games/shmup/src/systems/career/careerState.ts
@@ -8,6 +8,8 @@ import { CAREER_STATE_VERSION } from "./types";
 import type { CareerState, OwnedWeaponRef } from "./types";
 
 const STARTING_WEAPONS: OwnedWeaponRef[] = [{ weaponId: "placeholder", tier: 0 }];
+/** Matches content/chassis.ts's DEFAULT_CHASSIS.id by convention, same as STARTING_WEAPONS above — this module never imports content/. */
+const STARTING_CHASSIS_ID = "default";
 
 function randomSeed(): number {
   return Math.floor(Math.random() * 2 ** 31);
@@ -27,6 +29,7 @@ export function createNewCareer(startingRatings = 0, seed: number = randomSeed()
     currentNodeId: null,
     visitedNodeIds: [],
     deadlinePosition: 0,
+    chassisId: STARTING_CHASSIS_ID,
     weapons: STARTING_WEAPONS,
     items: [],
     gold: 0,

--- a/games/shmup/src/systems/career/persistence.ts
+++ b/games/shmup/src/systems/career/persistence.ts
@@ -52,6 +52,7 @@ export function isValidCareerState(value: unknown): value is CareerState {
     (v.currentNodeId === null || typeof v.currentNodeId === "string") &&
     Array.isArray(v.visitedNodeIds) &&
     typeof v.deadlinePosition === "number" &&
+    typeof v.chassisId === "string" &&
     Array.isArray(v.weapons) &&
     Array.isArray(v.items) &&
     typeof v.gold === "number" &&

--- a/games/shmup/src/systems/career/types.ts
+++ b/games/shmup/src/systems/career/types.ts
@@ -36,6 +36,8 @@ export interface CareerState {
   currentNodeId: string | null;
   visitedNodeIds: string[];
   deadlinePosition: number;
+  /** Equipped chassis id (chassis.spec.md, F10 #138 / C7 #146) — same id-indirection convention as `OwnedWeaponRef`/`OwnedItemRef` so a save never embeds a full ChassisDef snapshot. Resolved via `chassisById()`. */
+  chassisId: string;
   weapons: OwnedWeaponRef[];
   /** Owned passive items (economy.spec.todo.md, F9 #137) — persists across episodes exactly like `weapons`. */
   items: OwnedItemRef[];

--- a/games/shmup/src/systems/chassis/index.ts
+++ b/games/shmup/src/systems/chassis/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/games/shmup/src/systems/chassis/types.ts
+++ b/games/shmup/src/systems/chassis/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Chassis framework (chassis.spec.md, F10 #138). A chassis is DATA composed
+ * through the existing F3/F4 engines — weapon-slot cap, hitbox size, stat
+ * weightings, and 1-2 identity quirks, all consumed by `resolveLoadout()`
+ * exactly like a weapon or item's mods. No bespoke per-chassis subsystem.
+ */
+import type { StatBlock, StatModifier } from "../stats";
+
+export interface ChassisFocusDef {
+  /**
+   * Universal Focus action (chassis.spec.md): every chassis slows movement
+   * to this fraction of Player Speed while Focus is held, for precise
+   * dodging. This is not a perk — it's the one thing every chassis does.
+   */
+  speedMult: number;
+  /**
+   * Optional chassis perk: hitbox radius while focusing. Omitting it is the
+   * framework-neutral default (no automatic hitbox shrink) — a chassis
+   * opts into a smaller Focus hitbox as its own identity trait, same as any
+   * other quirk, not a rule the framework imposes.
+   */
+  hitboxRadiusFocus?: number;
+}
+
+export interface ChassisDef {
+  id: string;
+  name: string;
+  /**
+   * Weapon-slot cap (weapons.spec.todo.md's bullet-heaven default is 6) — a
+   * chassis may raise or lower it as its own identity trait.
+   */
+  maxWeaponSlots: number;
+  /** Collision hitbox radius while not focusing — distinct from sprite size (chassis.spec.md). */
+  hitboxRadiusNormal: number;
+  focus: ChassisFocusDef;
+  /**
+   * Per-stat base overrides — the chassis's stat weightings (chassis.spec.md),
+   * e.g. a tankier chassis raises base Max HP but lowers base Player Speed.
+   * Falls back to each StatDef's own base when a stat is omitted.
+   */
+  statBase?: Partial<StatBlock>;
+  /**
+   * 1-2 identity quirks: persistent modifiers reinterpreting the shared F3
+   * stat pool (Brotato-character model) — composed through the same
+   * `resolveLoadout()` path as weapon/item mods, never a bespoke subsystem.
+   */
+  mods: StatModifier[];
+}

--- a/games/shmup/src/systems/chassis/types.ts
+++ b/games/shmup/src/systems/chassis/types.ts
@@ -6,6 +6,33 @@
  */
 import type { StatBlock, StatModifier } from "../stats";
 
+/** Two-state polarity (chassis.spec.md's Ikaruga flagship example) — a chassis-declared hook, not a new stat archetype. */
+export type Polarity = "red" | "blue";
+
+/**
+ * Optional polarity-switch mechanic. Present only on a chassis that uses it
+ * (e.g. the Ikaruga-style flagship) — `ChassisDef.polarity` is undefined for
+ * every other chassis, and every polarity-aware code path treats "no config"
+ * as "this chassis doesn't do polarity," so DEFAULT_CHASSIS (and any future
+ * non-polarity chassis) is completely unaffected.
+ */
+export interface ChassisPolarityDef {
+  /** Polarity the chassis starts a fresh episode in. */
+  initial: Polarity;
+  /** Damage multiplier for a player shot fired at a target of the SAME current polarity — "gates which enemies take full damage" (chassis.spec.md). */
+  damageMultiplierSame: number;
+  /** Damage multiplier for a player shot fired at a target of the OPPOSITE polarity. */
+  damageMultiplierOpposite: number;
+  /**
+   * Hype gained per same-polarity enemy bullet absorbed (destroyed instead of
+   * damaging the player), before scaling by the shared `grazeMultiplier`
+   * stat — "same-color absorption feeds the same underlying graze-multiplier
+   * stat, repurposed as absorb-meter gain rate" (chassis.spec.md). Not a new
+   * meter; it's the existing Hype gain path with a different trigger.
+   */
+  absorbHypeBase: number;
+}
+
 export interface ChassisFocusDef {
   /**
    * Universal Focus action (chassis.spec.md): every chassis slows movement
@@ -45,4 +72,6 @@ export interface ChassisDef {
    * `resolveLoadout()` path as weapon/item mods, never a bespoke subsystem.
    */
   mods: StatModifier[];
+  /** Optional polarity-switch mechanic — see `ChassisPolarityDef`. Omitted entirely by chassis that don't use it. */
+  polarity?: ChassisPolarityDef;
 }

--- a/games/shmup/src/systems/combat/index.ts
+++ b/games/shmup/src/systems/combat/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./resolveHit";
 export * from "./applyDamage";
 export * from "./reflexes";
+export * from "./polarity";

--- a/games/shmup/src/systems/combat/polarity.test.ts
+++ b/games/shmup/src/systems/combat/polarity.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { polarityDamageMultiplier, absorbsBullet } from "./polarity";
+import type { ChassisPolarityDef } from "../chassis";
+
+const IKARUGA_POLARITY: ChassisPolarityDef = {
+  initial: "red",
+  damageMultiplierSame: 0,
+  damageMultiplierOpposite: 1,
+  absorbHypeBase: 10,
+};
+
+describe("polarityDamageMultiplier", () => {
+  it("returns 1 (no gating) when the chassis has no polarity mechanic", () => {
+    expect(polarityDamageMultiplier(undefined, "red", "red")).toBe(1);
+    expect(polarityDamageMultiplier(undefined, "red", "blue")).toBe(1);
+  });
+
+  it("returns 1 when the shot itself carries no polarity, even with a polarity chassis equipped", () => {
+    expect(polarityDamageMultiplier(IKARUGA_POLARITY, null, "red")).toBe(1);
+  });
+
+  it("applies damageMultiplierSame against a same-polarity target", () => {
+    expect(polarityDamageMultiplier(IKARUGA_POLARITY, "red", "red")).toBe(0);
+  });
+
+  it("applies damageMultiplierOpposite against an opposite-polarity target", () => {
+    expect(polarityDamageMultiplier(IKARUGA_POLARITY, "red", "blue")).toBe(1);
+  });
+});
+
+describe("absorbsBullet", () => {
+  it("never absorbs when the chassis has no polarity mechanic", () => {
+    expect(absorbsBullet(undefined, "red", "red")).toBe(false);
+  });
+
+  it("absorbs a same-polarity bullet", () => {
+    expect(absorbsBullet(IKARUGA_POLARITY, "red", "red")).toBe(true);
+  });
+
+  it("does not absorb an opposite-polarity bullet", () => {
+    expect(absorbsBullet(IKARUGA_POLARITY, "red", "blue")).toBe(false);
+  });
+});

--- a/games/shmup/src/systems/combat/polarity.ts
+++ b/games/shmup/src/systems/combat/polarity.ts
@@ -1,0 +1,39 @@
+/**
+ * Polarity resolution (chassis.spec.md's Ikaruga flagship example) — pure
+ * functions only, same convention as `applyDamage`/`rollCrit`. Both take the
+ * chassis's `ChassisPolarityDef | undefined` explicitly rather than reading
+ * a chassis object, so a chassis with no polarity mechanic (every chassis
+ * but Ikaruga today) always resolves to "no gating, no absorption" without
+ * either function needing a special case.
+ */
+import type { ChassisPolarityDef, Polarity } from "../chassis";
+
+/**
+ * Damage multiplier for a player shot fired at `shotPolarity` against a
+ * target of `targetPolarity` — "current polarity gates which enemies take
+ * full damage from your shots." `shotPolarity: null` (a chassis with no
+ * polarity mechanic never assigns one to its shots) always resolves to 1, no
+ * gating at all — the framework-neutral default.
+ */
+export function polarityDamageMultiplier(
+  polarityDef: ChassisPolarityDef | undefined,
+  shotPolarity: Polarity | null,
+  targetPolarity: Polarity
+): number {
+  if (!polarityDef || shotPolarity === null) return 1;
+  return shotPolarity === targetPolarity ? polarityDef.damageMultiplierSame : polarityDef.damageMultiplierOpposite;
+}
+
+/**
+ * True when an incoming bullet of `bulletPolarity` should be absorbed
+ * (destroyed, no damage, Hype gained instead) rather than hit the player at
+ * `playerPolarity` — "same-color absorption." Only meaningful when the
+ * chassis actually declares a polarity mechanic.
+ */
+export function absorbsBullet(
+  polarityDef: ChassisPolarityDef | undefined,
+  playerPolarity: Polarity,
+  bulletPolarity: Polarity
+): boolean {
+  return polarityDef !== undefined && playerPolarity === bulletPolarity;
+}

--- a/games/shmup/src/systems/effects/loadout.test.ts
+++ b/games/shmup/src/systems/effects/loadout.test.ts
@@ -146,6 +146,14 @@ describe("resolveLoadout — single resolution path", () => {
     expect(baseline.stats.pierce).toBeCloseTo(0.5, 10);
     expect(grazing.stats.pierce).toBeCloseTo(1.0, 10);
   });
+
+  it("statPickMods stack alongside chassisMods as separate persistent sources (chassis.spec.md)", () => {
+    const { stats } = resolveLoadout({
+      chassisMods: [{ kind: "flat", stat: "maxHp", amount: 10 }],
+      statPickMods: [{ kind: "flat", stat: "maxHp", amount: 12 }],
+    });
+    expect(stats.maxHp).toBeCloseTo(STAT_DEFS.maxHp.base + 22, 10);
+  });
 });
 
 interface SlotCase {
@@ -179,5 +187,10 @@ describe("resolveLoadout — 6 weapon-slot cap", () => {
     } else {
       expect(attempt).not.toThrow();
     }
+  });
+
+  it("a chassis-specific maxWeaponSlots overrides the framework default cap (chassis.spec.md)", () => {
+    expect(() => resolveLoadout({ weapons: ownedSlots(3), maxWeaponSlots: 2 })).toThrow();
+    expect(() => resolveLoadout({ weapons: ownedSlots(2), maxWeaponSlots: 2 })).not.toThrow();
   });
 });

--- a/games/shmup/src/systems/effects/loadout.ts
+++ b/games/shmup/src/systems/effects/loadout.ts
@@ -15,14 +15,18 @@ import { assertWeaponSlots } from "./slots";
 import type { OwnedItem, OwnedWeapon, ProjectileBehavior } from "./types";
 
 export interface LoadoutInput {
-  /** Per-chassis base stat overrides (chassis.spec.todo.md), e.g. a different base Max HP. */
+  /** Per-chassis base stat overrides (chassis.spec.md's stat weightings), e.g. a different base Max HP. */
   chassisBase?: Partial<StatBlock>;
-  /** Chassis quirks — persistent modifiers baked into the chassis itself. */
+  /** Chassis quirks — persistent modifiers baked into the chassis itself (chassis.spec.md). */
   chassisMods?: readonly StatModifier[];
+  /** Level-up stat-pick mods (economy.spec.md) — persistent like `chassisMods`, but not part of the chassis itself; kept as its own field so a caller can swap the build without touching the equipped chassis. */
+  statPickMods?: readonly StatModifier[];
   items?: readonly OwnedItem[];
-  /** Up to `MAX_WEAPON_SLOTS` weapons, each at its own upgrade tier. */
+  /** Up to the chassis's weapon-slot cap (`maxWeaponSlots`), each at its own upgrade tier. */
   weapons?: readonly OwnedWeapon[];
-  /** "While grazing"-style conditional mods, layered on top (stats.spec.md). */
+  /** Weapon-slot cap (chassis.spec.md) — defaults to `MAX_WEAPON_SLOTS` when the caller doesn't supply a chassis-specific cap. */
+  maxWeaponSlots?: number;
+  /** "While grazing"-style conditional mods, layered on top (stats.spec.md) — also where a chassis's Focus state layers a weapon's optional `focusedMods` in, since Focus is exactly this kind of toggled condition. */
   transientMods?: readonly StatModifier[];
 }
 
@@ -39,10 +43,11 @@ export interface ResolvedLoadout {
 
 export function resolveLoadout(input: LoadoutInput): ResolvedLoadout {
   const weapons = input.weapons ?? [];
-  assertWeaponSlots(weapons);
+  assertWeaponSlots(weapons, input.maxWeaponSlots);
 
   const persistentMods: StatModifier[] = [
     ...(input.chassisMods ?? []),
+    ...(input.statPickMods ?? []),
     ...(input.items ?? []).flatMap(itemModsForOwned),
     ...weapons.flatMap(({ weapon, tier }) => weaponModsAtTier(weapon, tier)),
   ];

--- a/games/shmup/src/systems/effects/slots.ts
+++ b/games/shmup/src/systems/effects/slots.ts
@@ -1,17 +1,17 @@
 /**
- * 6 weapon slots per chassis (bullet-heaven default + a hard performance
- * ceiling on worst-case concurrent projectiles — weapons.spec.todo.md).
- * Enforced here so every caller of `resolveLoadout` gets the cap for free.
+ * 6 weapon slots by default (bullet-heaven default + a hard performance
+ * ceiling on worst-case concurrent projectiles — weapons.spec.todo.md). A
+ * chassis (chassis.spec.md) may raise or lower this per its own
+ * `maxWeaponSlots` — `MAX_WEAPON_SLOTS` is only the framework's fallback cap
+ * when a caller doesn't supply a chassis-specific one.
  */
 import { TUNING } from "../../tuning";
 import type { OwnedWeapon } from "./types";
 
 export const MAX_WEAPON_SLOTS = TUNING.weapons.maxWeaponSlots;
 
-export function assertWeaponSlots(weapons: readonly OwnedWeapon[]): void {
-  if (weapons.length > MAX_WEAPON_SLOTS) {
-    throw new Error(
-      `Too many weapon slots: ${weapons.length} exceeds the chassis cap of ${MAX_WEAPON_SLOTS}`
-    );
+export function assertWeaponSlots(weapons: readonly OwnedWeapon[], maxSlots: number = MAX_WEAPON_SLOTS): void {
+  if (weapons.length > maxSlots) {
+    throw new Error(`Too many weapon slots: ${weapons.length} exceeds the chassis cap of ${maxSlots}`);
   }
 }

--- a/games/shmup/src/systems/effects/types.ts
+++ b/games/shmup/src/systems/effects/types.ts
@@ -72,6 +72,15 @@ export interface WeaponDef {
   /** Stats this weapon's tooltip should display itself scaling with. */
   scalesWith: StatId[];
   mods: ScalingModifier[];
+  /**
+   * Optional focused-fire variant (chassis.spec.md's "weapons MAY define a
+   * focused-fire mode", e.g. wide spray unfocused -> concentrated stream
+   * focused): extra scaling modifiers layered on top of `mods`, as transient
+   * mods, only while the chassis's Focus action is held. Same
+   * `ScalingModifier` shape and per-tier scaling as `mods` — expressed as
+   * data over the shared stat pool, not a bespoke firing-pattern mechanic.
+   */
+  focusedMods?: ScalingModifier[];
 }
 
 /**

--- a/games/shmup/src/systems/effects/upgrades.test.ts
+++ b/games/shmup/src/systems/effects/upgrades.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { weaponModsAtTier, weaponUpgradeCost, brandDiscount } from "./upgrades";
+import { weaponModsAtTier, weaponFocusModsAtTier, weaponUpgradeCost, brandDiscount } from "./upgrades";
 import { TUNING } from "../../tuning";
 import type { WeaponDef } from "./types";
 
@@ -55,6 +55,30 @@ describe("weaponModsAtTier", () => {
     // +0.5 pierce/level -> "+1" every other upgrade, but the raw value stays fractional here.
     const mods = weaponModsAtTier(PEA_SHOOTER, 1);
     expect(mods[1].amount).toBe(0.5);
+  });
+});
+
+describe("weaponFocusModsAtTier", () => {
+  const FOCUS_RIFLE: WeaponDef = {
+    id: "focus-rifle",
+    name: "Focus Rifle",
+    firingArc: "forward",
+    targetType: "both",
+    projectileSpeed: 600,
+    scalesWith: ["attackSpeed"],
+    mods: [{ base: { kind: "flat", stat: "damage", amount: 3 }, perLevel: 1 }],
+    // Wide spray unfocused -> a tighter, faster stream while Focus is held (chassis.spec.md).
+    focusedMods: [{ base: { kind: "percent", stat: "attackSpeed", amount: 0.3 }, perLevel: 0.05 }],
+  };
+
+  it("scales focusedMods by tier the same way weaponModsAtTier scales mods", () => {
+    expect(weaponFocusModsAtTier(FOCUS_RIFLE, 4)).toEqual([
+      { kind: "percent", stat: "attackSpeed", amount: 0.3 + 0.05 * 4 },
+    ]);
+  });
+
+  it("returns nothing for a weapon with no focused-fire variant", () => {
+    expect(weaponFocusModsAtTier(PEA_SHOOTER, 4)).toEqual([]);
   });
 });
 

--- a/games/shmup/src/systems/effects/upgrades.ts
+++ b/games/shmup/src/systems/effects/upgrades.ts
@@ -22,6 +22,21 @@ export function weaponModsAtTier(weapon: WeaponDef, tier: number): StatModifier[
   }));
 }
 
+/**
+ * Same statValue(tier) scaling as `weaponModsAtTier`, but for a weapon's
+ * optional `focusedMods` (chassis.spec.md) — the caller only includes these
+ * while Focus is actually held, as transient mods (stats.spec.md's
+ * toggled-by-condition-flip convention). Weapons without a focused-fire
+ * variant simply have nothing to add here.
+ */
+export function weaponFocusModsAtTier(weapon: WeaponDef, tier: number): StatModifier[] {
+  const safeTier = Math.max(0, Math.floor(tier));
+  return (weapon.focusedMods ?? []).map(({ base, perLevel }) => ({
+    ...base,
+    amount: base.amount + perLevel * safeTier,
+  }));
+}
+
 /** brandDiscount = min(cap, perItem * ownedCount(brand)) (weapons.spec.todo.md). */
 export function brandDiscount(ownedBrandCount: number): number {
   const { brandDiscountPerItem, brandDiscountCap } = TUNING.weapons;

--- a/games/shmup/src/tuning/index.ts
+++ b/games/shmup/src/tuning/index.ts
@@ -36,11 +36,12 @@ export const TUNING = {
     reflexMoveK: 1,
     reflexBulletSlowCap: 0.8,
     reflexMoveSlowCap: 0.5,
-    // Focus (chassis.spec.todo.md): hold to move slower for precision. The
-    // default chassis (F10 #138) hasn't landed yet, so F6 ships the
-    // universal base behavior plus a hitbox shrink (genre-standard "graze
-    // box") as the vertical-slice default; a future chassis quirk may
-    // override hitboxRadiusFocus instead of relying on this global.
+    // Focus (chassis.spec.md, F10 #138): hold to move slower for precision —
+    // the universal base action every chassis has (`ChassisFocusDef.speedMult`).
+    // hitboxRadiusFocus below is DEFAULT_CHASSIS's own perk
+    // (`ChassisFocusDef.hitboxRadiusFocus`, content/chassis.ts), not a rule
+    // the framework imposes — a future chassis may omit it or use a
+    // different value entirely.
     focusSpeedMult: 0.45,
     hitboxRadiusNormal: 6,
     hitboxRadiusFocus: 3,

--- a/games/shmup/src/tuning/index.ts
+++ b/games/shmup/src/tuning/index.ts
@@ -54,6 +54,29 @@ export const TUNING = {
     // overlapping enemy/bullet would re-deal damage every physics step.
     playerIFrameMs: 500,
   },
+  // Chassis content (chassis.spec.md, F10 #138 framework / C7 #146 content).
+  // Only Ikaruga-style polarity chassis read this block today — every other
+  // chassis has no `ChassisDef.polarity`, so these numbers are inert unless
+  // a polarity chassis is equipped.
+  chassis: {
+    ikaruga: {
+      // "Gates which enemies take full damage from your shots" — a shot
+      // fired at the wrong polarity bounces off harmlessly; the matching
+      // polarity deals full damage.
+      damageMultiplierSame: 0,
+      damageMultiplierOpposite: 1,
+      // Hype gained per same-polarity bullet absorbed, before scaling by the
+      // shared grazeMultiplier stat (repurposed as this chassis's
+      // absorb-meter gain rate, chassis.spec.md).
+      absorbHypeBase: 6,
+    },
+    // Shared tint applied to the player ship, enemies, and bullets when a
+    // polarity chassis is equipped — only Ikaruga-style chassis read this.
+    polarityColors: {
+      red: 0xff4444,
+      blue: 0x4488ff,
+    },
+  },
   // Grazing (hype-and-ratings.spec.md, F7 #135): concentric rings as
   // fractions of the grazeRadius stat. Innermost ring only applies (no
   // stacking) — point-blank grazing is the deliberate high-skill act.

--- a/specs/games/shmup/chassis.spec.md
+++ b/specs/games/shmup/chassis.spec.md
@@ -1,10 +1,12 @@
 # Shmup — Chassis Spec
 
-> Issue: **F10 #138**. Status: implemented (framework + default chassis).
-> Code lives in `games/shmup/src/systems/chassis/` (the `ChassisDef` shape)
-> and `games/shmup/src/content/chassis.ts` (the registry — `DEFAULT_CHASSIS`,
-> `chassisById()`). Additional chassis (Ikaruga polarity, etc.) are Epic 2
-> content — see `chassis.spec.todo.md`.
+> Issues: **F10 #138** (framework + default chassis), **C7 #146** (Ikaruga
+> polarity chassis). Status: implemented. Code lives in
+> `games/shmup/src/systems/chassis/` (the `ChassisDef`/`ChassisPolarityDef`
+> shapes), `games/shmup/src/systems/combat/polarity.ts` (pure damage-gating/
+> absorption resolution), and `games/shmup/src/content/chassis.ts` (the
+> registry — `DEFAULT_CHASSIS`, `IKARUGA_CHASSIS`, `chassisById()`).
+> Additional chassis are Epic 2 content — see `chassis.spec.todo.md`.
 
 ## A chassis is data, applied through existing engines
 
@@ -21,18 +23,20 @@
 - **`statBase`** / **`mods`** — stat weightings and identity quirks. These
   are exactly `LoadoutInput.chassisBase` / `chassisMods`
   (`systems/effects/loadout.ts`) — fields that already existed on the F4
-  engine before this issue landed. A chassis is proof that engine needed no
-  changes to express: `statBase` overrides a stat's base value (e.g. a
-  tankier frame raising base Max HP), `mods` are 1-2 persistent
-  `StatModifier`s reinterpreting the shared stat pool (Brotato-character
-  model) — run through `computeStats()` the same as any weapon or item mod,
-  no bespoke per-chassis subsystem.
+  engine before F10 landed. A chassis is proof that engine needed no changes
+  to express: `statBase` overrides a stat's base value (e.g. a tankier frame
+  raising base Max HP), `mods` are 1-2 persistent `StatModifier`s
+  reinterpreting the shared stat pool (Brotato-character model) — run
+  through `computeStats()` the same as any weapon or item mod, no bespoke
+  per-chassis subsystem.
 - **`focus`** — Focus behavior, see below.
+- **`polarity`** (optional) — the Ikaruga-style polarity-switch mechanic, see
+  below. Absent entirely on chassis that don't use it (`DEFAULT_CHASSIS`).
 
 `entities/Player.ts` holds the equipped `chassis: ChassisDef` (constructor
 param, defaults to `DEFAULT_CHASSIS`) and threads it into every
 `resolveLoadout()` call (`resolveEffectiveLoadout()`), and into its own
-hitbox/speed math (`applyHitboxRadius()`, `currentSpeed()`).
+hitbox/speed/polarity math.
 
 ## Focus — universal action + optional chassis perk
 
@@ -47,7 +51,8 @@ Focus is a chassis feature, not a player stat:
   wants the genre-standard "graze box" declares `hitboxRadiusFocus` as its
   own identity trait, same as any other quirk. `DEFAULT_CHASSIS` opts in
   (`hitboxRadiusNormal: 6` -> `hitboxRadiusFocus: 3`, both from
-  `TUNING.combat`).
+  `TUNING.combat`); `IKARUGA_CHASSIS` doesn't — its identity is entirely the
+  polarity hook below.
 - **Weapon-defined focused-fire mode:** a `WeaponDef` may declare
   `focusedMods?: ScalingModifier[]` (`systems/effects/types.ts`) — extra
   scaling modifiers (same shape/tiering as `mods`) layered in only while
@@ -57,66 +62,86 @@ Focus is a chassis feature, not a player stat:
   `transientMods` only when `this.focus` is true, and `setFocus()` recomputes
   on every toggle — the same "toggled by condition flips" convention
   `stats.spec.md` already uses for grazing/polarity-style effects. No new
-  engine: focused-fire is just another transient-mod source.
-
-`DEFAULT_CHASSIS` ships with no weapon declaring `focusedMods` — the field
-exists and is exercised by unit tests (`upgrades.test.ts`), proving the shape
-before any weapon actually uses it.
+  engine: focused-fire is just another transient-mod source. No shipped
+  weapon declares `focusedMods` yet (`chassis.spec.todo.md`).
 
 ## DEFAULT_CHASSIS
 
 `content/chassis.ts`'s `DEFAULT_CHASSIS`: 6 weapon slots, no `statBase`
 override, no quirks (`mods: []`), the Focus hitbox-shrink perk described
-above. A clean, quirk-free baseline — `resolveLoadout()` with
+above, no `polarity`. A clean, quirk-free baseline — `resolveLoadout()` with
 `DEFAULT_CHASSIS`'s fields plugged in produces exactly the same `StatBlock`
 as calling it with no chassis fields at all (`content/chassis.test.ts`).
 `chassisById(id)` falls back to `DEFAULT_CHASSIS` for an unknown id, the same
-convention as `weaponById`/`itemById`.
+convention as `weaponById`/`itemById`. Every fresh career (`createNewCareer()`)
+starts equipped with it (`CareerState.chassisId`).
 
-Chassis selection (persisting which chassis a career flies, once more than
-one exists) is Epic 2 scope (`chassis.spec.todo.md`) — `Player` always
-defaults to `DEFAULT_CHASSIS` today.
+## IKARUGA_CHASSIS — the polarity-switch flagship
 
-## Validating extensibility: a polarity-switch chassis needs no new subsystem
+`content/chassis.ts`'s `IKARUGA_CHASSIS` (C7 #146): no static stat quirks and
+no Focus hitbox-shrink perk — its entire identity is the optional
+`ChassisDef.polarity` hook (`ChassisPolarityDef`: `initial`,
+`damageMultiplierSame`, `damageMultiplierOpposite`, `absorbHypeBase`, sourced
+from `TUNING.chassis.ikaruga`), resolved by two pure functions in
+`systems/combat/polarity.ts`:
 
-The framework's job in this issue is to prove it can express a chassis as
-different as an Ikaruga-style polarity switch (C7 #146) without adding
-engine code. Here's how that chassis slots in, entirely with pieces that
-already exist above:
+- **`polarityDamageMultiplier(polarityDef, shotPolarity, targetPolarity)`** —
+  "current polarity gates which enemies take full damage from your shots."
+  `PlayerBullet.shotPolarity` is baked in once per shot fired (same
+  convention as crit, `combat.spec.todo.md`) from `Player.polarity` at the
+  moment `PlayScene.fireWeapon()` fires — a mid-flight polarity switch never
+  retroactively changes an already-fired shot. `Enemy.polarity` is assigned
+  randomly (50/50) on every spawn regardless of the equipped chassis (inert
+  data unless a polarity chassis reads it). `onPlayerBulletHitEnemy()`
+  applies the resulting multiplier to both the primary hit and any blast
+  splash damage, per target.
+- **`absorbsBullet(polarityDef, playerPolarity, bulletPolarity)`** —
+  "same-color absorption." `EnemyBullet.polarity` inherits its firing
+  enemy's polarity. `PlayScene.onEnemyBulletHitPlayer()` checks this before
+  applying damage: a same-polarity bullet is recycled with **no damage**
+  and instead calls `absorbBullet()`, which feeds `TUNING.chassis.ikaruga.absorbHypeBase`
+  into `gainHype()` scaled by the player's `grazeMultiplier` stat — "same-color
+  absorption feeds the same underlying graze-multiplier stat, repurposed as
+  absorb-meter gain rate": an instantaneous Hype pulse through the exact
+  gain path grazing already uses, not a new meter. An opposite-polarity
+  bullet damages the player normally.
 
-- **Remap an input onto the shared graze-multiplier stat.** Grazing already
-  drives `grazeMultiplier` (an exotic stat, `hype-and-ratings.spec.md`)
-  through Hype gain. A polarity chassis's "same-color absorption" is just a
-  different *input* feeding that same stat: on absorbing a same-polarity
-  bullet, the chassis (or the bullet's resolution code) applies a
-  `StatModifier` against `grazeMultiplier` — no new "absorb meter" stat, no
-  new subsystem, just a different producer writing into the same consumer
-  `PlayScene.updateGrazeAndHype()` already reads.
-- **Gate damage by state via a transient mod.** Current polarity is exactly
-  the kind of toggled condition `transientMods` already exists for (stats.spec.md's
-  "while grazing effects, polarity state, etc." is literally called out as
-  the intended use). Flipping polarity swaps in a transient `StatModifier`
-  set — e.g. a percent bonus to incoming-damage reduction in one category
-  gated on the current polarity — recomputed on every polarity flip exactly
-  like `Player.setFocus()` recomputes on every Focus toggle.
-- **The chassis quirk slot carries the rest.** Anything permanent about the
-  identity (e.g. a base stat reweight) is just `ChassisDef.statBase`/`mods`,
-  same as `DEFAULT_CHASSIS`.
+Both functions take `ChassisPolarityDef | undefined` explicitly rather than
+reading a chassis object, so a chassis with no polarity mechanic (every
+chassis but Ikaruga today) always resolves to "no gating, no absorption"
+with no special-casing anywhere in `PlayScene`.
 
-No part of this requires a new engine, a new stat archetype, or a bespoke
-per-chassis code path — it's a new `ChassisDef` plus a state flag toggling
-which `transientMods` are active, both patterns the framework already
-supports. Building the actual chassis (sprite, input mapping, the specific
-numbers) is C7 #146 content work, not framework work.
+`Player.togglePolarity()` flips red/blue (bound to the `X` key in
+`PlayScene`) and is a no-op on a chassis without `polarity`. Visual feedback
+uses `setTintFill()` (not `setTint()`, which multiplies over a placeholder
+sprite's own base color and reads as muddy rather than a clean red/blue) on
+the player ship, enemies, and both bullet types — `TUNING.chassis.polarityColors`
+— but only when the equipped chassis actually has `polarity`; a
+polarity-agnostic chassis never shows a meaningless red/blue split.
+
+## Chassis selection — the Hangar
+
+Chassis choice persists on `CareerState.chassisId` (same id-indirection
+convention as `OwnedWeaponRef`/`OwnedItemRef` — a save never embeds a full
+`ChassisDef` snapshot), resolved via `chassisById()` everywhere a build is
+resolved (`PlayScene`, `ShopScene`'s stat preview, `ResolveScene`'s Player
+Speed preview). `scenes/ChassisSelectScene.ts` (the "Hangar") lists every
+`ALL_CHASSIS` entry, highlights the currently-equipped one, and re-saves the
+career on tap. `MapScene` exposes it via a persistent corner button
+(opposite the "New Career" control) on both the Season map and Syndication
+screens — reachable any time, not gated behind starting a new career, since
+a chassis is career-persistent equipment rather than a one-time pick.
 
 ## Related
 
 - [`stats.spec.md`](stats.spec.md) — the composition grammar and
-  `chassisBase`/`chassisMods`/`transientMods` fields this spec builds on
+  `chassisBase`/`chassisMods`/`statPickMods`/`transientMods` fields this spec
+  builds on
 - [`weapons.spec.todo.md`](weapons.spec.todo.md) — `WeaponDef.focusedMods`,
   the weapon-slot cap, the effect-composition engine chassis reuses
-- [`hype-and-ratings.spec.md`](hype-and-ratings.spec.md) — `grazeMultiplier`,
-  the stat a polarity chassis remaps onto
-- [`chassis.spec.todo.md`](chassis.spec.todo.md) — Epic 2 chassis content
-  (Ikaruga polarity C7 #146, more chassis C8 #147) and chassis selection
+- [`hype-and-ratings.spec.md`](hype-and-ratings.spec.md) — `grazeMultiplier`
+  and `gainHype()`, which Ikaruga's absorption repurposes rather than
+  duplicating
+- [`chassis.spec.todo.md`](chassis.spec.todo.md) — remaining Epic 2 chassis
+  content (C8 #147) and follow-ups
 - [`overview.spec.todo.md`](overview.spec.todo.md) — spec map

--- a/specs/games/shmup/chassis.spec.md
+++ b/specs/games/shmup/chassis.spec.md
@@ -1,0 +1,122 @@
+# Shmup — Chassis Spec
+
+> Issue: **F10 #138**. Status: implemented (framework + default chassis).
+> Code lives in `games/shmup/src/systems/chassis/` (the `ChassisDef` shape)
+> and `games/shmup/src/content/chassis.ts` (the registry — `DEFAULT_CHASSIS`,
+> `chassisById()`). Additional chassis (Ikaruga polarity, etc.) are Epic 2
+> content — see `chassis.spec.todo.md`.
+
+## A chassis is data, applied through existing engines
+
+`ChassisDef` (`systems/chassis/types.ts`) declares:
+
+- **`maxWeaponSlots`** — weapon-slot cap (bullet-heaven default **6**,
+  `TUNING.weapons.maxWeaponSlots`). Enforced by `resolveLoadout()`'s
+  `assertWeaponSlots(weapons, maxSlots)` — the chassis's own cap flows in via
+  `LoadoutInput.maxWeaponSlots`, falling back to the framework's
+  `MAX_WEAPON_SLOTS` constant (`systems/effects/slots.ts`) when omitted.
+- **`hitboxRadiusNormal`** — collision hitbox radius while not focusing,
+  distinct from sprite size (a chassis can look big but hit small, or vice
+  versa).
+- **`statBase`** / **`mods`** — stat weightings and identity quirks. These
+  are exactly `LoadoutInput.chassisBase` / `chassisMods`
+  (`systems/effects/loadout.ts`) — fields that already existed on the F4
+  engine before this issue landed. A chassis is proof that engine needed no
+  changes to express: `statBase` overrides a stat's base value (e.g. a
+  tankier frame raising base Max HP), `mods` are 1-2 persistent
+  `StatModifier`s reinterpreting the shared stat pool (Brotato-character
+  model) — run through `computeStats()` the same as any weapon or item mod,
+  no bespoke per-chassis subsystem.
+- **`focus`** — Focus behavior, see below.
+
+`entities/Player.ts` holds the equipped `chassis: ChassisDef` (constructor
+param, defaults to `DEFAULT_CHASSIS`) and threads it into every
+`resolveLoadout()` call (`resolveEffectiveLoadout()`), and into its own
+hitbox/speed math (`applyHitboxRadius()`, `currentSpeed()`).
+
+## Focus — universal action + optional chassis perk
+
+Focus is a chassis feature, not a player stat:
+
+- **Base (universal, `ChassisFocusDef.speedMult`):** every chassis slows
+  Player Speed to this fraction while Focus (Shift) is held, for precise
+  dodging (Touhou-style). This is not a perk — every chassis has it.
+- **Hitbox shrink is an opt-in perk, not a rule:** `ChassisFocusDef` also
+  carries an optional `hitboxRadiusFocus`. Omitting it means Focus doesn't
+  shrink the hitbox at all (the framework-neutral default) — a chassis that
+  wants the genre-standard "graze box" declares `hitboxRadiusFocus` as its
+  own identity trait, same as any other quirk. `DEFAULT_CHASSIS` opts in
+  (`hitboxRadiusNormal: 6` -> `hitboxRadiusFocus: 3`, both from
+  `TUNING.combat`).
+- **Weapon-defined focused-fire mode:** a `WeaponDef` may declare
+  `focusedMods?: ScalingModifier[]` (`systems/effects/types.ts`) — extra
+  scaling modifiers (same shape/tiering as `mods`) layered in only while
+  Focus is held, expressing "wide spray unfocused -> concentrated stream
+  focused" as data over the shared stat pool. `Player.resolveEffectiveLoadout()`
+  includes a weapon's `focusedMods` (via `weaponFocusModsAtTier()`) in
+  `transientMods` only when `this.focus` is true, and `setFocus()` recomputes
+  on every toggle — the same "toggled by condition flips" convention
+  `stats.spec.md` already uses for grazing/polarity-style effects. No new
+  engine: focused-fire is just another transient-mod source.
+
+`DEFAULT_CHASSIS` ships with no weapon declaring `focusedMods` — the field
+exists and is exercised by unit tests (`upgrades.test.ts`), proving the shape
+before any weapon actually uses it.
+
+## DEFAULT_CHASSIS
+
+`content/chassis.ts`'s `DEFAULT_CHASSIS`: 6 weapon slots, no `statBase`
+override, no quirks (`mods: []`), the Focus hitbox-shrink perk described
+above. A clean, quirk-free baseline — `resolveLoadout()` with
+`DEFAULT_CHASSIS`'s fields plugged in produces exactly the same `StatBlock`
+as calling it with no chassis fields at all (`content/chassis.test.ts`).
+`chassisById(id)` falls back to `DEFAULT_CHASSIS` for an unknown id, the same
+convention as `weaponById`/`itemById`.
+
+Chassis selection (persisting which chassis a career flies, once more than
+one exists) is Epic 2 scope (`chassis.spec.todo.md`) — `Player` always
+defaults to `DEFAULT_CHASSIS` today.
+
+## Validating extensibility: a polarity-switch chassis needs no new subsystem
+
+The framework's job in this issue is to prove it can express a chassis as
+different as an Ikaruga-style polarity switch (C7 #146) without adding
+engine code. Here's how that chassis slots in, entirely with pieces that
+already exist above:
+
+- **Remap an input onto the shared graze-multiplier stat.** Grazing already
+  drives `grazeMultiplier` (an exotic stat, `hype-and-ratings.spec.md`)
+  through Hype gain. A polarity chassis's "same-color absorption" is just a
+  different *input* feeding that same stat: on absorbing a same-polarity
+  bullet, the chassis (or the bullet's resolution code) applies a
+  `StatModifier` against `grazeMultiplier` — no new "absorb meter" stat, no
+  new subsystem, just a different producer writing into the same consumer
+  `PlayScene.updateGrazeAndHype()` already reads.
+- **Gate damage by state via a transient mod.** Current polarity is exactly
+  the kind of toggled condition `transientMods` already exists for (stats.spec.md's
+  "while grazing effects, polarity state, etc." is literally called out as
+  the intended use). Flipping polarity swaps in a transient `StatModifier`
+  set — e.g. a percent bonus to incoming-damage reduction in one category
+  gated on the current polarity — recomputed on every polarity flip exactly
+  like `Player.setFocus()` recomputes on every Focus toggle.
+- **The chassis quirk slot carries the rest.** Anything permanent about the
+  identity (e.g. a base stat reweight) is just `ChassisDef.statBase`/`mods`,
+  same as `DEFAULT_CHASSIS`.
+
+No part of this requires a new engine, a new stat archetype, or a bespoke
+per-chassis code path — it's a new `ChassisDef` plus a state flag toggling
+which `transientMods` are active, both patterns the framework already
+supports. Building the actual chassis (sprite, input mapping, the specific
+numbers) is C7 #146 content work, not framework work.
+
+## Related
+
+- [`stats.spec.md`](stats.spec.md) — the composition grammar and
+  `chassisBase`/`chassisMods`/`transientMods` fields this spec builds on
+- [`weapons.spec.todo.md`](weapons.spec.todo.md) — `WeaponDef.focusedMods`,
+  the weapon-slot cap, the effect-composition engine chassis reuses
+- [`hype-and-ratings.spec.md`](hype-and-ratings.spec.md) — `grazeMultiplier`,
+  the stat a polarity chassis remaps onto
+- [`chassis.spec.todo.md`](chassis.spec.todo.md) — Epic 2 chassis content
+  (Ikaruga polarity C7 #146, more chassis C8 #147) and chassis selection
+- [`overview.spec.todo.md`](overview.spec.todo.md) — spec map

--- a/specs/games/shmup/chassis.spec.todo.md
+++ b/specs/games/shmup/chassis.spec.todo.md
@@ -1,28 +1,35 @@
-# Shmup — Chassis Spec
+# Shmup — Chassis TODO
 
-> Issues: **F10 #138** (framework), **C7 #146** (Ikaruga), **C8 #147** (more chassis). Status: framing locked.
+> Issues: **F10 #138** (framework — implemented, see `chassis.spec.md`),
+> **C7 #146** (Ikaruga), **C8 #147** (more chassis). Status: framework
+> shipped; content is Epic 2.
 
-## Framework
+## Remaining work (Epic 2 content)
 
-A chassis is **data**, defining:
-- weapon-slot config (default cap **6**),
-- hitbox size (distinct from sprite size),
-- stat weightings,
-- 1–2 identity **quirks** that *reinterpret existing stats* (Brotato-character model), composed through the effect engine — **no bespoke per-chassis subsystems**.
+- **C7 #146 — Ikaruga polarity chassis.** `chassis.spec.md`'s "Validating
+  extensibility" section already confirms the framework needs no new
+  subsystem: a polarity input remaps onto the shared `grazeMultiplier` stat,
+  current polarity gates damage via a toggled `transientMods` set (recomputed
+  on flip, same pattern as `Player.setFocus()`). Building it is sprite +
+  input mapping + the actual numbers, not new engine code.
+- **C8 #147 — more chassis.** Vary slot count, hitbox size, stat weighting,
+  and quirks — the same way Brotato characters differ. All expressed as
+  `ChassisDef` data through the existing engines; no new fields expected to
+  be needed based on C7's validation above, but revisit if a future chassis
+  idea genuinely can't be expressed with the current shape.
+- **Chassis selection.** `Player` always flies `DEFAULT_CHASSIS` today
+  (`chassis.spec.md`). Once a second chassis exists (C7), `CareerState` needs
+  a persisted chassis choice (a `chassisId` field, same id-indirection
+  convention as `OwnedWeaponRef`/`OwnedItemRef`) and a selection UI —
+  intentionally deferred until there's more than one option to choose from.
+- **At least one weapon should actually declare `focusedMods`** once C1/C2
+  grow the weapon roster, so the focused-fire variant described in
+  `chassis.spec.md` is player-visible rather than only unit-tested.
 
-Ship the **default chassis** in the framework issue; additional chassis are content.
+## Related
 
-## Focus (lives on the chassis)
-
-Focus is an action, not a stat:
-- **Base (universal):** hold to move slower for precise dodging. No automatic hitbox shrink.
-- **Weapon-defined:** a weapon may switch to a focused-fire mode (wide → concentrated).
-- **Chassis-defined perks:** hitbox shrink, a focus shield, etc. — identity, not a universal rule.
-
-## Flagship example — Ikaruga polarity chassis
-
-Instead of grazing, a **polarity switch**: same-color absorption feeds the **same underlying graze-multiplier stat**, repurposed as absorb-meter gain rate; current polarity gates which enemies take full damage. This must slot into the framework by **remapping an input onto an existing stat and gating damage by state** — validating that the framework needs no new subsystem for such a chassis.
-
-## Variety axes for future chassis
-
-Vary slot count, hitbox size, stat weighting, and quirks — the same way Brotato characters differ. All expressed as data through existing engines.
+- [`chassis.spec.md`](chassis.spec.md) — the shipped framework + default
+  chassis this TODO extends
+- [`weapons.spec.todo.md`](weapons.spec.todo.md) — weapon roster growth (C1
+  #140, C2 #141) that Focus-mode weapon variety depends on
+- [`overview.spec.todo.md`](overview.spec.todo.md) — spec map

--- a/specs/games/shmup/chassis.spec.todo.md
+++ b/specs/games/shmup/chassis.spec.todo.md
@@ -1,35 +1,32 @@
 # Shmup — Chassis TODO
 
-> Issues: **F10 #138** (framework — implemented, see `chassis.spec.md`),
-> **C7 #146** (Ikaruga), **C8 #147** (more chassis). Status: framework
-> shipped; content is Epic 2.
+> Issues: **F10 #138** (framework, implemented), **C7 #146** (Ikaruga,
+> implemented — see `chassis.spec.md`), **C8 #147** (more chassis). Status:
+> framework + flagship shipped; further chassis content is Epic 2.
 
 ## Remaining work (Epic 2 content)
 
-- **C7 #146 — Ikaruga polarity chassis.** `chassis.spec.md`'s "Validating
-  extensibility" section already confirms the framework needs no new
-  subsystem: a polarity input remaps onto the shared `grazeMultiplier` stat,
-  current polarity gates damage via a toggled `transientMods` set (recomputed
-  on flip, same pattern as `Player.setFocus()`). Building it is sprite +
-  input mapping + the actual numbers, not new engine code.
 - **C8 #147 — more chassis.** Vary slot count, hitbox size, stat weighting,
   and quirks — the same way Brotato characters differ. All expressed as
-  `ChassisDef` data through the existing engines; no new fields expected to
-  be needed based on C7's validation above, but revisit if a future chassis
-  idea genuinely can't be expressed with the current shape.
-- **Chassis selection.** `Player` always flies `DEFAULT_CHASSIS` today
-  (`chassis.spec.md`). Once a second chassis exists (C7), `CareerState` needs
-  a persisted chassis choice (a `chassisId` field, same id-indirection
-  convention as `OwnedWeaponRef`/`OwnedItemRef`) and a selection UI —
-  intentionally deferred until there's more than one option to choose from.
+  `ChassisDef` data through the existing engines; Ikaruga's `polarity` hook
+  proved the framework can carry a full offense/defense mechanic with zero
+  engine changes, so expect future chassis ideas to fit the same shape.
+  Revisit only if a genuinely new idea can't be expressed with the current
+  `ChassisDef`/`ChassisPolarityDef` fields.
 - **At least one weapon should actually declare `focusedMods`** once C1/C2
   grow the weapon roster, so the focused-fire variant described in
   `chassis.spec.md` is player-visible rather than only unit-tested.
+- **Ikaruga polish** (not required by C7's acceptance criteria, but natural
+  follow-ups): a mobile-friendly polarity-switch control (currently keyboard
+  `X` only, same gap as Focus's own "mobile Focus is TBD" note); a HUD
+  indicator for current polarity beyond the ship/bullet tint; enemy-type
+  variety in how polarity is assigned (currently uniform random 50/50 per
+  spawn) once real enemy archetypes beyond drone/elite/boss exist.
 
 ## Related
 
-- [`chassis.spec.md`](chassis.spec.md) — the shipped framework + default
-  chassis this TODO extends
+- [`chassis.spec.md`](chassis.spec.md) — the shipped framework, default
+  chassis, and Ikaruga polarity chassis this TODO extends
 - [`weapons.spec.todo.md`](weapons.spec.todo.md) — weapon roster growth (C1
   #140, C2 #141) that Focus-mode weapon variety depends on
 - [`overview.spec.todo.md`](overview.spec.todo.md) — spec map

--- a/specs/games/shmup/overview.spec.todo.md
+++ b/specs/games/shmup/overview.spec.todo.md
@@ -41,8 +41,8 @@ A **career** = ~5 **Seasons**, each a node map ending in a **Season Finale boss*
 | `combat.spec.todo.md` | damage, defense pipeline, mobility | F3 #131, F6 #134 |
 | `weapons.spec.todo.md` | effect engine, attack modifiers, gold upgrades | F4 #132, C1 #140, C2 #141 |
 | `items-and-brands.spec.todo.md` | items, stacking, brand tags, offer weighting (offer-weighting math **implemented** by F9; item/brand catalog growth still open) | F4 #132, F9 #137, C3 #142, C4 #143 |
-| `chassis.spec.md` | chassis framework, default chassis, Focus mode — **implemented** | F10 #138 |
-| `chassis.spec.todo.md` | Epic 2 chassis content (Ikaruga polarity, more chassis), chassis selection | C7 #146, C8 #147 |
+| `chassis.spec.md` | chassis framework, default chassis, Focus mode, Ikaruga polarity chassis, chassis-selection Hangar — **implemented** | F10 #138, C7 #146 |
+| `chassis.spec.todo.md` | remaining Epic 2 chassis content (more chassis, polish) | C8 #147 |
 | `hype-and-ratings.spec.md` | grazing, Hype + Ratings formulas (Model 1) — **implemented** | F7 #135 |
 | `economy.spec.md` | currencies, level-ups (end-of-level break only), coins/tips, interest, shop, gold sinks, offer weighting — **implemented** | F9 #137 |
 | `economy.spec.todo.md` | remaining balance pass + content growth | F9 #137 |

--- a/specs/games/shmup/overview.spec.todo.md
+++ b/specs/games/shmup/overview.spec.todo.md
@@ -41,7 +41,8 @@ A **career** = ~5 **Seasons**, each a node map ending in a **Season Finale boss*
 | `combat.spec.todo.md` | damage, defense pipeline, mobility | F3 #131, F6 #134 |
 | `weapons.spec.todo.md` | effect engine, attack modifiers, gold upgrades | F4 #132, C1 #140, C2 #141 |
 | `items-and-brands.spec.todo.md` | items, stacking, brand tags, offer weighting (offer-weighting math **implemented** by F9; item/brand catalog growth still open) | F4 #132, F9 #137, C3 #142, C4 #143 |
-| `chassis.spec.todo.md` | chassis framework, focus, polarity example | F10 #138, C7 #146, C8 #147 |
+| `chassis.spec.md` | chassis framework, default chassis, Focus mode — **implemented** | F10 #138 |
+| `chassis.spec.todo.md` | Epic 2 chassis content (Ikaruga polarity, more chassis), chassis selection | C7 #146, C8 #147 |
 | `hype-and-ratings.spec.md` | grazing, Hype + Ratings formulas (Model 1) — **implemented** | F7 #135 |
 | `economy.spec.md` | currencies, level-ups (end-of-level break only), coins/tips, interest, shop, gold sinks, offer weighting — **implemented** | F9 #137 |
 | `economy.spec.todo.md` | remaining balance pass + content growth | F9 #137 |

--- a/specs/games/shmup/stats.spec.md
+++ b/specs/games/shmup/stats.spec.md
@@ -37,7 +37,7 @@ Level-ups (`economy.spec.todo.md`) only ever offer these (`MAIN_STAT_IDS` in `sy
 
 **Exotic stats** (`EXOTIC_STAT_IDS`) — Pierce, Blast Radius, Homing Strength — never appear in level-ups. They come only from weapons/items/shop, keeping the level pick legible and exotic builds intentional. Pierce and Homing Strength are unbounded percentages; Blast Radius is a flat px value. Pierce used to be four separate stats (Pierce/Bounce/Fork/Chain) — they were behaviorally redundant, so they were consolidated into one unified Pierce stat with per-weapon `PierceDecay` driving the above-100% forking behavior (`weapons.spec.todo.md`).
 
-Hype/graze-specific stats — `grazeRadius`, `grazeMultiplier` — are exotics too, added to `EXOTIC_STAT_IDS` by `hype-and-ratings.spec.md` (F7 #135), using the same `StatDef` shape as the rest of this table. Hitbox size is not a stat; it's a fixed normal/Focus radius pair (`TUNING.combat.hitboxRadiusNormal`/`hitboxRadiusFocus`, F6 #134).
+Hype/graze-specific stats — `grazeRadius`, `grazeMultiplier` — are exotics too, added to `EXOTIC_STAT_IDS` by `hype-and-ratings.spec.md` (F7 #135), using the same `StatDef` shape as the rest of this table. Hitbox size is not a stat; it's a normal/Focus radius pair owned by the equipped chassis (`ChassisDef.hitboxRadiusNormal`/`focus.hitboxRadiusFocus`, `chassis.spec.md`, F10 #138).
 
 ## StatDef shape
 

--- a/specs/games/shmup/weapons.spec.todo.md
+++ b/specs/games/shmup/weapons.spec.todo.md
@@ -10,14 +10,14 @@ A **weapon** is data:
 - a base type + base stat values + **per-weapon projectile speed** (authored, see `combat.spec.todo.md`),
 - **firing arc** (forward / behind / sides — some exist to cover blind spots),
 - **target type** (ground-only / air-only / both — gates which weapons matter),
-- optional **focused-fire mode** (e.g. wide spray → concentrated stream when focusing),
+- optional **focused-fire mode** (`WeaponDef.focusedMods` — implemented, `chassis.spec.md`, F10 #138: e.g. wide spray → concentrated stream when focusing),
 - a **per-level bonus table** (see Upgrades),
 - optional **`pierceDecay`** (see Pierce, below) — defaults to `TUNING.weapons.defaultPierceDecay` when omitted,
 - `scalesWith: StatId[]` for the explicit-stat display.
 
 ## Slots
 
-**6 weapon slots per chassis** (bullet-heaven default + a hard performance ceiling that bounds worst-case concurrent projectiles). Each slot holds an **independent weapon instance with its own upgrade level** — you may buy the same weapon into two slots for redundancy *or* pour gold into one.
+**6 weapon slots per chassis** (bullet-heaven default + a hard performance ceiling that bounds worst-case concurrent projectiles) — the cap itself is owned by the equipped chassis (`ChassisDef.maxWeaponSlots`, `chassis.spec.md`, F10 #138), 6 just being the framework's default. Each slot holds an **independent weapon instance with its own upgrade level** — you may buy the same weapon into two slots for redundancy *or* pour gold into one.
 
 ## Attack-behavior modifiers (freeform, generic)
 


### PR DESCRIPTION
## Summary

Implements #138 (F10, chassis framework + default chassis) and #146 (C7, Ikaruga polarity chassis) as one PR — the second commit builds the flagship chassis that the first commit's spec note validated, plus a real, persisted chassis-selection screen so it's actually flyable and testable.

### F10 — framework + default chassis

Built as **data composed through the existing F3 (stats) / F4 (effect engine) / F6 (loop)** — no bespoke per-chassis subsystem.

- `systems/chassis/types.ts` — `ChassisDef`/`ChassisFocusDef`: weapon-slot cap (`maxWeaponSlots`), hitbox size (`hitboxRadiusNormal`, distinct from sprite size), stat weightings (`statBase`), and identity quirks (`mods`).
- `content/chassis.ts` — `DEFAULT_CHASSIS` (6 slots, no quirks, opts into the Focus hitbox-shrink perk) + `chassisById()` lookup, same convention as `weaponById`/`itemById`.
- Chassis quirks/weightings flow through `resolveLoadout()`'s **existing** `chassisBase`/`chassisMods` fields — proving the framework needed zero engine changes to express a chassis. Only additions: `LoadoutInput.maxWeaponSlots` and `LoadoutInput.statPickMods`.
- **Focus mode lives on the chassis**: universal slow-move (`ChassisFocusDef.speedMult`) plus an optional hitbox-shrink perk (`hitboxRadiusFocus`) — omitted entirely means no automatic shrink; `DEFAULT_CHASSIS` opts in, `IKARUGA_CHASSIS` doesn't.
- **Weapon focused-fire mode**: `WeaponDef.focusedMods` (+ `weaponFocusModsAtTier()`) lets a weapon declare extra scaling mods that only apply while Focus is held, layered in as transient mods, recomputed on every Focus toggle.

### C7 — Ikaruga polarity chassis

- `ChassisDef` gains an optional `polarity` config (`ChassisPolarityDef`) — absent entirely on chassis that don't use it.
- `systems/combat/polarity.ts` (pure, unit-tested): `polarityDamageMultiplier()` gates player-shot damage by current polarity vs. target polarity; `absorbsBullet()` decides whether a same-polarity enemy bullet is absorbed instead of damaging the player.
- Absorption feeds the **same underlying `grazeMultiplier` stat**, repurposed as an absorb-meter gain rate, via the existing `gainHype()` path — no new meter, no parallel stat logic.
- `Player` gains polarity state + `togglePolarity()` (bound to `X`); `Enemy`/`EnemyBullet`/`PlayerBullet` carry a polarity tag (random per enemy spawn, baked into a shot at fire time like crit). Visual feedback uses `setTintFill()` so red/blue reads cleanly over placeholder sprites, and only ever shows when the equipped chassis actually has a polarity mechanic.

### Chassis selection — the Hangar

- `CareerState.chassisId` persists the equipped chassis (same id-indirection convention as owned weapons/items); `PlayScene`/`ShopScene`/`ResolveScene` all resolve the real equipped chassis.
- New `ChassisSelectScene` lists every registered chassis, highlights the equipped one, re-saves on tap. Reachable any time from a new "HANGAR" corner button on `MapScene` (opposite "New Career"), on both the Season map and Syndication screens.

`specs/games/shmup/chassis.spec.md` documents the real implementation (updated from F10's hypothetical validation note); `chassis.spec.todo.md` trimmed to the remaining Epic 2 follow-ups (C8 #147 more chassis, minor Ikaruga polish).

## Test plan

- [x] `npm run test:unit` — 324 tests pass (34 files)
- [x] `npm run build` (root, which also builds `@toybox/shmup`) — clean, no `error TS`
- [x] Verified end-to-end in a headless browser: equip Ikaruga via the Hangar, fly it, confirm red/blue tint on ship/bullets/enemies, toggle polarity with `X`, and a 12s soak of movement/firing/toggling with zero runtime errors
- [x] Verified `DEFAULT_CHASSIS` still renders/plays with no tint or behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xw4UwoRuSkTVBGYv2H6qLc
