### PR TITLE
[Shmup][S3] Main menu / title + app flow

### DIFF
--- a/games/shmup/src/content/copy.ts
+++ b/games/shmup/src/content/copy.ts
@@ -11,6 +11,16 @@ export const COPY = {
   "intro.presents": "Noahsoft presents:",
   "intro.sticker": "Works on Doors 97!",
 
+  // ---- Main menu / app flow (run-structure app-flow, S3 #173) ----
+  "menu.newCareer": "NEW CAREER",
+  "menu.continue": "CONTINUE",
+  "menu.continue.disabled": "CONTINUE (NO SAVE)",
+  "menu.settings": "SETTINGS",
+  "menu.hallOfFame": "HALL OF FAME",
+  "menu.hint": "Arrows or Tap to select · Enter/Tap to confirm",
+  "menu.stub.comingSoon": "Coming soon.",
+  "menu.stub.back": "PRESS ANY KEY OR TAP TO GO BACK",
+
   // ---- Season / Finale / Syndication flavor (run-structure.spec.todo.md) ----
   "season.finale.title": "SEASON FINALE",
   "season.finale.flavor": "The network's watching. Don't blow it.",
@@ -86,7 +96,7 @@ export const COPY = {
   "resolve.syndicationScore": "Syndication Score: {score}",
   "resolve.goldCollected": "+{gold}g collected",
   "resolve.levelUp": "LEVEL UP x{count}",
-  "cancelled.restartPrompt": "PRESS ANY KEY OR TAP TO START A NEW CAREER",
+  "cancelled.restartPrompt": "PRESS ANY KEY OR TAP TO RETURN TO THE MENU",
 
   // ---- Season node-map (run-structure.spec.todo.md, F8 #136) ----
   "map.title": "SEASON {season}",

--- a/games/shmup/src/main.ts
+++ b/games/shmup/src/main.ts
@@ -1,11 +1,14 @@
 import Phaser from "phaser";
 import { BootScene } from "./scenes/BootScene";
+import { MainMenuScene } from "./scenes/MainMenuScene";
 import { MapScene } from "./scenes/MapScene";
 import { PlayScene } from "./scenes/PlayScene";
 import { ResolveScene } from "./scenes/ResolveScene";
 import { LevelUpScene } from "./scenes/LevelUpScene";
 import { ShopScene } from "./scenes/ShopScene";
 import { ChassisSelectScene } from "./scenes/ChassisSelectScene";
+import { SettingsScene } from "./scenes/SettingsScene";
+import { HallOfFameScene } from "./scenes/HallOfFameScene";
 import { GAME_WIDTH, GAME_HEIGHT } from "./config";
 
 new Phaser.Game({
@@ -24,5 +27,16 @@ new Phaser.Game({
     default: "arcade",
     arcade: { debug: false },
   },
-  scene: [BootScene, MapScene, PlayScene, ResolveScene, LevelUpScene, ShopScene, ChassisSelectScene],
+  scene: [
+    BootScene,
+    MainMenuScene,
+    MapScene,
+    PlayScene,
+    ResolveScene,
+    LevelUpScene,
+    ShopScene,
+    ChassisSelectScene,
+    SettingsScene,
+    HallOfFameScene,
+  ],
 });

--- a/games/shmup/src/scenes/BootScene.ts
+++ b/games/shmup/src/scenes/BootScene.ts
@@ -7,7 +7,10 @@ import { SCENE_KEYS } from "./sceneData";
 /**
  * Title card — proves the skeleton renders and that copy comes from the
  * content registry (specs/content-and-assets), not inline strings.
- * Press any key / tap to drop into the Season map (run-structure.spec.todo.md, F8 #136).
+ * Press any key / tap to land on the main menu (S3 #173) — the intro splash
+ * sequence itself (S2 #172) isn't built yet, so this card is the whole
+ * pre-menu beat for now; a real splash can slot in ahead of it later
+ * without touching where it hands off to.
  */
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -62,7 +65,7 @@ export class BootScene extends Phaser.Scene {
     // handler — this tap is the only one guaranteed before PlayScene exists.
     const start = () => {
       requestMotionPermission();
-      this.scene.start(SCENE_KEYS.map);
+      this.scene.start(SCENE_KEYS.mainMenu);
     };
     this.input.keyboard?.once("keydown", start);
     this.input.once("pointerdown", start);

--- a/games/shmup/src/scenes/HallOfFameScene.ts
+++ b/games/shmup/src/scenes/HallOfFameScene.ts
@@ -1,0 +1,50 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { copy } from "../content";
+import { SCENE_KEYS } from "./sceneData";
+
+/**
+ * Hall of Fame stub (S3 #173) — recorded scores come from C14 #163's
+ * results screen, not built yet. This proves the menu -> stub -> back
+ * transition exists now so wiring the real screen later is a content swap,
+ * not new plumbing.
+ */
+export class HallOfFameScene extends Phaser.Scene {
+  constructor() {
+    super(SCENE_KEYS.hallOfFame);
+  }
+
+  create() {
+    const cx = GAME_WIDTH / 2;
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.42, copy("menu.hallOfFame"), {
+        fontFamily: "monospace",
+        fontSize: "26px",
+        color: "#ffcc00",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.49, copy("menu.stub.comingSoon"), {
+        fontFamily: "monospace",
+        fontSize: "14px",
+        color: "#cccccc",
+      })
+      .setOrigin(0.5);
+
+    const prompt = this.add
+      .text(cx, GAME_HEIGHT * 0.62, copy("menu.stub.back"), {
+        fontFamily: "monospace",
+        fontSize: "13px",
+        color: "#888888",
+      })
+      .setOrigin(0.5);
+
+    this.tweens.add({ targets: prompt, alpha: 0.3, duration: 600, yoyo: true, repeat: -1 });
+
+    const back = () => this.scene.start(SCENE_KEYS.mainMenu);
+    this.input.keyboard?.once("keydown", back);
+    this.input.once("pointerdown", back);
+  }
+}

--- a/games/shmup/src/scenes/MainMenuScene.ts
+++ b/games/shmup/src/scenes/MainMenuScene.ts
@@ -1,0 +1,177 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { copy } from "../content";
+import { createNewCareer, hasCareerSave, saveCareer } from "../systems/career";
+import { SCENE_KEYS } from "./sceneData";
+
+interface MenuEntry {
+  labelKey: string;
+  enabled: boolean;
+  onSelect: () => void;
+}
+
+const BUTTON_WIDTH = GAME_WIDTH - 120;
+const BUTTON_HEIGHT = 84;
+const BUTTON_GAP = 22;
+const FIRST_BUTTON_Y = GAME_HEIGHT * 0.5;
+
+/**
+ * The title / main-menu screen and top-level app hub (S3 #173): boot lands
+ * here, "New Career"/"Continue" are the only two doors into the map, and a
+ * finished career (ResolveScene's Cancelled screen) comes back here rather
+ * than auto-starting a new one — this scene owns every high-level
+ * menu<->game<->results transition so nothing else needs to know how a
+ * career starts or resumes. Settings/Hall of Fame are stub destinations
+ * until their own Epic 4 issues land.
+ */
+export class MainMenuScene extends Phaser.Scene {
+  private entries: MenuEntry[] = [];
+  private buttons: Phaser.GameObjects.Rectangle[] = [];
+  private selected = 0;
+
+  constructor() {
+    super(SCENE_KEYS.mainMenu);
+  }
+
+  create() {
+    this.selected = 0;
+    this.buttons = [];
+    this.entries = this.buildEntries();
+
+    const cx = GAME_WIDTH / 2;
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.16, copy("intro.presents"), {
+        fontFamily: "monospace",
+        fontSize: "20px",
+        color: "#ff6b00",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.24, copy("game.title"), {
+        fontFamily: "monospace",
+        fontSize: "56px",
+        color: "#ffffff",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.33, copy("intro.sticker"), {
+        fontFamily: "monospace",
+        fontSize: "14px",
+        color: "#7b3dbe",
+      })
+      .setOrigin(0.5);
+
+    this.entries.forEach((entry, i) => this.renderButton(entry, i));
+
+    this.add
+      .text(cx, GAME_HEIGHT - 40, copy("menu.hint"), {
+        fontFamily: "monospace",
+        fontSize: "11px",
+        color: "#888888",
+      })
+      .setOrigin(0.5);
+
+    this.refreshSelection();
+    this.bindKeyboard();
+  }
+
+  private buildEntries(): MenuEntry[] {
+    const canContinue = hasCareerSave();
+    return [
+      {
+        labelKey: "menu.newCareer",
+        enabled: true,
+        onSelect: () => {
+          saveCareer(createNewCareer());
+          this.scene.start(SCENE_KEYS.map);
+        },
+      },
+      {
+        labelKey: canContinue ? "menu.continue" : "menu.continue.disabled",
+        enabled: canContinue,
+        onSelect: () => this.scene.start(SCENE_KEYS.map),
+      },
+      {
+        labelKey: "menu.settings",
+        enabled: true,
+        onSelect: () => this.scene.start(SCENE_KEYS.settings),
+      },
+      {
+        labelKey: "menu.hallOfFame",
+        enabled: true,
+        onSelect: () => this.scene.start(SCENE_KEYS.hallOfFame),
+      },
+    ];
+  }
+
+  private renderButton(entry: MenuEntry, index: number): void {
+    const cx = GAME_WIDTH / 2;
+    const y = FIRST_BUTTON_Y + index * (BUTTON_HEIGHT + BUTTON_GAP);
+
+    const box = this.add
+      .rectangle(cx, y, BUTTON_WIDTH, BUTTON_HEIGHT, entry.enabled ? 0x2a1000 : 0x1a1a1a)
+      .setStrokeStyle(3, entry.enabled ? 0x7b3dbe : 0x444444);
+    this.add
+      .text(cx, y, copy(entry.labelKey), {
+        fontFamily: "monospace",
+        fontSize: "18px",
+        color: entry.enabled ? "#ffffff" : "#666666",
+      })
+      .setOrigin(0.5);
+
+    // Disabled entries (Continue with no save) render greyed and stay
+    // non-interactive — no tap target at all, matching root CLAUDE.md's
+    // "large tap targets, no hover-only affordances" for the enabled ones.
+    if (entry.enabled) {
+      box.setInteractive({ useHandCursor: true });
+      box.on("pointerover", () => {
+        this.selected = index;
+        this.refreshSelection();
+      });
+      box.on("pointerdown", () => this.activate(index));
+    }
+
+    this.buttons.push(box);
+  }
+
+  private bindKeyboard(): void {
+    const kb = this.input.keyboard;
+    kb?.on("keydown-UP", () => this.move(-1));
+    kb?.on("keydown-DOWN", () => this.move(1));
+    kb?.on("keydown-W", () => this.move(-1));
+    kb?.on("keydown-S", () => this.move(1));
+    kb?.on("keydown-ENTER", () => this.activate(this.selected));
+    kb?.on("keydown-SPACE", () => this.activate(this.selected));
+  }
+
+  /** Cycles selection, skipping disabled entries so a keyboard-only player never lands on an unusable option. */
+  private move(delta: number): void {
+    const len = this.entries.length;
+    let next = this.selected;
+    for (let i = 0; i < len; i++) {
+      next = (next + delta + len) % len;
+      if (this.entries[next].enabled) break;
+    }
+    this.selected = next;
+    this.refreshSelection();
+  }
+
+  private refreshSelection(): void {
+    this.buttons.forEach((box, i) => {
+      const entry = this.entries[i];
+      const isSelected = i === this.selected;
+      box.setStrokeStyle(isSelected && entry.enabled ? 4 : 3, entry.enabled ? (isSelected ? 0xffcc88 : 0x7b3dbe) : 0x444444);
+    });
+  }
+
+  private activate(index: number): void {
+    const entry = this.entries[index];
+    if (!entry.enabled) return;
+    this.selected = index;
+    this.refreshSelection();
+    entry.onSelect();
+  }
+}

--- a/games/shmup/src/scenes/ResolveScene.ts
+++ b/games/shmup/src/scenes/ResolveScene.ts
@@ -3,7 +3,7 @@ import { GAME_WIDTH, GAME_HEIGHT } from "../config";
 import { chassisById, copy, itemById, ratingsTierForScore, ratingsTierName, weaponById } from "../content";
 import { applyRatingsDelta } from "../systems/hype";
 import { advanceDeadline } from "../systems/map";
-import { advanceToNextSeason, createNewCareer, loadCareer, saveCareer } from "../systems/career";
+import { advanceToNextSeason, loadCareer, saveCareer } from "../systems/career";
 import type { CareerState } from "../systems/career";
 import { applyExpGain, statPickMods } from "../systems/economy";
 import { resolveLoadout } from "../systems/effects";
@@ -247,7 +247,14 @@ export class ResolveScene extends Phaser.Scene {
     );
   }
 
-  /** Cumulative Ratings < 0 is Cancelled — the career ends here; no meta-progression carries into the next one. `syndicationScore` is only recorded when the cancellation happened during Syndication. */
+  /**
+   * Cumulative Ratings < 0 is Cancelled — the career ends here; no
+   * meta-progression carries into the next one. `syndicationScore` is only
+   * recorded when the cancellation happened during Syndication. Per the
+   * app-level flow (S3 #173: boot -> menu -> game -> results -> menu), a
+   * finished career lands back on MainMenuScene rather than auto-starting a
+   * new one — the player picks New Career from there themselves.
+   */
   private showCancelled(syndicationScore: number | null): void {
     const lines = [
       copy("cancelled.title"),
@@ -258,10 +265,7 @@ export class ResolveScene extends Phaser.Scene {
     if (syndicationScore !== null) lines.push(copy("resolve.syndicationScore", { score: Math.round(syndicationScore) }));
     lines.push("", copy("cancelled.restartPrompt"));
 
-    this.render(lines, () => {
-      saveCareer(createNewCareer());
-      this.scene.start(SCENE_KEYS.map);
-    });
+    this.render(lines, () => this.scene.start(SCENE_KEYS.mainMenu));
   }
 
   private ratingsLine(career: CareerState): string {

--- a/games/shmup/src/scenes/SettingsScene.ts
+++ b/games/shmup/src/scenes/SettingsScene.ts
@@ -1,0 +1,49 @@
+import Phaser from "phaser";
+import { GAME_WIDTH, GAME_HEIGHT } from "../config";
+import { copy } from "../content";
+import { SCENE_KEYS } from "./sceneData";
+
+/**
+ * Settings stub (S3 #173) — the real screen is a later Epic 4 issue. This
+ * proves the menu -> stub -> back transition exists now so wiring the real
+ * screen later is a content swap, not new plumbing.
+ */
+export class SettingsScene extends Phaser.Scene {
+  constructor() {
+    super(SCENE_KEYS.settings);
+  }
+
+  create() {
+    const cx = GAME_WIDTH / 2;
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.42, copy("menu.settings"), {
+        fontFamily: "monospace",
+        fontSize: "28px",
+        color: "#ffcc00",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(cx, GAME_HEIGHT * 0.49, copy("menu.stub.comingSoon"), {
+        fontFamily: "monospace",
+        fontSize: "14px",
+        color: "#cccccc",
+      })
+      .setOrigin(0.5);
+
+    const prompt = this.add
+      .text(cx, GAME_HEIGHT * 0.62, copy("menu.stub.back"), {
+        fontFamily: "monospace",
+        fontSize: "13px",
+        color: "#888888",
+      })
+      .setOrigin(0.5);
+
+    this.tweens.add({ targets: prompt, alpha: 0.3, duration: 600, yoyo: true, repeat: -1 });
+
+    const back = () => this.scene.start(SCENE_KEYS.mainMenu);
+    this.input.keyboard?.once("keydown", back);
+    this.input.once("pointerdown", back);
+  }
+}

--- a/games/shmup/src/scenes/sceneData.ts
+++ b/games/shmup/src/scenes/sceneData.ts
@@ -10,12 +10,15 @@ import type { MainStatId } from "../systems/stats";
 
 export const SCENE_KEYS = {
   boot: "Boot",
+  mainMenu: "MainMenu",
   map: "Map",
   play: "Play",
   resolve: "Resolve",
   levelUp: "LevelUp",
   shop: "Shop",
   chassisSelect: "ChassisSelect",
+  settings: "Settings",
+  hallOfFame: "HallOfFame",
 } as const;
 
 /** Map -> Play: everything PlayScene needs to run one episode, resolved ahead of time by the map (Difficulty, build) so PlayScene has zero career/map knowledge of its own. */

--- a/games/shmup/src/systems/career/persistence.ts
+++ b/games/shmup/src/systems/career/persistence.ts
@@ -95,3 +95,14 @@ export function loadCareer(): CareerState {
 export function saveCareer(state: CareerState): void {
   saveStore.write(CAREER_SAVE_KEY, JSON.stringify({ ...state, savedAt: Date.now() }));
 }
+
+/** MainMenuScene's Continue gate (S3 #173) — true only when a save exists AND parses/validates, same trust bar as `loadCareer()` itself. Never creates one as a side effect (unlike `loadCareer()`), so checking this can't spuriously plant a fresh career. */
+export function hasCareerSave(): boolean {
+  const raw = saveStore.read(CAREER_SAVE_KEY);
+  if (!raw) return false;
+  try {
+    return isValidCareerState(JSON.parse(raw));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #173.

## Summary

- Add `MainMenuScene` as the app's top-level hub. `BootScene`'s title card now hands off here (instead of straight to the map) — the intro splash sequence (S2 #172) isn't built yet, so this is the whole pre-menu beat for now; a real splash can slot in ahead of it later without touching the hand-off.
- **New Career** — `createNewCareer()` + `saveCareer()`, then into the existing map flow.
- **Continue** — enabled only when a valid career save exists, via a new `hasCareerSave()` helper in `systems/career/persistence.ts` (reads + validates through the same `isValidCareerState` gate as `loadCareer()`, but never plants a fresh career as a side effect). Disabled entries render greyed out with no tap target.
- **Settings** / **Hall of Fame** — stub scenes (`SettingsScene`, `HallOfFameScene`) with a "Coming soon." placeholder and a back-to-menu affordance, wired for their own later Epic 4 issues.
- Fully keyboard (Up/Down/W/S to move selection — skipping disabled entries — Enter/Space to confirm) and pointer/touch (tap any enabled row) navigable. All text goes through the content registry (`copy()`), new keys added under a `Main menu / app flow` section in `content/copy.ts`.
- `ResolveScene`'s Cancelled screen now returns to `MainMenuScene` instead of silently auto-starting a new career, completing the `menu ↔ game ↔ results` loop the issue describes — the player picks New Career from the menu themselves.
- Registered `MainMenuScene`, `SettingsScene`, `HallOfFameScene` in `main.ts`.

## Test plan

- [x] `npm run build` (root, filtered per `CLAUDE.md`) — no errors
- [x] `npm run build` in `games/shmup` — passes
- [x] `npm run test:unit` in `games/shmup` — 324/324 passing
- [x] Manual verification via Playwright against the dev server: boot → menu (Continue correctly greyed out with no save) → keyboard nav skips the disabled Continue entry → New Career drops into a fresh Season 1 map → reload → menu (Continue now enabled) → Continue resumes the same map → Settings/Hall of Fame stubs render and tap-to-go-back returns to the menu


---
_Generated by [Claude Code](https://claude.ai/code/session_01VnJAJYgxTWGPysc2vDSd5g)_